### PR TITLE
Unify email validation logic between backend & SDK

### DIFF
--- a/lib/src/common/utils/email_validator.dart
+++ b/lib/src/common/utils/email_validator.dart
@@ -1,0 +1,12 @@
+class EmailValidator {
+  const EmailValidator();
+
+  bool validate(String email) {
+    return _pattern.hasMatch(email);
+  }
+}
+
+final _pattern = RegExp(
+  r"^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*",
+  caseSensitive: false,
+);

--- a/lib/src/feedback/components/input_component.dart
+++ b/lib/src/feedback/components/input_component.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
 import 'package:wiredash/src/common/translation/wiredash_localizations.dart';
 import 'package:wiredash/src/common/user/user_manager.dart';
+import 'package:wiredash/src/common/utils/email_validator.dart';
 import 'package:wiredash/src/common/widgets/wiredash_icons.dart';
 import 'package:wiredash/src/feedback/feedback_model.dart';
 
@@ -161,12 +162,16 @@ class _InputComponentState extends State<InputComponent> {
         }
         break;
       case InputComponentType.email:
-        if (input.isEmpty) return null;
-        final isValidEmail = RegExp(
-                r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+")
-            .hasMatch(input);
-        if (isValidEmail) return null;
-        return WiredashLocalizations.of(context).validationHintEmail;
+        if (input.isEmpty) {
+          // It's okay to not provide an email address, in which we consider the
+          // input to be valid.
+          return null;
+        }
+
+        // If the email is non-null, we validate it.
+        return debugEmailValidator.validate(input)
+            ? null
+            : WiredashLocalizations.of(context).validationHintEmail;
     }
 
     return null;
@@ -184,3 +189,6 @@ class _InputComponentState extends State<InputComponent> {
     }
   }
 }
+
+@visibleForTesting
+EmailValidator debugEmailValidator = const EmailValidator();

