### PR TITLE
Make Wiredash host overridable

### DIFF
--- a/lib/src/common/network/api_client.dart
+++ b/lib/src/common/network/api_client.dart
@@ -8,13 +8,15 @@ class ApiClient {
     @required this.httpClient,
     @required this.projectId,
     @required this.secret,
+    @required this.host,
   });
-
-  static const String _host = 'https://api.wiredash.io/';
 
   final Client httpClient;
   final String projectId;
   final String secret;
+  final String host;
+
+  String get _host => host ?? 'https://api.wiredash.io/';
 
   Future<Map<String, dynamic>> get(String urlPath) async {
     final url = '$_host$urlPath';

--- a/lib/src/wiredash_widget.dart
+++ b/lib/src/wiredash_widget.dart
@@ -64,6 +64,7 @@ class Wiredash extends StatefulWidget {
     @required this.navigatorKey,
     this.options,
     this.theme,
+    this.host,
     @required this.child,
   })  : assert(projectId != null),
         assert(secret != null),
@@ -79,6 +80,9 @@ class Wiredash extends StatefulWidget {
 
   /// Your Wiredash project secret
   final String secret;
+
+  /// The Wiredash host
+  final String host;
 
   /// Customize Wiredash's behaviour and language
   final WiredashOptionsData options;
@@ -140,10 +144,10 @@ class WiredashState extends State<Wiredash> {
     _updateDependencies();
 
     networkManager = NetworkManager(ApiClient(
-      httpClient: Client(),
-      projectId: widget.projectId,
-      secret: widget.secret,
-    ));
+        httpClient: Client(),
+        projectId: widget.projectId,
+        secret: widget.secret,
+        host: widget.host));
 
     userManager = UserManager();
     buildInfoManager = BuildInfoManager(PlatformBuildInfo());


### PR DESCRIPTION
Make the wiredash endpoint overridable in order to send data to mock, localhost during test, beta wiredash environment.