### PR TITLE
Error handling: Delete feedback when disk parsing/submission fails

### DIFF
--- a/lib/src/common/network/wiredash_api.dart
+++ b/lib/src/common/network/wiredash_api.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -72,14 +73,27 @@ class WiredashApi {
 
 /// Generic error from the Wiredash API
 class WiredashApiException implements Exception {
-  WiredashApiException({this.message, this.response});
+  WiredashApiException({String message, this.response}) : _message = message;
+  String /*?*/ get message {
+    final String /*?*/ bodyMessage = () {
+      try {
+        return jsonDecode(response?.body)['message'] as String;
+      } catch (e) {
+        return response?.body;
+      }
+    }();
+    if (_message == null) {
+      return bodyMessage;
+    }
+    return "$_message $bodyMessage";
+  }
 
-  final String /*?*/ message;
+  final String /*?*/ _message;
   final Response /*?*/ response;
 
   @override
   String toString() {
-    return 'WiredashApiException{message: $message, ${response?.statusCode} response: ${response.body}';
+    return 'WiredashApiException{${response?.statusCode}, message: $message, body: ${response?.body}';
   }
 }
 
@@ -89,14 +103,13 @@ class UnauthenticatedWiredashApiException extends WiredashApiException {
     Response response,
     this.projectId,
     this.secret,
-  ) : super(response: response);
+  ) : super(
+          message: "Unknown projectId:'$projectId' or invalid secret:'$secret'",
+          response: response,
+        );
 
   final String projectId;
   final String secret;
-
-  @override
-  String get message =>
-      "Unknown projectId:'$projectId' or invalid secret:'$secret'";
 
   @override
   String toString() {

--- a/lib/src/feedback/data/retrying_feedback_submitter.dart
+++ b/lib/src/feedback/data/retrying_feedback_submitter.dart
@@ -108,7 +108,7 @@ class RetryingFeedbackSubmitter {
 
         await _api.sendFeedback(
             feedback: item.feedbackItem, screenshot: screenshot);
-        await _pendingFeedbackItemStorage.clearPendingItem(item);
+        await _pendingFeedbackItemStorage.clearPendingItem(item.id);
         break;
       } on UnauthenticatedWiredashApiException catch (e, stack) {
         // Project configuration is off, retry at next app start

--- a/lib/src/feedback/data/retrying_feedback_submitter.dart
+++ b/lib/src/feedback/data/retrying_feedback_submitter.dart
@@ -99,15 +99,15 @@ class RetryingFeedbackSubmitter {
     // ignore: literal_only_boolean_expressions
     while (true) {
       attempt++;
-
       try {
         final Uint8List screenshot = item.screenshotPath != null &&
                 await fs.file(item.screenshotPath).exists()
             ? await fs.file(item.screenshotPath).readAsBytes()
             : null;
-
         await _api.sendFeedback(
             feedback: item.feedbackItem, screenshot: screenshot);
+        // ignore: avoid_print
+        print("Feedback submitted ✌️");
         await _pendingFeedbackItemStorage.clearPendingItem(item.id);
         break;
       } on UnauthenticatedWiredashApiException catch (e, stack) {
@@ -121,6 +121,8 @@ class RetryingFeedbackSubmitter {
             e.message.contains("is required")) {
           // some required property is missing. The item will never be delivered
           // to the server, therefore discard it.
+          reportWiredashError(e, stack,
+              'Feedback has missing properties and can not be submitted to server');
           await _pendingFeedbackItemStorage.clearPendingItem(item.id);
           break;
         }

--- a/test/feedback/data/pending_feedback_item_storage_test.dart
+++ b/test/feedback/data/pending_feedback_item_storage_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/test.dart';
@@ -169,8 +170,7 @@ void main() {
         }),
       ]);
 
-      final item = (await storage.retrieveAllPendingItems()).single;
-      await storage.clearPendingItem(item);
+      await storage.clearPendingItem('<existing item id>');
 
       verify(
         mockSharedPreferences
@@ -256,9 +256,7 @@ void main() {
         }),
       ]);
 
