### PR TITLE
Show only one Wiredash feedback flow at a time

### DIFF
--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -130,17 +130,18 @@ Thanks!
 ''');
 
     if (_navigatorKey.currentState == null ||
-        feedbackUiState == FeedbackUiState.capture) return;
+        feedbackUiState == FeedbackUiState.capture ||
+        feedbackUiState != FeedbackUiState.hidden) return;
 
     feedbackUiState = FeedbackUiState.intro;
-    _navigatorKey.currentState.push(
-      DismissiblePageRoute(
-        builder: (context) => FeedbackSheet(),
-        onPagePopped: () {
-          feedbackUiState = FeedbackUiState.hidden;
-        },
-      ),
-    );
+    _navigatorKey.currentState
+        .push(
+          DismissiblePageRoute(
+            builder: (context) => FeedbackSheet(),
+            onPagePopped: () => feedbackUiState = FeedbackUiState.hidden,
+          ),
+        )
+        .then((_) => _feedbackUiState = FeedbackUiState.hidden);
   }
 }
 

--- a/lib/src/wiredash_controller.dart
+++ b/lib/src/wiredash_controller.dart
@@ -57,6 +57,9 @@ class WiredashController {
   /// own [WiredashTheme] and / or [WiredashTranslation] to the [Wiredash]
   /// root widget. In a future release you'll be able to customize the SDK
   /// through the Wiredash admin console as well.
+  ///
+  /// If a Wiredash feedback flow is already active (=a feedback sheet is open),
+  /// does nothing.
   void show() => _state.show();
 
   /// A [ValueNotifier] representing the current state of the capture UI. Use

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -1,22 +1,74 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wiredash/src/feedback/feedback_sheet.dart';
 import 'package:wiredash/wiredash.dart';
 
 void main() {
-  testWidgets('Wiredash widget can be created', (WidgetTester tester) async {
-    const key = ValueKey('wiredash');
-    await tester.pumpWidget(
-      Wiredash(
-        projectId: 'test',
-        secret: 'test',
-        navigatorKey: GlobalKey<NavigatorState>(),
-        key: key,
-        child: const SizedBox(),
-      ),
+  group('Wiredash', () {
+    testWidgets('widget can be created', (tester) async {
+      await tester.pumpWidget(
+        Wiredash(
+          projectId: 'test',
+          secret: 'test',
+          navigatorKey: GlobalKey<NavigatorState>(),
+          child: const SizedBox(),
+        ),
+      );
+
+      expect(find.byType(Wiredash), findsOneWidget);
+    });
+
+    testWidgets(
+      'only one feedback flow will be launched at a time',
+      (tester) async {
+        final navigatorKey = GlobalKey<NavigatorState>();
+        WiredashController controller;
+
+        await tester.pumpWidget(
+          Wiredash(
+            projectId: 'test',
+            secret: 'test',
+            navigatorKey: navigatorKey,
+            child: MaterialApp(
+              home: const SizedBox(),
+              navigatorKey: navigatorKey,
+              builder: (context, child) {
+                controller = Wiredash.of(context);
+                return child;
+              },
+            ),
+          ),
+        );
+
+        expect(controller, isNotNull);
+        expect(find.byType(FeedbackSheet), findsNothing);
+
+        // Calling controller.show() once should bring out the FeedbackSheet.
+        controller.show();
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(FeedbackSheet), findsOneWidget);
+
+        // Further calls to controller.show() should not bring out additional
+        // FeedbackSheets - there should still be only one.
+        controller.show();
+        controller.show();
+        controller.show();
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(FeedbackSheet), findsOneWidget);
+
+        // Hide the FeedbackSheet
+        navigatorKey.currentState.pop();
+        await tester.pump();
+        expect(find.byType(FeedbackSheet), findsNothing);
+
+        // Calling controller.show() should bring out a FeedbackSheet normally.
+        controller.show();
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(FeedbackSheet), findsOneWidget);
+      },
     );
-
-    final wiredashFinder = find.byKey(key);
-
-    expect(wiredashFinder, findsOneWidget);
   });
 }


### PR DESCRIPTION
Fixes the use case in #62, specifically https://github.com/wiredashio/wiredash-sdk/issues/62#issuecomment-653822796.

When calling `Wiredash.of(context).show()`, a new `FeedbackSheet` will be only pushed if there's no existing one open.