### PR TITLE
Use maxLengthEnforcement instead of maxLengthEnforced

### DIFF
--- a/lib/src/feedback/components/input_component.dart
+++ b/lib/src/feedback/components/input_component.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
 import 'package:wiredash/src/common/translation/wiredash_localizations.dart';
@@ -100,8 +101,7 @@ class _InputComponentState extends State<InputComponent> {
             errorMaxLines: 2,
           ),
           maxLength: _maxInputLength,
-          // ignore: deprecated_member_use
-          maxLengthEnforced: false,
+          maxLengthEnforcement: MaxLengthEnforcement.none,
           buildCounter: _getCounterText,
           textCapitalization: _getTextCapitalization(),
           keyboardAppearance: WiredashTheme.of(context)!.brightness,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/wiredashio/wiredash-sdk
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.24.0-8.0.pre.341"
+  flutter: ">=1.26.0-1.0.pre"
 
 dependencies:
   file: ">=6.0.0-0 <7.0.0"


### PR DESCRIPTION
Background https://flutter.dev/docs/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.

This change removes our only deprecation in the repository. But it requires a flutter version bump which would be an unnecessary breaking change. 

Landed in version: v1.26.0-1.0.pre In stable release: not yet


Let's keep this PR open until either 
- the deprecated property was removed or 
- we have to bump the flutter sdk for other reasons