-      final item = (await storage.retrieveAllPendingItems())
-          .singleWhere((element) => element.id == '<existing item id>');
-      await storage.clearPendingItem(item);
+      await storage.clearPendingItem('<existing item id>');
 
       verify(
         mockSharedPreferences
@@ -320,10 +318,122 @@ void main() {
         }),
       ]);
 
-      final item = (await storage.retrieveAllPendingItems()).single;
-      await storage.clearPendingItem(item);
+      await storage.clearPendingItem('<existing item id>');
 
       // If the test didn't crash until this point, it's considered a passing test.
+    });
+
+    test('removes items which can not be parsed', () async {
+      await fileSystem
+          .file('<screenshot for invalid item>')
+          .writeAsBytes(kTransparentImage);
+
+      await fileSystem
+          .file('<existing item screenshot>')
+          .writeAsBytes(kTransparentImage);
+
+      expect(
+        fileSystem.file('<screenshot for invalid item>').existsSync(),
+        isTrue,
+      );
+
+      expect(
+        fileSystem.file('<existing item screenshot>').existsSync(),
+        isTrue,
+      );
+
+      final illegalItem = json.encode({
+        // item has some required properties missing
+        'id': '<screenshot for invalid item>',
+        'feedbackItem': {
+          'email': '<email for item to be preserved>',
+          'type': '<type for item to be preserved>',
+        },
+        'screenshotPath': '<screenshot for invalid item>'
+      });
+
+      final legalItem = json.encode({
+        'id': '<id for item to be preserved>',
+        'feedbackItem': {
+          'deviceInfo': {
+            'appIsDebug': true,
+            'deviceId': '8F821AB6-B3A7-41BA-882E-32D8367243C1',
+            'locale': 'en_US',
+            'padding': [0.0, 66.0, 0.0, 0.0],
+            'physicalSize': [1080.0, 2088.0],
+            'pixelRatio': 2.75,
+            'platformOS': 'android',
+            'platformOSVersion': 'RSR1.201013.001',
+            'dartVersion':
+                '2.10.2 (stable) (Tue Oct 13 15:50:27 2020 +0200) on "android_ia32"',
+            'textScaleFactor': 1.0,
+            'viewInsets': [0.0, 0.0, 0.0, 685.0],
+          },
+          'email': '<email for item to be preserved>',
+          'message': '<message for item to be preserved>',
+          'type': '<type for item to be preserved>',
+          'user': '<item user for item to be preserved>'
+        },
+        'screenshotPath': '<screenshot for item to be preserved>'
+      });
+
+      when(mockSharedPreferences
+              .getStringList('io.wiredash.pending_feedback_items'))
+          .thenReturn([illegalItem, legalItem]);
+
+      final oldOnErrorHandler = FlutterError.onError;
+      FlutterErrorDetails caught;
+      FlutterError.onError = (FlutterErrorDetails details) {
+        caught = details;
+      };
+
+      final retrieved = await storage.retrieveAllPendingItems();
+
+      // method returns only valid items
+      expect(retrieved.length, 1);
+
+      // error was reported to Flutter.onError
+      expect(
+          caught.stack.toString(),
+          stringContainsInOrder([
+            'PendingFeedbackItem.fromJson',
+            'PendingFeedbackItemStorage.retrieveAllPendingItems',
+          ]));
+      // reset error reporter after successful assertion
+      FlutterError.onError = oldOnErrorHandler;
+
+      // add pending item to remove the illegal one
+      when(mockUuidV4Generator.generate()).thenReturn('<unique identifier>');
+      final pendingItem = await withUuidV4Generator(
+        mockUuidV4Generator,
+        () => storage.addPendingItem(
+          const FeedbackItem(
+            deviceInfo: DeviceInfo(),
+            email: 'email@example.com',
+            message: 'Hello world!',
+            type: 'bug',
+            user: 'Testy McTestFace',
+          ),
+          kTransparentImage,
+        ),
+      );
+
+      // verify the invalid item was removed, while the legal and new item
+      // where saved
+      verify(mockSharedPreferences.setStringList(
+          'io.wiredash.pending_feedback_items',
+          [legalItem, json.encode(pendingItem.toJson())]));
+
+      // screenshot was deleted as well, leave nothing behind!
+      expect(
+        fileSystem.file('<screenshot for invalid item>').existsSync(),
+        isFalse,
+      );
+
+      expect(
+        fileSystem.file('<existing item screenshot>').existsSync(),
+        isTrue,
+      );
     });
   });
 }

