### PR TITLE
Update changelog, pubspec, README & fix bugs for a 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## [0.2.1] - Confidential enabled flag
-
-* Added an `enabled` flag to the `Confidential` widget.
-* Added docs for the `Confidential` widget.
-* Hid `PaintItBlack` from the public API - this should not be a breaking change since no one will
-  have ever used this.
+## [0.3.0] - Hello offline support, bye-bye FloatingEntryPoint!
+* Support sending feedback and screenshots when offline.
+* Added translations for Arabic, Portuguese, and Turkish.
+* Removed `FloatingEntryPoint` as it was a bit confusing to first-time users and most would disable it anyway.
+* Added an `enabled` flag, docs, and hid `PaintItBlack` in the `Confidential` widget.
+* Fixed translation overflow exceptions for some languages.
 
 ## [0.2.0] - Internationalization Support 🇬🇧🇩🇪🇵🇱
 We added initial internationalization support for several languages. Feel free to contribute your own translations 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to get started, you need to create an account at [wiredash.io](https://
 
 ### Setting up your Flutter project
 
-After successfully creating a new project in the Wiredash admin console it's time to add Wiredash to your app. Simply open your `pubspec.yaml` file and add the current version of Wiredash as a dependency, e.g. `wiredash: 0.2.0`. Make sure to get the newest version.
+After successfully creating a new project in the Wiredash admin console it's time to add Wiredash to your app. Simply open your `pubspec.yaml` file and add the current version of Wiredash as a dependency, e.g. `wiredash: 0.3.0`. Make sure to get the newest version.
 
 Now get all pub packages by clicking on `Packages get` in your IDE or executing `flutter packages get` inside your Flutter project.
 

--- a/lib/src/common/widgets/navigation_buttons.dart
+++ b/lib/src/common/widgets/navigation_buttons.dart
@@ -23,11 +23,13 @@ class PreviousButton extends StatelessWidget {
       onPressed: onPressed,
       child: Row(
         children: [
-          Text(
-            text,
-            style: theme.buttonCancel,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
+          Expanded(
+            child: Text(
+              text,
+              style: theme.buttonCancel,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),

--- a/lib/src/feedback/data/pending_feedback_item_storage.dart
+++ b/lib/src/feedback/data/pending_feedback_item_storage.dart
@@ -73,7 +73,10 @@ class PendingFeedbackItemStorage {
       for (final item in items) {
         if (item.id == itemToClear.id) {
           if (item.screenshotPath != null) {
-            await _fs.file(item.screenshotPath).delete();
+            final screenshot = _fs.file(item.screenshotPath);
+            if (await screenshot.exists()) {
+              await screenshot.delete();
+            }
           }
 
           final updatedItems = List.of(await retrieveAllPendingItems());

--- a/lib/src/feedback/data/retrying_feedback_submitter.dart
+++ b/lib/src/feedback/data/retrying_feedback_submitter.dart
@@ -92,17 +92,17 @@ class RetryingFeedbackSubmitter {
   Future<void> _submitWithRetry<T>(PendingFeedbackItem item) async {
     var attempt = 0;
 
-    final feedback = item.feedbackItem;
-    final Uint8List screenshot = item.screenshotPath != null
-        ? await fs.file(item.screenshotPath).readAsBytes()
-        : null;
-
     // ignore: literal_only_boolean_expressions
     while (true) {
       attempt++;
 
       try {
-        await _networkManager.sendFeedback(feedback, screenshot);
+        final Uint8List screenshot = item.screenshotPath != null &&
+                await fs.file(item.screenshotPath).exists()
+            ? await fs.file(item.screenshotPath).readAsBytes()
+            : null;
+
+        await _networkManager.sendFeedback(item.feedbackItem, screenshot);
         await _pendingFeedbackItemStorage.clearPendingItem(item);
         break;
       } catch (_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wiredash
 description: Wiredash is an interactive user feedback tool for Flutter apps.
-version: 0.2.1
+version: 0.3.0
 homepage: https://wiredash.io
 repository: https://github.com/wiredashio/wiredash-sdk
 

--- a/test/feedback/data/pending_feedback_item_storage_test.dart
+++ b/test/feedback/data/pending_feedback_item_storage_test.dart
@@ -265,5 +265,30 @@ void main() {
         isFalse,
       );
     });
+
+    test(
+        'does not crash when clearing an item and the screenshot file does not exist',
+        () async {
+      when(mockSharedPreferences
+              .getStringList('io.wiredash.pending_feedback_items'))
+          .thenReturn([
+        json.encode({
+          'id': '<existing item id>',
+          'feedbackItem': {
+            'deviceInfo': '<existing item device info>',
+            'email': '<existing item email>',
+            'message': '<existing item message>',
+            'type': '<existing item type>',
+            'user': '<existing item user>'
+          },
+          'screenshotPath': '<existing item screenshot>'
+        }),
+      ]);
+
+      final item = (await storage.retrieveAllPendingItems()).single;
+      await storage.clearPendingItem(item);
+
+      // If the test didn't crash until this point, it's considered a passing test.
+    });
   });
 }


### PR DESCRIPTION
Closes #41, closes #54.

(did a bigger bump than `0.2.0->0.2.1` because we're removing `FloatingEntryPoint` from the SDK)

Encountered some bugs while running tests that need fixing:
- [x] the `PreviousButton` can cause overflow exceptions in NL locale
- [x] there was a bug where if a stored screenshot file was not found, it would prevent sending further feedback items altogether. I think I fixed it, but I'll test it some more and write some test cases to be extra sure.