### PR TITLE
macOS improvements

### DIFF
--- a/lib/src/common/theme/wiredash_theme_data.dart
+++ b/lib/src/common/theme/wiredash_theme_data.dart
@@ -12,6 +12,7 @@ class WiredashThemeData {
     Color? secondaryTextColor,
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
+    Color? appBackgroundColor,
     Color? errorColor,
     String? fontFamily,
     Size? windowSize,
@@ -28,6 +29,7 @@ class WiredashThemeData {
             primaryBackgroundColor ?? const Color(0xffffffff),
         secondaryBackgroundColor:
             secondaryBackgroundColor ?? const Color(0xfff5f6f8),
+        appBackgroundColor: appBackgroundColor ?? const Color(0xfff5f6f8),
         errorColor: errorColor ?? const Color(0xffff5c6a),
         fontFamily: fontFamily ?? _fontFamily,
         windowSize: windowSize ?? Size.zero,
@@ -44,6 +46,7 @@ class WiredashThemeData {
             primaryBackgroundColor ?? const Color(0xffffffff),
         secondaryBackgroundColor:
             secondaryBackgroundColor ?? const Color(0xfff5f6f8),
+        appBackgroundColor: appBackgroundColor ?? const Color(0xfff5f6f8),
         errorColor: errorColor ?? const Color(0xffff5c6a),
         fontFamily: fontFamily ?? _fontFamily,
         windowSize: windowSize ?? Size.zero,
@@ -95,6 +98,7 @@ class WiredashThemeData {
     required this.secondaryTextColor,
     required this.primaryBackgroundColor,
     required this.secondaryBackgroundColor,
+    required this.appBackgroundColor,
     required this.errorColor,
     required this.deviceClass,
     required this.fontFamily,
@@ -112,6 +116,8 @@ class WiredashThemeData {
   final Color primaryBackgroundColor;
   final Color secondaryBackgroundColor;
   final Color errorColor;
+
+  final Color appBackgroundColor;
 
   final DeviceClass deviceClass;
   final Size windowSize;
@@ -253,6 +259,7 @@ class WiredashThemeData {
           secondaryTextColor == other.secondaryTextColor &&
           primaryBackgroundColor == other.primaryBackgroundColor &&
           secondaryBackgroundColor == other.secondaryBackgroundColor &&
+          appBackgroundColor == other.appBackgroundColor &&
           errorColor == other.errorColor &&
           deviceClass == other.deviceClass &&
           windowSize == other.windowSize &&
@@ -267,6 +274,7 @@ class WiredashThemeData {
       secondaryTextColor.hashCode ^
       primaryBackgroundColor.hashCode ^
       secondaryBackgroundColor.hashCode ^
+      appBackgroundColor.hashCode ^
       errorColor.hashCode ^
       deviceClass.hashCode ^
       windowSize.hashCode ^
@@ -282,6 +290,7 @@ class WiredashThemeData {
         'secondaryTextColor: $secondaryTextColor, '
         'primaryBackgroundColor: $primaryBackgroundColor, '
         'secondaryBackgroundColor: $secondaryBackgroundColor, '
+        'appBackgroundColor: $appBackgroundColor, '
         'errorColor: $errorColor, '
         'deviceClass: $deviceClass, '
         'fontFamily: $fontFamily, '
@@ -297,6 +306,7 @@ class WiredashThemeData {
     Color? secondaryTextColor,
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
+    Color? appBackgroundColor,
     Color? errorColor,
     DeviceClass? deviceClass,
     String? fontFamily,
@@ -312,6 +322,7 @@ class WiredashThemeData {
           primaryBackgroundColor ?? this.primaryBackgroundColor,
       secondaryBackgroundColor:
           secondaryBackgroundColor ?? this.secondaryBackgroundColor,
+      appBackgroundColor: appBackgroundColor ?? this.appBackgroundColor,
       errorColor: errorColor ?? this.errorColor,
       deviceClass: deviceClass ?? this.deviceClass,
       fontFamily: fontFamily ?? this.fontFamily,

--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -36,11 +36,13 @@ class WiredashBackdrop extends StatefulWidget {
     Key? key,
     required this.child,
     required this.controller,
+    this.padding,
   }) : super(key: key);
 
   /// The wrapped app
   final Widget child;
   final BackdropController controller;
+  final EdgeInsets? padding;
 
   static BackdropController of(BuildContext context) {
     final state = context.findAncestorStateOfType<_WiredashBackdropState>();

--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -293,8 +293,12 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       0,
       context.theme.maxContentWidth,
       contentHeight - buttonBarHeight,
-    ).removePadding(wiredashPadding.copyWith(bottom: 0)).centerHorizontally(
-          maxWidth: screenSize.width,
+    )
+        .removePadding(
+          wiredashPadding.copyWith(bottom: 0),
+        )
+        .centerHorizontally(
+          maxWidth: screenSize.width - wiredashPadding.horizontal,
           minPadding: context.theme.horizontalPadding,
         );
 
@@ -303,10 +307,14 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       contentHeight,
       screenSize.width * centerScaleFactor,
       screenSize.height * centerScaleFactor,
-    ).centerHorizontally(
-      maxWidth: screenSize.width,
-      minPadding: context.theme.horizontalPadding,
-    );
+    )
+        .removePadding(
+          wiredashPadding.copyWith(bottom: 0, top: 0),
+        )
+        .centerHorizontally(
+          maxWidth: screenSize.width - wiredashPadding.horizontal,
+          minPadding: context.theme.horizontalPadding,
+        );
 
     _rectNavigationButtons = Rect.fromLTWH(
       _rectAppOutOfFocus.left,
@@ -427,7 +435,8 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
     _mediaQueryData = newMq;
     if (newMq.size != oldMq.size ||
         // keyboard detection
-        newMq.viewInsets != oldMq.viewInsets) {
+        newMq.viewInsets != oldMq.viewInsets ||
+        newMq.padding != oldMq.padding) {
       _calculateRects();
       _swapAnimation();
     }
@@ -444,6 +453,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
     }
     if (oldWidget.padding != widget.padding) {
       _calculateRects();
+      _swapAnimation();
     }
   }
 
@@ -559,6 +569,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       opacity: _backdropStatus == WiredashBackdropStatus.closing ? 0.0 : 1.0,
       child: FeedbackNavigation(
         defaultLocation: _rectNavigationButtons,
+        windowPadding: widget.padding,
       ),
     );
   }
@@ -772,11 +783,14 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
             heightDifference;
         // The scale the app should be scaled to, compared to fullscreen
         final appScale =
-            _transformAnimation.value!.width / _rectAppFillsScreen.width;
+            (_transformAnimation.value!.width) / _rectAppFillsScreen.width;
 
         // ignore: join_return_with_assignment
         app = Transform.translate(
-          offset: Offset(0, yTranslation),
+          offset: Offset(
+            ((widget.padding?.left ?? 0) - (widget.padding?.right ?? 0)) / 2,
+            yTranslation,
+          ),
           child: Transform.scale(
             scale: appScale,
             alignment: Alignment.bottomCenter,
@@ -824,7 +838,7 @@ extension on Rect {
       padding = minPadding;
     }
     return Rect.fromLTWH(
-      padding,
+      left + padding,
       top,
       maxWidth - padding * 2,
       height,

--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -567,6 +567,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   borderRadius: _cornerRadiusAnimation.value,
+                  color: context.theme.primaryBackgroundColor,
                   boxShadow: [
                     BoxShadow(
                       color: const Color(0xFF000000).withOpacity(0.04),

--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -577,7 +577,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   borderRadius: _cornerRadiusAnimation.value,
-                  color: context.theme.primaryBackgroundColor,
+                  color: context.theme.appBackgroundColor,
                   boxShadow: [
                     BoxShadow(
                       color: const Color(0xFF000000).withOpacity(0.04),

--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -484,9 +484,18 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       rect: _rectContentArea,
       child: MediaQuery(
         data: _mediaQueryData.removePadding(removeBottom: true),
-        child: const Focus(
+        child: Focus(
           debugLabel: 'wiredash backdrop content',
-          child: WiredashFeedbackFlow(),
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 300),
+            opacity: widget.controller.backdropStatus ==
+                        WiredashBackdropStatus.centered ||
+                    widget.controller.backdropStatus ==
+                        WiredashBackdropStatus.openingCentered
+                ? 0.0
+                : 1.0,
+            child: const WiredashFeedbackFlow(),
+          ),
         ),
       ),
     );

--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -442,6 +442,9 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       widget.controller._state = this;
       widget.controller.addListener(_markAsDirty);
     }
+    if (oldWidget.padding != widget.padding) {
+      _calculateRects();
+    }
   }
 
   void _markAsDirty() {

--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -221,6 +221,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
 
   /// (re-)calculates the rects for the different states
   void _calculateRects() {
+    final wiredashPadding = widget.padding ?? EdgeInsets.zero;
     final Size screenSize = _mediaQueryData.size;
 
     // scale to show app in safeArea
@@ -229,12 +230,19 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       final minContentWidthPadding = context.theme.horizontalPadding * 2;
       final maxContentWidth = screenSize.width -
           math.max(
-            _mediaQueryData.viewPadding.horizontal,
-            minContentWidthPadding,
+            wiredashPadding.horizontal,
+            math.max(
+              _mediaQueryData.viewPadding.horizontal,
+              minContentWidthPadding,
+            ),
           );
 
-      final maxContentHeight =
-          screenSize.height - math.max(0, _mediaQueryData.viewPadding.vertical);
+      final maxContentHeight = screenSize.height -
+          math.max(
+            0,
+            // wiredashPadding.vertical,
+            _mediaQueryData.viewPadding.vertical,
+          );
 
       return math.min(
         maxContentWidth / screenSize.width,
@@ -243,8 +251,9 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
     }();
 
     _rectAppCentered = Rect.fromCenter(
-      center:
-          screenSize.center(Offset.zero) + _mediaQueryData.viewInsets.topLeft,
+      center: screenSize.center(Offset.zero) +
+          _mediaQueryData.viewInsets.topLeft / 2 +
+          wiredashPadding.topLeft / 2,
       width: screenSize.width * centerScaleFactor,
       height: screenSize.height * centerScaleFactor,
     );
@@ -262,6 +271,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
     if (!isKeyboardOpen) {
       preferredAppHeight -= minAppPeakHeight;
       preferredAppHeight -= buttonBarHeight / 2;
+      preferredAppHeight -= wiredashPadding.top / 2;
     }
     final preferredContentHeight =
         _mediaQueryData.size.height - preferredAppHeight;
@@ -278,13 +288,13 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
 
     _rectContentArea = Rect.fromLTWH(
       0,
-      0, // TODO top padding?
+      0,
       context.theme.maxContentWidth,
       contentHeight - buttonBarHeight,
-    ).centerHorizontally(
-      maxWidth: screenSize.width,
-      minPadding: context.theme.horizontalPadding,
-    );
+    ).removePadding(wiredashPadding.copyWith(bottom: 0)).centerHorizontally(
+          maxWidth: screenSize.width,
+          minPadding: context.theme.horizontalPadding,
+        );
 
     _rectAppOutOfFocus = Rect.fromLTWH(
       0,
@@ -799,6 +809,10 @@ class _KeepAppAliveState extends State<_KeepAppAlive>
 }
 
 extension on Rect {
+  Rect removePadding(EdgeInsets padding) {
+    return padding.deflateRect(this);
+  }
+
   Rect centerHorizontally({required double maxWidth, double minPadding = 0.0}) {
     double padding = (maxWidth - width) / 2;
     if (padding < minPadding) {

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -42,7 +42,8 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
       return;
     }
     if (oldIndex != newIndex) {
-      final state = _lpvKey.currentState!;
+      final state = _lpvKey.currentState;
+      if (state == null) return;
       // jump to next page after the widget has been rebuild and LarryPageView
       // knows about the new itemCount
       WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {

--- a/lib/src/feedback/ui/feedback_navigation.dart
+++ b/lib/src/feedback/ui/feedback_navigation.dart
@@ -12,9 +12,11 @@ class FeedbackNavigation extends StatefulWidget {
   const FeedbackNavigation({
     Key? key,
     required this.defaultLocation,
+    this.windowPadding,
   }) : super(key: key);
 
   final Rect defaultLocation;
+  final EdgeInsets? windowPadding;
 
   @override
   State<FeedbackNavigation> createState() => _FeedbackNavigationState();
@@ -55,7 +57,8 @@ class _FeedbackNavigationState extends State<FeedbackNavigation>
     const double buttonTransitionWidth = 30;
     _prevButtonAnimation = Tween(
       begin: Offset(widget.defaultLocation.left, 0),
-      end: const Offset(-buttonTransitionWidth, 0),
+      end:
+          Offset(-buttonTransitionWidth + (widget.windowPadding?.left ?? 0), 0),
     ).animate(
       CurvedAnimation(
         parent: _controller,

--- a/lib/src/feedback/ui/larry_page_view.dart
+++ b/lib/src/feedback/ui/larry_page_view.dart
@@ -92,6 +92,19 @@ class LarryPageViewState extends State<LarryPageView>
   }
 
   @override
+  void didUpdateWidget(covariant LarryPageView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.pageIndex < oldWidget.pageIndex &&
+        widget.stepCount < oldWidget.stepCount) {
+      _nextPageTimer?.cancel();
+      _animatingPageOut = false;
+      _offset = 0;
+      _controller.reset();
+      _controller.value = 0;
+    }
+  }
+
+  @override
   void dispose() {
     _controller.dispose();
     _childScrollController.dispose();

--- a/lib/src/not_a_widgets_app.dart
+++ b/lib/src/not_a_widgets_app.dart
@@ -74,6 +74,7 @@ class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
 
     // Make Wiredash a Material widget to support TextFields, etc.
     child = Material(
+      color: Colors.transparent,
       child: child,
     );
 

--- a/lib/src/wiredash_widget.dart
+++ b/lib/src/wiredash_widget.dart
@@ -64,6 +64,7 @@ class Wiredash extends StatefulWidget {
     this.options,
     this.theme,
     this.feedbackOptions,
+    this.padding,
     required this.child,
   }) : super(key: key);
 
@@ -96,6 +97,12 @@ class Wiredash extends StatefulWidget {
   /// );
   /// ```
   final WiredashThemeData? theme;
+
+  /// The padding inside wiredash, parts of the screen it should not draw into
+  ///
+  /// This is useful for macOS applications that draw the window titlebar
+  /// themselves.
+  final EdgeInsets? padding;
 
   /// Your application
   final Widget child;
@@ -235,6 +242,7 @@ class WiredashState extends State<Wiredash> {
               WiredashBackdrop(
                 key: _backdropKey,
                 controller: _services.backdropController,
+                padding: widget.padding,
                 child: appBuilder,
               ),
             ],


### PR DESCRIPTION
<img width="932" alt="Screen-Shot-2022-01-02-01-31-11 82" src="https://user-images.githubusercontent.com/1096485/147863065-b74dc65f-7f0c-47ad-8780-b676d92fdbfd.png">

- Support for transparent windows with custom theme
```dart 
return Wiredash(
  //...
  theme: WiredashThemeData(
    primaryBackgroundColor: Colors.transparent,
    secondaryBackgroundColor: Colors.transparent,
    appBackgroundColor: MacosThemeData.dark().canvasColor,
    brightness: Brightness.dark,
  ),
)
```
- New `WiredashThemeData.appBackgroundColor` that can be used as background for the app. You'll only see it for transparent apps
- New `Wiredash.padding` property that can be used by apps that draw the window titleBar themselves. Wiredash will not draw content in the padding area.
```dart
return Wiredash(
  //...
  padding: EdgeInsets.only(top: 44),
)
```
- Hide backdrop content when in screenshot mode