--- a/test/feedback/data/retrying_feedback_submitter_test.dart
+++ b/test/feedback/data/retrying_feedback_submitter_test.dart
@@ -378,9 +378,9 @@ void main() {
                 feedback: item, screenshot: kTransparentImage))
             .thenAnswer((_) {
           throw WiredashApiException(
-              message:
-                  'child "deviceInfo" fails because [child "platformOS" fails because ["platformOS" is required]]',
-              response: Response("error", 401));
+              response: Response(
+                  '{"message": "child "deviceInfo" fails because [child "platformOS" fails because ["platformOS" is required]]"}',
+                  401));
         });
 
         retryingFeedbackSubmitter.submit(item, kTransparentImage);

--- a/test/feedback/data/retrying_feedback_submitter_test.dart
+++ b/test/feedback/data/retrying_feedback_submitter_test.dart
@@ -28,12 +28,12 @@ class FakePendingFeedbackItemStorage implements PendingFeedbackItemStorage {
   final _deletedItemIds = <String>[];
 
   @override
-  Future<void> clearPendingItem(PendingFeedbackItem itemToClear) async {
-    final screenshot = fs.file(itemToClear.screenshotPath);
+  Future<void> clearPendingItem(String itemId) async {
+    final screenshot = fs.file('$itemId.png');
     if (await screenshot.exists()) await screenshot.delete();
 
-    _deletedItemIds.add(itemToClear.id);
-    _currentItems.remove(itemToClear);
+    _deletedItemIds.add(itemId);
+    _currentItems.removeWhere((it) => it.id == itemId);
   }
 
   @override

--- a/test/feedback/data/retrying_feedback_submitter_test.dart
+++ b/test/feedback/data/retrying_feedback_submitter_test.dart
@@ -347,7 +347,7 @@ void main() {
                 feedback: item, screenshot: kTransparentImage))
             .called(1);
 
-        // Should've retried sending feedback at these very specific times.
+        // Log shows only one entry
         expect(retryLog, [
           DateTime(2000, 01, 01, 00, 00, 00, 000),
         ]);
@@ -361,6 +361,40 @@ void main() {
           ),
         ]);
       }, initialTime: initialTime);
+    });
+
+    test('submit() - does not retry when server reports missing properties',
+        () async {
+      const item = FeedbackItem(
+        deviceInfo: DeviceInfo(),
+        email: 'email@example.com',
+        message: 'test post pls ignore',
+        type: 'feedback',
+        user: 'Testy McTestFace',
+      );
+
+      fakeAsync((async) {
+        when(mockNetworkManager.sendFeedback(
+                feedback: item, screenshot: kTransparentImage))
+            .thenAnswer((_) {
+          throw WiredashApiException(
+              message:
+                  'child "deviceInfo" fails because [child "platformOS" fails because ["platformOS" is required]]',
+              response: Response("error", 401));
+        });
+
+        retryingFeedbackSubmitter.submit(item, kTransparentImage);
+        async.elapse(const Duration(seconds: 1));
+
+        // Sending one feedback item should be retried no more than 8 times.
+        verify(mockNetworkManager.sendFeedback(
+                feedback: item, screenshot: kTransparentImage))
+            .called(1);
+
+        // Item has beend deleted
+        expect(fakePendingFeedbackItemStorage._deletedItemIds, ['1']);
+        expect(fakePendingFeedbackItemStorage._currentItems, isEmpty);
+      });
     });
   });
 }


### PR DESCRIPTION
Fixes two scenarios:

## Can't parse feedback from disk

It may happen, when using non-stable Wiredash releases, that feedbacks with missing properties exist. Previously this caused the submit loop to error, preventing all further feedbacks to never be submitted. 

Now feedback parsing errors from disk are caught and removed while submitting all valid remaining feedbacks

## Can't submit when fields are missing

The server requires certain fields. If they aren't available in the feedback (let's say due to a server update / required sdk update) the saved feedbacks are retried forever. On certain API errors, the queued feedbacks are silently dismissed. 