### PR TITLE
Specify the supported platforms

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,19 @@ flutter:
     - packages/wiredash/assets/images/logo_white.png
     - packages/wiredash/assets/images/pen.png
 
+  plugin:
+    platforms:
+      android:
+        default_package: wiredash
+      ios:
+        default_package: wiredash
+      linux:
+        default_package: wiredash
+      macos:
+        default_package: wiredash
+      web:
+        default_package: wiredash
+
   fonts:
     - family: LexendDeca
       fonts:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,19 +9,19 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  file: ">=5.2.1 <7.0.0"
   flutter:
     sdk: flutter
-  file: ">=5.2.1 <7.0.0"
   http: ">=0.12.0 <0.13.0"
   http_parser: ">=3.1.0 <4.0.0"
   path_provider: ">=1.6.14 <2.0.0"
   shared_preferences: '>=0.5.6 <2.0.0'
 
 dev_dependencies:
-  lint: ^1.0.0
   fake_async: any
   flutter_test:
     sdk: flutter
+  lint: ^1.0.0
   test: any
   transparent_image: any
   mockito: any


### PR DESCRIPTION
Aims to specify the platforms supported by `Wiredash`, both to give more information to users and improve the `pub.dev` rating.

Not 100% sure it works, since we don't have plugin classes, but it is the only syntax I found that might.
Worth trying in my opinion.