### PR TITLE
Add EN (US) locale fallback for when window.locale is null.

### DIFF
--- a/lib/src/common/options/wiredash_options_data.dart
+++ b/lib/src/common/options/wiredash_options_data.dart
@@ -13,7 +13,7 @@ class WiredashOptionsData {
     this.screenshotStep = true,
     this.customTranslations,
   })  : textDirection = textDirection ?? TextDirection.ltr,
-        _currentLocale = locale ?? window.locale,
+        _currentLocale = locale ?? window.locale ?? const Locale('en', 'US'),
         assert(
           bugReportButton || praiseButton || featureRequestButton,
           'WiredashOptionsData Configuration Error: Show at least one button',
@@ -60,7 +60,7 @@ class WiredashOptionsData {
     if (WiredashLocalizations.isSupported(locale)) {
       _currentLocale = locale;
     } else {
-      _currentLocale = window.locale;
+      _currentLocale = window.locale ?? const Locale('en', 'US');
     }
   }
 }

--- a/lib/src/common/options/wiredash_options_data.dart
+++ b/lib/src/common/options/wiredash_options_data.dart
@@ -13,6 +13,7 @@ class WiredashOptionsData {
     this.screenshotStep = true,
     this.customTranslations,
   })  : textDirection = textDirection ?? TextDirection.ltr,
+        // ignore: dead_null_aware_expression
         _currentLocale = locale ?? window.locale ?? const Locale('en', 'US'),
         assert(
           bugReportButton || praiseButton || featureRequestButton,
@@ -60,6 +61,7 @@ class WiredashOptionsData {
     if (WiredashLocalizations.isSupported(locale)) {
       _currentLocale = locale;
     } else {
+      // ignore: dead_null_aware_expression
       _currentLocale = window.locale ?? const Locale('en', 'US');
     }
   }


### PR DESCRIPTION
Added an EN (US) locale fallback for when the window locale is null. Because the window.locales list is empty unset. 

This currently throws an error on flutter 2.0.0 when building for web.

This is a fix for #129 