--- a/lib/src/feedback/components/input_component.dart
+++ b/lib/src/feedback/components/input_component.dart
@@ -154,7 +154,7 @@ class _InputComponentState extends State<InputComponent> {
   String _validateInput(String input) {
     switch (widget.type) {
       case InputComponentType.feedback:
-        if (input.isEmpty) {
+        if (input.trim().isEmpty) {
           return WiredashLocalizations.of(context).validationHintFeedbackEmpty;
         } else if (input.length > 512) {
           return WiredashLocalizations.of(context).validationHintFeedbackLength;

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -60,7 +60,7 @@ class FeedbackModel with ChangeNotifier {
           _feedbackUiState = FeedbackUiState.feedback;
           _navigatorKey.currentState.push(
             DismissiblePageRoute(
-              builder: (context) => FeedbackSheet(),
+              builder: (context) => const FeedbackSheet(),
               background: image,
               onPagePopped: () {
                 feedbackUiState = FeedbackUiState.hidden;
@@ -137,7 +137,7 @@ Thanks!
     _navigatorKey.currentState
         .push(
           DismissiblePageRoute(
-            builder: (context) => FeedbackSheet(),
+            builder: (context) => const FeedbackSheet(),
             onPagePopped: () => feedbackUiState = FeedbackUiState.hidden,
           ),
         )

--- a/lib/src/feedback/feedback_sheet.dart
+++ b/lib/src/feedback/feedback_sheet.dart
@@ -295,7 +295,7 @@ class _FeedbackSheetState extends State<FeedbackSheet>
         );
       case FeedbackUiState.email:
         return InputComponent(
-          key: ValueKey(uiState),
+          key: const ValueKey('wiredash.sdk.email_input_field'),
           type: InputComponentType.email,
           formKey: _emailFormKey,
           focusNode: _emailFocusNode,

--- a/lib/src/feedback/feedback_sheet.dart
+++ b/lib/src/feedback/feedback_sheet.dart
@@ -13,8 +13,9 @@ import 'package:wiredash/src/feedback/components/intro_component.dart';
 import 'package:wiredash/src/feedback/components/success_component.dart';
 import 'package:wiredash/src/feedback/feedback_model.dart';
 
-// ignore: use_key_in_widget_constructors
 class FeedbackSheet extends StatefulWidget {
+  const FeedbackSheet({Key key}) : super(key: key);
+
   @override
   _FeedbackSheetState createState() => _FeedbackSheetState();
 }
@@ -285,7 +286,7 @@ class _FeedbackSheetState extends State<FeedbackSheet>
         return IntroComponent(_onFeedbackModeSelected);
       case FeedbackUiState.feedback:
         return InputComponent(
-          key: ValueKey(uiState),
+          key: const ValueKey('wiredash.sdk.feedback_input_field'),
           type: InputComponentType.feedback,
           formKey: _feedbackFormKey,
           focusNode: _feedbackFocusNode,

--- a/test/common/utils/email_validator_test.dart
+++ b/test/common/utils/email_validator_test.dart
@@ -1,0 +1,30 @@
+import 'package:test/test.dart';
+import 'package:wiredash/src/common/utils/email_validator.dart';
+
+void main() {
+  group('EmailValidator', () {
+    EmailValidator validator;
+
+    setUp(() {
+      validator = const EmailValidator();
+    });
+
+    test('valid emails', () {
+      expect(validator.validate('test@example.com'), true);
+      expect(validator.validate('TEST@exSMAo.COM'), true);
+      expect(validator.validate('dash@wiredash.io'), true);
+      expect(validator.validate('hey.ho@gmail.com'), true);
+      expect(validator.validate('no_reply@phntm.xyz'), true);
+      expect(validator.validate('no_reply@spitch.live'), true);
+    });
+
+    test('invalid emails', () {
+      expect(validator.validate('test@example.'), false);
+      expect(validator.validate('TEST@exSMAocom'), false);
+      expect(validator.validate('wiredash.io'), false);
+      expect(validator.validate('@gmail.com'), false);
+      expect(validator.validate('frank'), false);
+      expect(validator.validate(''), false);
+    });
+  });
+}

--- a/test/feedback/feedback_sheet_test.dart
+++ b/test/feedback/feedback_sheet_test.dart
@@ -7,18 +7,30 @@ import 'package:wiredash/src/common/options/wiredash_options.dart';
 import 'package:wiredash/src/common/options/wiredash_options_data.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme_data.dart';
+import 'package:wiredash/src/common/user/user_manager.dart';
+import 'package:wiredash/src/common/utils/email_validator.dart';
+import 'package:wiredash/src/feedback/components/input_component.dart';
 import 'package:wiredash/src/feedback/feedback_model.dart';
 import 'package:wiredash/src/feedback/feedback_sheet.dart';
 import 'package:wiredash/wiredash.dart';
 
 class MockFeedbackModel extends Mock implements FeedbackModel {}
 
+class MockUserManager extends Mock implements UserManager {}
+
+class MockEmailValidator extends Mock implements EmailValidator {}
+
 void main() {
   group('FeedbackSheet', () {
     MockFeedbackModel mockFeedbackModel;
+    MockUserManager mockUserManager;
+    MockEmailValidator mockEmailValidator;
 
     setUp(() {
       mockFeedbackModel = MockFeedbackModel();
+      mockUserManager = MockUserManager();
+      mockEmailValidator = MockEmailValidator();
+      debugEmailValidator = mockEmailValidator;
     });
 
     testWidgets(
@@ -31,6 +43,7 @@ void main() {
         await tester.pumpWidget(
           _TestBoilerplate(
             feedbackModel: mockFeedbackModel,
+            userManager: mockUserManager,
             child: const FeedbackSheet(),
           ),
         );
@@ -59,6 +72,7 @@ void main() {
         await tester.pumpWidget(
           _TestBoilerplate(
             feedbackModel: mockFeedbackModel,
+            userManager: mockUserManager,
             child: const FeedbackSheet(),
           ),
         );
@@ -76,6 +90,76 @@ void main() {
         verify(mockFeedbackModel.feedbackUiState = FeedbackUiState.email);
       },
     );
+
+    testWidgets(
+      'displays error message when email validation does not pass',
+      (tester) async {
+        when(mockFeedbackModel.feedbackUiState)
+            .thenReturn(FeedbackUiState.email);
+        when(mockFeedbackModel.loading).thenReturn(false);
+        when(mockEmailValidator.validate(any)).thenReturn(false);
+
+        await tester.pumpWidget(
+          _TestBoilerplate(
+            feedbackModel: mockFeedbackModel,
+            userManager: mockUserManager,
+            child: const FeedbackSheet(),
+          ),
+        );
+
+        await tester.enterText(
+          find.byKey(const ValueKey('wiredash.sdk.email_input_field')),
+          '<does not matter>',
+        );
+
+        await tester.tap(
+            find.byKey(const ValueKey('wiredash.sdk.send_feedback_button')));
+        await tester.pump();
+
+        expect(
+          find.text('Please enter a valid email or leave this field blank.'),
+          findsOneWidget,
+        );
+
+        verifyNever(
+          mockFeedbackModel.feedbackUiState = FeedbackUiState.success,
+        );
+      },
+    );
+
+    testWidgets(
+      'goes to success step when email validation passes',
+      (tester) async {
+        when(mockFeedbackModel.feedbackUiState)
+            .thenReturn(FeedbackUiState.email);
+        when(mockFeedbackModel.loading).thenReturn(false);
+        when(mockEmailValidator.validate(any)).thenReturn(true);
+
+        await tester.pumpWidget(
+          _TestBoilerplate(
+            feedbackModel: mockFeedbackModel,
+            userManager: mockUserManager,
+            child: const FeedbackSheet(),
+          ),
+        );
+
+        await tester.enterText(
+          find.byKey(const ValueKey('wiredash.sdk.email_input_field')),
+          '<does not matter>',
+        );
+
+        await tester.tap(
+            find.byKey(const ValueKey('wiredash.sdk.send_feedback_button')));
+        await tester.pump();
+
+        expect(
+          find.text('Please enter a valid email or leave this field blank.'),
+          findsNothing,
+        );
+
+        verify(mockFeedbackModel.feedbackUiState = FeedbackUiState.success);
+      },
+    );
   });
 }
 
@@ -83,12 +167,15 @@ class _TestBoilerplate extends StatelessWidget {
   const _TestBoilerplate({
     Key key,
     @required this.feedbackModel,
+    @required this.userManager,
     @required this.child,
   })  : assert(feedbackModel != null),
+        assert(userManager != null),
         assert(child != null),
         super(key: key);
 
   final FeedbackModel feedbackModel;
+  final UserManager userManager;
   final Widget child;
 
   @override
@@ -100,8 +187,11 @@ class _TestBoilerplate extends StatelessWidget {
           locale: const Locale('en', 'US'),
         ),
         child: WiredashLocalizations(
-          child: ChangeNotifierProvider<FeedbackModel>.value(
-            value: feedbackModel,
+          child: MultiProvider(
+            providers: [
+              Provider<UserManager>.value(value: userManager),
+              ChangeNotifierProvider<FeedbackModel>.value(value: feedbackModel),
+            ],
             child: MaterialApp(
               locale: const Locale('en', 'US'),
               home: ChangeNotifierProvider<FeedbackModel>.value(

--- a/test/feedback/feedback_sheet_test.dart
+++ b/test/feedback/feedback_sheet_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:wiredash/src/common/options/wiredash_options.dart';
+import 'package:wiredash/src/common/options/wiredash_options_data.dart';
+import 'package:wiredash/src/common/theme/wiredash_theme.dart';
+import 'package:wiredash/src/common/theme/wiredash_theme_data.dart';
+import 'package:wiredash/src/feedback/feedback_model.dart';
+import 'package:wiredash/src/feedback/feedback_sheet.dart';
+import 'package:wiredash/wiredash.dart';
+
+class MockFeedbackModel extends Mock implements FeedbackModel {}
+
+void main() {
+  group('FeedbackSheet', () {
+    MockFeedbackModel mockFeedbackModel;
+
+    setUp(() {
+      mockFeedbackModel = MockFeedbackModel();
+    });
+
+    testWidgets(
+      'displays error message when submitting blank feedback',
+      (tester) async {
+        when(mockFeedbackModel.feedbackUiState)
+            .thenReturn(FeedbackUiState.feedback);
+        when(mockFeedbackModel.loading).thenReturn(false);
+
+        await tester.pumpWidget(
+          _TestBoilerplate(
+            feedbackModel: mockFeedbackModel,
+            child: const FeedbackSheet(),
+          ),
+        );
+
+        await tester.enterText(
+          find.byKey(const ValueKey('wiredash.sdk.feedback_input_field')),
+          '        ',
+        );
+
+        await tester.tap(
+            find.byKey(const ValueKey('wiredash.sdk.save_feedback_button')));
+        await tester.pump();
+
+        expect(find.text('Please provide your feedback.'), findsOneWidget);
+        verifyNever(mockFeedbackModel.feedbackUiState = FeedbackUiState.email);
+      },
+    );
+
+    testWidgets(
+      'goes to email step when submitting non-empty feedback',
+      (tester) async {
+        when(mockFeedbackModel.feedbackUiState)
+            .thenReturn(FeedbackUiState.feedback);
+        when(mockFeedbackModel.loading).thenReturn(false);
+
+        await tester.pumpWidget(
+          _TestBoilerplate(
+            feedbackModel: mockFeedbackModel,
+            child: const FeedbackSheet(),
+          ),
+        );
+
+        await tester.enterText(
+          find.byKey(const ValueKey('wiredash.sdk.feedback_input_field')),
+          'amazing game!! 0/5 stars I love it',
+        );
+
+        await tester.tap(
+            find.byKey(const ValueKey('wiredash.sdk.save_feedback_button')));
+        await tester.pump();
+
+        expect(find.text('Please provide your feedback.'), findsNothing);
+        verify(mockFeedbackModel.feedbackUiState = FeedbackUiState.email);
+      },
+    );
+  });
+}
+
+class _TestBoilerplate extends StatelessWidget {
+  const _TestBoilerplate({
+    Key key,
+    @required this.feedbackModel,
+    @required this.child,
+  })  : assert(feedbackModel != null),
+        assert(child != null),
+        super(key: key);
+
+  final FeedbackModel feedbackModel;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return WiredashTheme(
+      data: WiredashThemeData(),
+      child: WiredashOptions(
+        data: WiredashOptionsData(
+          locale: const Locale('en', 'US'),
+        ),
+        child: WiredashLocalizations(
+          child: ChangeNotifierProvider<FeedbackModel>.value(
+            value: feedbackModel,
+            child: MaterialApp(
+              locale: const Locale('en', 'US'),
+              home: ChangeNotifierProvider<FeedbackModel>.value(
+                value: feedbackModel,
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
As this uses the same email validation pattern as the backend server does, this should fix the bug where the SDK accepts an email address that the backend later rejects.

(I think we should relax email validation to only check for the `@` and `.` as proposed in #1, because email address validation without sending a verification link is notoriously hard to do right.)

Needs #83 to be merged first.