### PR TITLE
Disallow opening feedback in capture mode

### DIFF
--- a/lib/src/common/widgets/spotlight.dart
+++ b/lib/src/common/widgets/spotlight.dart
@@ -50,6 +50,7 @@ class SpotlightState extends State<Spotlight>
   @override
   void dispose() {
     _animationController.dispose();
+    _timer?.cancel();
     super.dispose();
   }
 

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -33,7 +33,9 @@ class FeedbackModel with ChangeNotifier {
   Uint8List screenshot;
 
   FeedbackUiState _feedbackUiState = FeedbackUiState.hidden;
+
   FeedbackUiState get feedbackUiState => _feedbackUiState;
+
   set feedbackUiState(FeedbackUiState newValue) {
     if (_feedbackUiState == newValue) return;
     _feedbackUiState = newValue;
@@ -42,7 +44,9 @@ class FeedbackModel with ChangeNotifier {
   }
 
   bool _loading = false;
+
   bool get loading => _loading;
+
   set loading(bool newValue) {
     if (_loading == newValue) return;
     _loading = newValue;
@@ -134,14 +138,18 @@ Thanks!
         feedbackUiState != FeedbackUiState.hidden) return;
 
     feedbackUiState = FeedbackUiState.intro;
-    _navigatorKey.currentState
-        .push(
-          DismissiblePageRoute(
-            builder: (context) => const FeedbackSheet(),
-            onPagePopped: () => feedbackUiState = FeedbackUiState.hidden,
-          ),
-        )
-        .then((_) => _feedbackUiState = FeedbackUiState.hidden);
+    final route = DismissiblePageRoute(
+      builder: (context) => const FeedbackSheet(),
+      onPagePopped: () => feedbackUiState = FeedbackUiState.hidden,
+    );
+    _navigatorKey.currentState.push(route).then((_) {
+      if (_feedbackUiState == FeedbackUiState.capture) {
+        // The capture mode pops this route but it stays in capture mode
+        // and doesn't switch to hidden
+        return;
+      }
+      _feedbackUiState = FeedbackUiState.hidden;
+    });
   }
 }
 

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/capture/capture.dart';
 import 'package:wiredash/src/common/utils/project_credential_validator.dart';
 import 'package:wiredash/src/feedback/feedback_sheet.dart';
 import 'package:wiredash/src/wiredash_widget.dart';
@@ -16,6 +18,7 @@ void main() {
     setUp(() {
       mockProjectCredentialValidator = MockProjectCredentialValidator();
       debugProjectCredentialValidator = mockProjectCredentialValidator;
+      SharedPreferences.setMockInitialValues({});
     });
 
     tearDown(() {
@@ -57,7 +60,8 @@ void main() {
       },
     );
 
-    testWidgets('only one feedback flow will be launched at a time',
+    testWidgets(
+        'only one feedback flow will be launched at a time - intro mode',
         (tester) async {
       final navigatorKey = GlobalKey<NavigatorState>();
       WiredashController controller;
@@ -106,6 +110,49 @@ void main() {
       await tester.pump();
       await tester.pump();
       expect(find.byType(FeedbackSheet), findsOneWidget);
+    });
+
+    testWidgets(
+        'only one feedback flow will be launched at a time - in capture mode',
+        (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+
+      await tester.pumpWidget(
+        Wiredash(
+          projectId: 'test',
+          secret: 'test',
+          navigatorKey: navigatorKey,
+          child: MaterialApp(
+            home: Builder(builder: (context) {
+              return Scaffold(
+                floatingActionButton: FloatingActionButton(
+                  onPressed: Wiredash.of(context).show,
+                ),
+              );
+            }),
+            navigatorKey: navigatorKey,
+          ),
+        ),
+      );
+
+      expect(find.byType(FeedbackSheet), findsNothing);
+
+      // Open the FeedbackSheet.
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+      expect(find.byType(FeedbackSheet), findsOneWidget);
+
+      // Go to capture mode
+      await tester.tap(
+          find.byKey(const ValueKey('wiredash.sdk.intro.report_a_bug_button')));
+      await tester.pumpAndSettle();
+      expect(find.byType(Capture), findsOneWidget);
+
+      // Tapping the FeedbackSheet again does nothing
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+      // FeedbackSheet doesn't open
+      expect(find.byType(FeedbackSheet), findsNothing);
     });
   });
 }


### PR DESCRIPTION
I noticed that it is possible to open the feedback sheet while in `capture` mode. Calling `Wiredash.of(context).show()` now does nothing.

This should not be possible
![Screen-Shot-2020-11-29-13-50-34 83](https://user-images.githubusercontent.com/1096485/100545801-1248af00-325e-11eb-93ee-d258933b1203.png)

Added test as proof