### PR TITLE
Upgrade lint to 1.2.0 and fix warnings

### DIFF
--- a/lib/src/capture/drawer/drawer.dart
+++ b/lib/src/capture/drawer/drawer.dart
@@ -6,6 +6,7 @@ import 'package:wiredash/src/capture/sketcher/sketcher_controller.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
 import 'package:wiredash/src/common/widgets/wiredash_icons.dart';
 
+// ignore: use_key_in_widget_constructors
 class Drawer extends StatelessWidget {
   static const width = 80.0;
 

--- a/lib/src/common/network/network_manager.dart
+++ b/lib/src/common/network/network_manager.dart
@@ -43,7 +43,7 @@ class NetworkManager {
     }
 
     await _apiClient.post(
-      urlPath: '$_feedbackPath',
+      urlPath: _feedbackPath,
       arguments: {
         _parameterDeviceInfo: json.encode(deviceInfo),
         if (email != null) _parameterEmail: email,

--- a/lib/src/common/options/wiredash_options.dart
+++ b/lib/src/common/options/wiredash_options.dart
@@ -2,7 +2,8 @@ import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/common/options/wiredash_options_data.dart';
 
 class WiredashOptions extends StatelessWidget {
-  const WiredashOptions({@required this.data, @required this.child});
+  const WiredashOptions({@required this.data, @required this.child, Key key})
+      : super(key: key);
 
   final WiredashOptionsData data;
   final Widget child;

--- a/lib/src/common/theme/wiredash_theme.dart
+++ b/lib/src/common/theme/wiredash_theme.dart
@@ -2,7 +2,8 @@ import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme_data.dart';
 
 class WiredashTheme extends StatelessWidget {
-  const WiredashTheme({@required this.data, @required this.child});
+  const WiredashTheme({@required this.data, @required this.child, Key key})
+      : super(key: key);
 
   final WiredashThemeData data;
   final Widget child;

--- a/lib/src/common/translation/wiredash_translation.dart
+++ b/lib/src/common/translation/wiredash_translation.dart
@@ -2,7 +2,9 @@ import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/common/translation/wiredash_translation_data.dart';
 
 class WiredashTranslation extends StatelessWidget {
-  const WiredashTranslation({@required this.data, @required this.child});
+  const WiredashTranslation(
+      {@required this.data, @required this.child, Key key})
+      : super(key: key);
 
   final WiredashTranslationData data;
   final Widget child;

--- a/lib/src/common/translation/wiredash_translation_data.dart
+++ b/lib/src/common/translation/wiredash_translation_data.dart
@@ -35,7 +35,7 @@ class WiredashTranslationData {
       'If you want to get updates regarding your feedback, enter your email down below.';
   String get feedbackStateSuccessTitle => 'Thank you ✌️';
   String get feedbackStateSuccessMsg =>
-      'That\'s it. Thank you so much for helping us building a better app!';
+      "That's it. Thank you so much for helping us building a better app!";
   String get feedbackStateSuccessCloseTitle => 'Close this Dialog';
   String get feedbackStateSuccessCloseMsg =>
       'Thanks for submitting your feedback!';

--- a/lib/src/feedback/feedback_sheet.dart
+++ b/lib/src/feedback/feedback_sheet.dart
@@ -13,6 +13,7 @@ import 'package:wiredash/src/feedback/components/intro_component.dart';
 import 'package:wiredash/src/feedback/components/success_component.dart';
 import 'package:wiredash/src/feedback/feedback_model.dart';
 
+// ignore: use_key_in_widget_constructors
 class FeedbackSheet extends StatefulWidget {
   @override
   _FeedbackSheetState createState() => _FeedbackSheetState();
@@ -103,7 +104,6 @@ class _FeedbackSheetState extends State<FeedbackSheet>
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Align(
-            alignment: Alignment.center,
             child: Material(
               shape: const StadiumBorder(),
               color: WiredashTheme.of(context).dividerColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   shared_preferences: ^0.5.6
 
 dev_dependencies:
-  lint: ^1.1.0
+  lint: ^1.2.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Use the newest ruleset from the lint package. This also fixes the linting errors which came up after merging https://github.com/wiredashio/wiredash-sdk/pull/21. 

FYI I have added `ignore: use_key_in_widget_constructors` on widgets which only use the default constructor and thus specify a key 🔑 