### PR TITLE
Fixes #26

### DIFF
--- a/lib/src/common/widgets/floating_entry_point.dart
+++ b/lib/src/common/widgets/floating_entry_point.dart
@@ -48,7 +48,7 @@ class _FloatingEntryPointState extends State<FloatingEntryPoint> {
             widget.child,
             if (WiredashOptions.of(context).showDebugFloatingEntryPoint) ...[
               IgnorePointer(
-                ignoring: !_isDragging || _isButtonDiscarded,
+                ignoring: true,
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: _buildDiscardCorner(),

--- a/lib/src/common/widgets/floating_entry_point.dart
+++ b/lib/src/common/widgets/floating_entry_point.dart
@@ -47,9 +47,12 @@ class _FloatingEntryPointState extends State<FloatingEntryPoint> {
           children: <Widget>[
             widget.child,
             if (WiredashOptions.of(context).showDebugFloatingEntryPoint) ...[
-              Align(
-                alignment: Alignment.bottomLeft,
-                child: _buildDiscardCorner(),
+              IgnorePointer(
+                ignoring: !_isDragging || _isButtonDiscarded,
+                child: Align(
+                  alignment: Alignment.bottomLeft,
+                  child: _buildDiscardCorner(),
+                ),
               ),
               Positioned(
                 left: _position.dx,


### PR DESCRIPTION
## Description 
When a user clicks the bottom left corner of their screen, pointer events are intercepted by the Floating Feedback Botton's detection zone. 
As a result, these events are not propagated to underlying UI elements such as buttons or navigation components.

## Implementation Notes 
- Added `IgnorePointer` to better control when pointer events are captured. Pointer events are intercepted when the user is dragging the Feedback button, and the button is on screen. 
- Closes #26 