### PR TITLE
Don't show a warning for Flutter 1.27 (dev) channel

### DIFF
--- a/lib/src/common/options/wiredash_options_data.dart
+++ b/lib/src/common/options/wiredash_options_data.dart
@@ -13,8 +13,7 @@ class WiredashOptionsData {
     this.screenshotStep = true,
     this.customTranslations,
   })  : textDirection = textDirection ?? TextDirection.ltr,
-        // ignore: dead_null_aware_expression
-        _currentLocale = locale ?? window.locale ?? const Locale('en', 'US'),
+        _currentLocale = locale ?? _defaultLocale,
         assert(
           bugReportButton || praiseButton || featureRequestButton,
           'WiredashOptionsData Configuration Error: Show at least one button',
@@ -61,8 +60,14 @@ class WiredashOptionsData {
     if (WiredashLocalizations.isSupported(locale)) {
       _currentLocale = locale;
     } else {
-      // ignore: dead_null_aware_expression
-      _currentLocale = window.locale ?? const Locale('en', 'US');
+      _currentLocale = _defaultLocale;
     }
   }
+}
+
+Locale get _defaultLocale {
+  // Flutter 1.26 (2.0.1) returns `Locale?`, 1.27 `Locale`
+  // ignore: unnecessary_nullable_for_final_variable_declarations
+  final Locale? locale = window.locale;
+  return locale ?? const Locale('en', 'US');
 }


### PR DESCRIPTION
Removes the warning during compilation

```
Warning: Operand of null-aware operation '??' has type 'Locale' which excludes null.
```

It's a warning, not an error. It doesn't prevent building apps. It also doesn't error the build command, therefore it can't be used on CI to catch similar errors in the future 😢 

Instead of going full nnbd on the `dev` branch only, I chose a solution that works on `stable`, too. 

Fixes #134  