### PR TITLE
Widen file dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
-  file: ^5.2.1
+  file: ">=5.2.1 <7.0.0"
   http: ^0.12.0
   http_parser: ^3.1.0
   path_provider: ^1.6.14


### PR DESCRIPTION
Widen `file` dependency to support Flutter 1.22+

I ran our tests with `6.0.0-nullsafety.2` without problems. So I guess we're compatible with [file: 0.6.0](https://github.com/google/file.dart/blob/master/packages/file/CHANGELOG.md) when it lands

Fixes #87