### PR TITLE
Raise min flutter sdk to 1.26.0-17.5.pre

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,6 +7,25 @@ on:
     - cron: '0 3 * * *'
 
 jobs:
+  minVersion:
+    runs-on: ubuntu-latest
+    container:
+      image: cirrusci/flutter:1.26.0-17.5.pre
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          ref: stable
+      - name: Flutter version
+        run: flutter doctor -v
+      - name: Download dependencies
+        run: sudo --preserve-env=PATH env flutter packages get
+      - name: Analyze
+        run: sudo --preserve-env=PATH env dartanalyzer --fatal-infos --fatal-warnings lib
+      - name: Test
+        run: sudo --preserve-env=PATH env flutter test
+      - name: Build
+        run: cd example && sudo --preserve-env=PATH env flutter build web
+
   stable:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,6 +9,26 @@ on:
       - dev
 
 jobs:
+  pr-min:
+    runs-on: ubuntu-latest
+    container:
+      image: cirrusci/flutter:1.26.0-17.5.pre
+    if: github.base_ref == 'stable' || github.ref == 'refs/heads/stable'
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Flutter version
+        run: flutter doctor -v
+      - name: Download dependencies
+        run: sudo --preserve-env=PATH env flutter packages get
+      - name: Check formatting
+        run: sudo --preserve-env=PATH env dartfmt --dry-run --set-exit-if-changed lib
+      - name: Analyze
+        run: sudo --preserve-env=PATH env dartanalyzer --fatal-infos --fatal-warnings lib
+      - name: Test
+        run: sudo --preserve-env=PATH env flutter test
+      - name: Build
+        run: cd example && sudo --preserve-env=PATH env flutter build web
+
   pr-stable:
     runs-on: ubuntu-latest
     container:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/wiredashio/wiredash-sdk
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.26.0-1.0.pre"
+  flutter: ">=1.26.0-17.5.pre"
 
 dependencies:
   file: ">=6.0.0-0 <7.0.0"


### PR DESCRIPTION
The oldest version which is compatible with our `path_provider` dependency