### PR TITLE
Fixes #18: Option to hide buttons

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,9 @@ class _ExampleAppState extends State<ExampleApp> {
       options: WiredashOptionsData(
 
           /// Uncomment below to see how custom translations work
+          // bugReportButton: false,
+          // featureRequestButton: false,
+          // praiseButton: false,
           // customTranslations: {
           //   const Locale.fromSubtags(languageCode: 'en'):
           //       const DemoCustomTranslations(),

--- a/lib/src/common/options/wiredash_options_data.dart
+++ b/lib/src/common/options/wiredash_options_data.dart
@@ -7,15 +7,31 @@ class WiredashOptionsData {
   WiredashOptionsData({
     Locale locale,
     TextDirection textDirection,
+    this.bugReportButton = true,
+    this.praiseButton = true,
+    this.featureRequestButton = true,
     this.customTranslations,
   })  : textDirection = textDirection ?? TextDirection.ltr,
-        _currentLocale = locale ?? window.locale;
+        _currentLocale = locale ?? window.locale,
+        assert(
+          bugReportButton || praiseButton || featureRequestButton,
+          'WiredashOptionsData Configuration Error: Show at least one button',
+        );
 
   /// Replace desired texts in Wiredash and localize it for you audience
   ///
   /// You can also use Wiredash delegate in your MaterialApp
   /// if default translations are sufficient for you
   final Map<Locale, WiredashTranslations> customTranslations;
+
+  /// Whether to display the Bug Report button or not.
+  final bool bugReportButton;
+
+  /// Whether to display the Send Praise button or not.
+  final bool praiseButton;
+
+  /// Whether to display the Feature Request button or not.
+  final bool featureRequestButton;
 
   /// Current [TextDirection] used by Wiredash widget
   TextDirection textDirection;

--- a/lib/src/feedback/components/intro_component.dart
+++ b/lib/src/feedback/components/intro_component.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:wiredash/src/common/options/wiredash_options.dart';
 import 'package:wiredash/src/common/translation/wiredash_localizations.dart';
 import 'package:wiredash/src/common/widgets/list_tile_button.dart';
 import 'package:wiredash/src/common/widgets/wiredash_icons.dart';
@@ -13,40 +14,48 @@ class IntroComponent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final options = WiredashOptions.of(context);
+
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 16),
+      padding: const EdgeInsets.only(top: 12, bottom: 16),
       child: Column(
         children: [
-          const SizedBox(height: 8),
-          ListTileButton(
-            key: const ValueKey('wiredash.sdk.intro.report_a_bug_button'),
-            icon: WiredashIcons.bug,
-            iconColor: const Color(0xff9c4db1),
-            iconBackgroundColor: const Color(0xffffc4f0),
-            title: WiredashLocalizations.of(context).feedbackModeBugTitle,
-            subtitle: WiredashLocalizations.of(context).feedbackModeBugMsg,
-            onPressed: () => onModeSelectedCallback(FeedbackType.bug),
-          ),
-          const SizedBox(height: 12),
-          ListTileButton(
-            icon: WiredashIcons.feature,
-            iconColor: const Color(0xff007cbc),
-            iconBackgroundColor: const Color(0xff2bd9fc),
-            title:
-                WiredashLocalizations.of(context).feedbackModeImprovementTitle,
-            subtitle:
-                WiredashLocalizations.of(context).feedbackModeImprovementMsg,
-            onPressed: () => onModeSelectedCallback(FeedbackType.improvement),
-          ),
-          const SizedBox(height: 12),
-          ListTileButton(
-            icon: WiredashIcons.applause,
-            iconColor: const Color(0xff00b779),
-            iconBackgroundColor: const Color(0xffcdfbcb),
-            title: WiredashLocalizations.of(context).feedbackModePraiseTitle,
-            subtitle: WiredashLocalizations.of(context).feedbackModePraiseMsg,
-            onPressed: () => onModeSelectedCallback(FeedbackType.praise),
-          ),
+          if (options.bugReportButton) ...[
+            const SizedBox(height: 12),
+            ListTileButton(
+              key: const ValueKey('wiredash.sdk.intro.report_a_bug_button'),
+              icon: WiredashIcons.bug,
+              iconColor: const Color(0xff9c4db1),
+              iconBackgroundColor: const Color(0xffffc4f0),
+              title: WiredashLocalizations.of(context).feedbackModeBugTitle,
+              subtitle: WiredashLocalizations.of(context).feedbackModeBugMsg,
+              onPressed: () => onModeSelectedCallback(FeedbackType.bug),
+            ),
+          ],
+          if (options.featureRequestButton) ...[
+            const SizedBox(height: 12),
+            ListTileButton(
+              icon: WiredashIcons.feature,
+              iconColor: const Color(0xff007cbc),
+              iconBackgroundColor: const Color(0xff2bd9fc),
+              title: WiredashLocalizations.of(context)
+                  .feedbackModeImprovementTitle,
+              subtitle:
+                  WiredashLocalizations.of(context).feedbackModeImprovementMsg,
+              onPressed: () => onModeSelectedCallback(FeedbackType.improvement),
+            ),
+          ],
+          if (options.praiseButton) ...[
+            const SizedBox(height: 12),
+            ListTileButton(
+              icon: WiredashIcons.applause,
+              iconColor: const Color(0xff00b779),
+              iconBackgroundColor: const Color(0xffcdfbcb),
+              title: WiredashLocalizations.of(context).feedbackModePraiseTitle,
+              subtitle: WiredashLocalizations.of(context).feedbackModePraiseMsg,
+              onPressed: () => onModeSelectedCallback(FeedbackType.praise),
+            ),
+          ],
         ],
       ),
     );


### PR DESCRIPTION
  - Adds 3 booleans to the WiredashOptionsData
    - bugReportButton
    - featureRequestButton
    - praiseButton
  - All Buttons enabled by default

If any of these are set to false, hide the button. If all of them are set to false, throw an error requiring at least 1 button be enabled.