### PR TITLE
Validate email

### DIFF
--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/common/build_info/build_info_manager.dart';
 import 'package:wiredash/src/common/renderer/renderer.dart';
 import 'package:wiredash/src/common/services/services.dart';
@@ -31,6 +32,8 @@ class FeedbackModel with ChangeNotifier {
   FeedbackFlowStatus get feedbackFlowStatus => _feedbackFlowStatus;
 
   final BuildInfoManager buildInfoManager = BuildInfoManager();
+
+  final GlobalKey<FormState> stepFormKey = GlobalKey<FormState>();
 
   String? get feedbackMessage => _feedbackMessage;
   String? _feedbackMessage;
@@ -74,7 +77,10 @@ class FeedbackModel with ChangeNotifier {
 
   List<FeedbackFlowStatus> get steps {
     if (submitted) {
-      return [FeedbackFlowStatus.submitting];
+      // Return just a single step, no back/forward possible
+      return [
+        FeedbackFlowStatus.submitting,
+      ];
     }
 
     final stack = [FeedbackFlowStatus.message];
@@ -125,6 +131,9 @@ class FeedbackModel with ChangeNotifier {
   }
 
   Future<void> goToNextStep() async {
+    if (!validateForm()) {
+      throw FormValidationException();
+    }
     final index = currentStepIndex;
     if (index == null) {
       throw StateError('Unknown step index');
@@ -330,4 +339,15 @@ class FeedbackModel with ChangeNotifier {
       // ignore when it is already disposed due to recreation
     }
   }
+
+  /// Returns `true` when there are no errors
+  bool validateForm() {
+    final state = stepFormKey.currentState;
+    if (state == null) {
+      return true;
+    }
+    return state.validate();
+  }
 }
+
+class FormValidationException implements Exception {}

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -21,12 +21,9 @@ class WiredashFeedbackFlow extends StatefulWidget {
 
 class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
     with TickerProviderStateMixin {
-  final GlobalKey<LarryPageViewState> stepFormKey =
-      GlobalKey<LarryPageViewState>();
+  final GlobalKey<LarryPageViewState> _lpvKey = GlobalKey();
 
   int _index = 0;
-
-  final GlobalKey<LarryPageViewState> _lpvKey = GlobalKey();
 
   @override
   void didChangeDependencies() {
@@ -125,7 +122,10 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
       },
       child: Stack(
         children: [
-          larryPageView,
+          Form(
+            key: feedbackModel.stepFormKey,
+            child: larryPageView,
+          ),
           _buildProgressIndicator(),
         ],
       ),

--- a/lib/src/feedback/ui/feedback_navigation.dart
+++ b/lib/src/feedback/ui/feedback_navigation.dart
@@ -264,7 +264,7 @@ class _FeedbackNavigationState extends State<FeedbackNavigation>
           label: 'Next',
           onTap: () {
             if (context.feedbackModel.hasScreenshots) {
-              context.feedbackModel.goToStep(FeedbackFlowStatus.email);
+              context.feedbackModel.goToNextStep();
             } else {
               context.feedbackModel
                   .goToStep(FeedbackFlowStatus.screenshotNavigating);
@@ -277,7 +277,9 @@ class _FeedbackNavigationState extends State<FeedbackNavigation>
           icon: Wirecons.check,
           label: 'Next',
           onTap: () {
-            context.feedbackModel.submitFeedback();
+            if (context.feedbackModel.validateForm()) {
+              context.feedbackModel.submitFeedback();
+            }
           },
         );
       case FeedbackFlowStatus.submitting:

--- a/lib/src/feedback/ui/steps/step_5_email.dart
+++ b/lib/src/feedback/ui/steps/step_5_email.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
-import 'package:wiredash/src/feedback/feedback_model.dart';
+import 'package:wiredash/src/common/utils/email_validator.dart';
 import 'package:wiredash/src/feedback/feedback_model_provider.dart';
 import 'package:wiredash/src/feedback/ui/feedback_flow.dart';
+import 'package:wiredash/wiredash.dart';
 
 class Step5Email extends StatefulWidget {
   const Step5Email({Key? key}) : super(key: key);
@@ -55,14 +56,27 @@ class _Step5EmailState extends State<Step5Email> with TickerProviderStateMixin {
                     'Enter your email to get updates regarding your issue',
                     style: context.theme.titleTextStyle,
                   ),
-                  TextField(
+                  TextFormField(
                     controller: _controller,
                     keyboardType: TextInputType.emailAddress,
                     cursorColor: context.theme.primaryColor,
                     style: context.theme.bodyTextStyle,
-                    onSubmitted: (_) {
-                      context.feedbackModel
-                          .goToStep(FeedbackFlowStatus.submitting);
+                    onFieldSubmitted: (_) {
+                      if (context.feedbackModel.validateForm()) {
+                        context.feedbackModel.submitFeedback();
+                      }
+                    },
+                    validator: (data) {
+                      final email = data ?? '';
+                      if (email.isEmpty) {
+                        // leaving this field empty is ok
+                        return null;
+                      }
+                      final valid = const EmailValidator().validate(email);
+                      return valid
+                          ? null
+                          : WiredashLocalizations.of(context)!
+                              .validationHintEmail;
                     },
                     decoration: InputDecoration(
                       border: InputBorder.none,

--- a/test/email_validation_test.dart
+++ b/test/email_validation_test.dart
@@ -1,0 +1,70 @@
+// ignore_for_file: avoid_print
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wiredash/src/common/options/feedback_options.dart';
+import 'package:wiredash/src/feedback/data/label.dart';
+
+import 'util/robot.dart';
+import 'util/wiredash_tester.dart';
+
+void main() {
+  group('Email validation errors', () {
+    testWidgets('Submit works with valid email', (tester) async {
+      final WiredashTestRobot robot = await goToEmailStep(tester);
+      await robot.enterEmail('dash@flutter.io');
+      await robot.submitEmailViaButton();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+    });
+    testWidgets('Submit works without email', (tester) async {
+      final WiredashTestRobot robot = await goToEmailStep(tester);
+      await robot.enterEmail('');
+      await robot.submitEmailViaButton();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+    });
+    testWidgets('Submit via button - Shows error for invalid email',
+        (tester) async {
+      final WiredashTestRobot robot = await goToEmailStep(tester);
+      await robot.enterEmail('invalid');
+      await robot.submitEmailViaButton();
+      await tester.waitUntil(
+        find.text('Please enter a valid email or leave this field blank.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Submit via enter - Shows error for invalid email',
+        (tester) async {
+      final WiredashTestRobot robot = await goToEmailStep(tester);
+      await robot.enterEmail('invalid');
+      await robot.submitEmailViaKeyboard();
+      await tester.waitUntil(
+        find.text('Please enter a valid email or leave this field blank.'),
+        findsOneWidget,
+      );
+    });
+  });
+}
+
+Future<WiredashTestRobot> goToEmailStep(WidgetTester tester) async {
+  final robot = await WiredashTestRobot.launchApp(
+    tester,
+    feedbackOptions: const WiredashFeedbackOptions(
+      labels: [
+        Label(id: 'label-bug', title: 'Bug'),
+      ],
+    ),
+  );
+
+  await robot.openWiredash();
+  await robot.enterFeedbackMessage('test message');
+  await robot.goToNextStep();
+  await robot.skipLabels();
+  await robot.skipScreenshot();
+  return robot;
+}

--- a/test/util/mock_api.dart
+++ b/test/util/mock_api.dart
@@ -1,0 +1,25 @@
+import 'dart:typed_data';
+
+import 'package:wiredash/src/common/network/wiredash_api.dart';
+import 'package:wiredash/src/feedback/data/persisted_feedback_item.dart';
+
+import 'invocation_catcher.dart';
+
+class MockWiredashApi implements WiredashApi {
+  List<PersistedFeedbackItem> submissions = [];
+  MethodInvocationCatcher sendFeedbackInvocations =
+      MethodInvocationCatcher('sendFeedback');
+  @override
+  Future<void> sendFeedback(
+    PersistedFeedbackItem feedback, {
+    List<ImageBlob> images = const [],
+  }) async {
+    return sendFeedbackInvocations
+        .addMethodCall(namedArgs: {'images': images}, args: [feedback]);
+  }
+
+  @override
+  Future<ImageBlob> sendImage(Uint8List screenshot) async {
+    return ImageBlob({});
+  }
+}

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -1,0 +1,221 @@
+// ignore_for_file: avoid_print
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/common/network/wiredash_api.dart';
+import 'package:wiredash/src/common/options/feedback_options.dart';
+import 'package:wiredash/src/common/services/services.dart';
+import 'package:wiredash/src/common/widgets/tron_button.dart';
+import 'package:wiredash/src/common/widgets/wirecons.dart';
+import 'package:wiredash/src/feedback/data/direct_feedback_submitter.dart';
+import 'package:wiredash/src/feedback/data/feedback_submitter.dart';
+import 'package:wiredash/src/feedback/feedback_model.dart';
+import 'package:wiredash/src/feedback/ui/feedback_flow.dart';
+import 'package:wiredash/src/feedback/ui/feedback_navigation.dart';
+import 'package:wiredash/src/feedback/ui/steps/step_1_feedback_message.dart';
+import 'package:wiredash/src/feedback/ui/steps/step_2_labels.dart';
+import 'package:wiredash/src/feedback/ui/steps/step_3_screenshot_overview.dart';
+import 'package:wiredash/src/feedback/ui/steps/step_5_email.dart';
+import 'package:wiredash/src/wiredash_widget.dart';
+
+import 'mock_api.dart';
+import 'wiredash_tester.dart';
+
+class WiredashTestRobot {
+  final WidgetTester tester;
+
+  WiredashTestRobot(this.tester);
+
+  static Future<WiredashTestRobot> launchApp(
+    WidgetTester tester, {
+    WiredashFeedbackOptions? feedbackOptions,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    TestWidgetsFlutterBinding.ensureInitialized();
+    const MethodChannel channel =
+        MethodChannel('plugins.flutter.io/path_provider_macos');
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      return '.';
+    });
+    await tester.pumpWidget(
+      Wiredash(
+        projectId: 'test',
+        secret: 'test',
+        feedbackOptions: feedbackOptions,
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                floatingActionButton: FloatingActionButton(
+                  onPressed: Wiredash.of(context).show,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    final robot = WiredashTestRobot(tester);
+
+    // Don't do actual http calls
+    robot.services.inject<WiredashApi>((_) => MockWiredashApi());
+
+    // replace submitter, because for testing we always want to submit directly
+    robot.services.inject<FeedbackSubmitter>(
+      (locator) => DirectFeedbackSubmitter(locator.api),
+    );
+
+    return robot;
+  }
+
+  final _navigationButtonFinder = find.descendant(
+    of: find.byType(FeedbackNavigation),
+    matching: find.byType(TronButton),
+  );
+
+  Wiredash get widget {
+    final element = find.byType(Wiredash).evaluate().first as StatefulElement;
+    return element.widget as Wiredash;
+  }
+
+  WiredashServices get services {
+    final element = find.byType(Wiredash).evaluate().first as StatefulElement;
+    return (element.state as WiredashState).debugServices;
+  }
+
+  void mockWiredashApi(WiredashApi api) {
+    services.inject<WiredashApi>((_) => api);
+  }
+
+  Future<void> openWiredash() async {
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(find.byType(WiredashFeedbackFlow), findsOneWidget);
+    print('opened Wiredash');
+  }
+
+  Future<void> enterFeedbackMessage(String message) async {
+    expect(find.byType(Step1FeedbackMessage), findsOneWidget);
+    await tester.enterText(find.byType(TextField), message);
+    await tester.pumpAndSettle();
+    await tester.waitUntil(
+      find.byIcon(Wirecons.arrow_narrow_right),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Wirecons.arrow_narrow_right), findsOneWidget);
+    expect(find.byIcon(Wirecons.chevron_double_up), findsOneWidget);
+    print('entered feedback message: $message');
+  }
+
+  Future<void> enterEmail(String emailAddress) async {
+    expect(find.byType(Step5Email), findsOneWidget);
+    await tester.enterText(find.byType(TextField), emailAddress);
+    await tester.pumpAndSettle();
+    print('entered email: $emailAddress');
+  }
+
+  Future<void> skipScreenshot() async {
+    expect(find.byType(Step3ScreenshotOverview), findsOneWidget);
+    await tester.tap(find.byIcon(Wirecons.chevron_double_right));
+    await tester.pumpAndSettle();
+    final newStatus = services.feedbackModel.feedbackFlowStatus;
+    print('Skipped taking screenshot, next $newStatus');
+  }
+
+  Future<void> skipLabels() async {
+    expect(find.byType(Step2Labels), findsOneWidget);
+    await goToNextStep();
+    print('Skipped label selection');
+  }
+
+  Future<void> submitFeedback() async {
+    expect(find.byType(Step5Email), findsOneWidget);
+    await tester.tap(find.byIcon(Wirecons.check));
+    print('submit feedback');
+    await tester.pump();
+  }
+
+  Future<void> skipEmail() async {
+    expect(find.byType(Step5Email), findsOneWidget);
+    await tester.tap(find.byIcon(Wirecons.check));
+    print('Skipped email');
+    await tester.pump();
+  }
+
+  Future<void> submitEmailViaButton() async {
+    await tester.tap(find.byIcon(Wirecons.check));
+    await tester.pump();
+  }
+
+  Future<void> submitEmailViaKeyboard() async {
+    await tester.testTextInput.receiveAction(TextInputAction.send);
+    await tester.pump();
+  }
+
+  Future<void> goToNextStep() async {
+    final oldStatus = services.feedbackModel.feedbackFlowStatus;
+    await tester.tap(_navigationButtonFinder.last);
+    await tester.pumpAndSettle();
+    final newStatus = services.feedbackModel.feedbackFlowStatus;
+    print('Jumped from $oldStatus to next $newStatus');
+  }
+
+  Future<void> goToPrevStep() async {
+    final oldStatus = services.feedbackModel.feedbackFlowStatus;
+    await tester.tap(_navigationButtonFinder.first);
+    await tester.pumpAndSettle();
+    final newStatus = services.feedbackModel.feedbackFlowStatus;
+    print('Jumped from $oldStatus to prev $newStatus');
+  }
+
+  Future<void> enterScreenshotMode() async {
+    expect(find.byType(Step3ScreenshotOverview), findsOneWidget);
+    await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
+    await tester.waitUntil(find.byIcon(Wirecons.camera), findsOneWidget);
+    print('Entered screenshot mode');
+  }
+
+  Future<void> takeScreenshot() async {
+    expect(find.byType(Step3ScreenshotOverview), findsOneWidget);
+    expect(
+      services.feedbackModel.feedbackFlowStatus,
+      FeedbackFlowStatus.screenshotNavigating,
+    );
+
+    print('Take screeshot');
+    // Click the screenshot button
+    await tester.tap(find.byIcon(Wirecons.camera));
+    await tester.pumpAndSettle();
+
+    // Wait for edit screen
+    await tester.waitUntil(find.byIcon(Wirecons.check), findsOneWidget);
+
+    // Navigation buttons should show the pencil button and a check button
+    expect(find.byIcon(Wirecons.pencil), findsOneWidget);
+    expect(find.byIcon(Wirecons.check), findsOneWidget);
+  }
+
+  Future<void> confirmDrawing() async {
+    expect(
+      services.feedbackModel.feedbackFlowStatus,
+      FeedbackFlowStatus.screenshotDrawing,
+    );
+    await tester.tap(find.byIcon(Wirecons.check));
+    await tester.pumpAndSettle();
+
+    // wait until the animation is closed
+    await tester.waitUntil(
+      find.byIcon(Wirecons.arrow_narrow_right),
+      findsOneWidget,
+    );
+    final newStatus = services.feedbackModel.feedbackFlowStatus;
+    print('Confirmed drawing $newStatus');
+  }
+
+  Future<void> selectLabel(String labelText) async {
+    await tester.tap(find.text('Two'));
+    await tester.pumpAndSettle();
+  }
+}

--- a/test/util/wiredash_tester.dart
+++ b/test/util/wiredash_tester.dart
@@ -1,0 +1,67 @@
+// ignore_for_file: avoid_print
+
+library wiredashtester;
+
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+extension WiredashTester on WidgetTester {
+  /// Pumps and also drains the event queue, then pumps again and settles
+  Future<void> pumpHardAndSettle([
+    Duration duration = const Duration(milliseconds: 1),
+  ]) async {
+    await pumpAndSettle();
+    // pump event queue, trigger timers
+    await runAsync(() => Future.delayed(duration));
+  }
+
+  Future<void> waitUntil(
+    Finder finder,
+    Matcher matcher, {
+    Duration timeout = const Duration(seconds: 3),
+  }) async {
+    // print('waitUntil $finder matches within $timeout');
+    final stack = StackTrace.current;
+    final start = DateTime.now();
+    // await pumpAndSettle();
+    var attempt = 0;
+    while (true) {
+      attempt++;
+      if (matcher.matches(finder, {})) {
+        break;
+      }
+      if (finder.runtimeType.toString().contains('_TextFinder')) {
+        print('Text on screen (${DateTime.now().difference(start)}):');
+        print(allWidgets.whereType<Text>().map((e) => e.data).toList());
+      }
+
+      final now = DateTime.now();
+      if (now.isAfter(start.add(timeout))) {
+        print(stack);
+        if (finder.runtimeType.toString().contains('_TextFinder')) {
+          print('Text on screen:');
+          print(allWidgets.whereType<Text>().map((e) => e.data).toList());
+        }
+        throw 'Did not find $finder after $timeout (attempt: $attempt)';
+      }
+
+      final duration =
+          Duration(milliseconds: math.pow(attempt, math.e).toInt());
+      if (duration > const Duration(seconds: 1)) {
+        // show continuous updates
+        print(
+          'Waiting for (attempt: $attempt)\n'
+          '\tFinder: $finder to match\n'
+          '\tMatcher: $matcher',
+        );
+      }
+      if (attempt < 10) {
+        await pumpAndSettle(duration);
+      } else {
+        await pumpHardAndSettle(duration);
+      }
+    }
+  }
+}

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -1,23 +1,17 @@
 // ignore_for_file: avoid_print
 
-import 'dart:math' as math;
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:wiredash/src/common/network/wiredash_api.dart';
 import 'package:wiredash/src/common/utils/project_credential_validator.dart';
-import 'package:wiredash/src/common/widgets/wirecons.dart';
-import 'package:wiredash/src/feedback/data/direct_feedback_submitter.dart';
-import 'package:wiredash/src/feedback/data/feedback_submitter.dart';
 import 'package:wiredash/src/feedback/data/persisted_feedback_item.dart';
-import 'package:wiredash/src/feedback/ui/feedback_flow.dart';
 import 'package:wiredash/src/wiredash_widget.dart';
 import 'package:wiredash/wiredash.dart';
 
 import 'util/invocation_catcher.dart';
+import 'util/mock_api.dart';
+import 'util/robot.dart';
+import 'util/wiredash_tester.dart';
 
 void main() {
   group('Wiredash', () {
@@ -62,92 +56,38 @@ void main() {
       },
     );
 
+    testWidgets('Send text only feedback', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(tester);
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.skipScreenshot();
+      await robot.skipEmail();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback!.message, 'test message');
+    });
+
     testWidgets('Send feedback with screenshot', (tester) async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-      const MethodChannel channel =
-          MethodChannel('plugins.flutter.io/path_provider_macos');
-      channel.setMockMethodCallHandler((MethodCall methodCall) async {
-        return '.';
-      });
-      await tester.pumpWidget(
-        Wiredash(
-          projectId: 'test',
-          secret: 'test',
-          child: MaterialApp(
-            home: Builder(
-              builder: (context) {
-                return Scaffold(
-                  floatingActionButton: FloatingActionButton(
-                    onPressed: Wiredash.of(context).show,
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
-      );
-      final wiredashWidget =
-          find.byType(Wiredash).evaluate().first as StatefulElement;
-      final services = (wiredashWidget.state as WiredashState).debugServices;
-      final mockApi = _MockApi();
-      services.inject<WiredashApi>((_) => mockApi);
-      services.inject<FeedbackSubmitter>(
-        (locator) => DirectFeedbackSubmitter(locator.api),
-      );
+      final robot = await WiredashTestRobot.launchApp(tester);
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
 
-      expect(find.byType(WiredashFeedbackFlow), findsNothing);
-
-      // Open Wiredash
-      await tester.tap(find.byType(FloatingActionButton));
-      await tester.pumpAndSettle();
-      expect(find.byType(WiredashFeedbackFlow), findsOneWidget);
-
-      await tester.enterText(find.byType(TextField), 'feedback_text');
-      await tester.pumpAndSettle();
-      await tester.waitUntil(
-        find.byIcon(Wirecons.arrow_narrow_right),
-        findsOneWidget,
-      );
-      expect(find.byIcon(Wirecons.arrow_narrow_right), findsOneWidget);
-      expect(find.byIcon(Wirecons.chevron_double_up), findsOneWidget);
-      // next to screenshot overview
-      await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
-      await tester.pumpHardAndSettle();
-
-      // Go to screenshot section
-      await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
-      await tester.waitUntil(find.byIcon(Wirecons.camera), findsOneWidget);
-      // TODO check app is interactive
-
-      // Click the screenshot button
-      await tester.tap(find.byIcon(Wirecons.camera));
-      await tester.pumpAndSettle();
-
-      // Wait for edit screen
-      await tester.waitUntil(find.byIcon(Wirecons.check), findsOneWidget);
-
-      // Check for save screenshot button
-      expect(find.byIcon(Wirecons.check), findsOneWidget);
-      expect(find.byIcon(Wirecons.pencil), findsOneWidget);
-
-      await tester.tap(find.byIcon(Wirecons.check));
-      await tester.pumpAndSettle();
-
-      await tester.waitUntil(
-        find.byIcon(Wirecons.arrow_narrow_right),
-        findsOneWidget,
-      );
-
-      // TODO check that we see the screenshot
-      await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
-      await tester.pumpAndSettle();
-
-      await tester.enterText(find.byType(TextField), 'dash@wiredash.io');
-      await tester.pumpAndSettle();
-
-      // Submit
-      await tester.tap(find.byIcon(Wirecons.check));
-      await tester.pump();
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.enterScreenshotMode();
+      await robot.takeScreenshot();
+      await robot.confirmDrawing();
+      await robot.goToNextStep();
+      await robot.skipEmail();
       await tester.waitUntil(
         find.text('Thanks for your feedback!'),
         findsOneWidget,
@@ -155,111 +95,35 @@ void main() {
       final latestCall = mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback, isNotNull);
+      expect(submittedFeedback!.message, 'test message');
       expect(latestCall['images'], hasLength(1));
     });
 
-    testWidgets('Send feedback with labels and screenshot', (tester) async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-      const MethodChannel channel =
-          MethodChannel('plugins.flutter.io/path_provider_macos');
-      channel.setMockMethodCallHandler((MethodCall methodCall) async {
-        return '.';
-      });
-      await tester.pumpWidget(
-        Wiredash(
-          projectId: 'test',
-          secret: 'test',
-          feedbackOptions: const WiredashFeedbackOptions(
-            labels: [
-              Label(id: 'lbl-1', title: 'One', description: 'First'),
-              Label(id: 'lbl-2', title: 'Two', description: 'Second'),
-            ],
-          ),
-          child: MaterialApp(
-            home: Builder(
-              builder: (context) {
-                return Scaffold(
-                  floatingActionButton: FloatingActionButton(
-                    onPressed: Wiredash.of(context).show,
-                  ),
-                );
-              },
-            ),
-          ),
+    testWidgets('Send feedback with labels', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(
+        tester,
+        feedbackOptions: const WiredashFeedbackOptions(
+          labels: [
+            Label(id: 'lbl-1', title: 'One', description: 'First'),
+            Label(id: 'lbl-2', title: 'Two', description: 'Second'),
+          ],
         ),
       );
-      final wiredashWidget =
-          find.byType(Wiredash).evaluate().first as StatefulElement;
-      final services = (wiredashWidget.state as WiredashState).debugServices;
-      final mockApi = _MockApi();
-      services.inject<WiredashApi>((_) => mockApi);
-      services.inject<FeedbackSubmitter>(
-        (locator) => DirectFeedbackSubmitter(locator.api),
-      );
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
 
-      expect(find.byType(WiredashFeedbackFlow), findsNothing);
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('feedback with labels');
+      await robot.goToNextStep();
 
-      // Open Wiredash
-      await tester.tap(find.byType(FloatingActionButton));
-      await tester.pumpAndSettle();
-      expect(find.byType(WiredashFeedbackFlow), findsOneWidget);
-
-      await tester.enterText(find.byType(TextField), 'feedback_text');
-      await tester.pumpAndSettle();
-      await tester.waitUntil(
-        find.byIcon(Wirecons.arrow_narrow_right),
-        findsOneWidget,
-      );
-      expect(find.byIcon(Wirecons.arrow_narrow_right), findsOneWidget);
-      expect(find.byIcon(Wirecons.chevron_double_up), findsOneWidget);
-
-      await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
-      await tester.pumpHardAndSettle();
-      // Check labels exist
+      // labels
       expect(find.text('One'), findsOneWidget);
       expect(find.text('Two'), findsOneWidget);
+      await robot.selectLabel('Two');
+      await robot.goToNextStep();
 
-      await tester.tap(find.text('Two'));
-      await tester.pumpAndSettle();
-
-      // screenshot overview
-      await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
-      await tester.pumpHardAndSettle();
-
-      // Go to screenshot section
-      await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
-      await tester.waitUntil(find.byIcon(Wirecons.camera), findsOneWidget);
-      // TODO check app is interactive
-
-      // Click the screenshot button
-      await tester.tap(find.byIcon(Wirecons.camera));
-      await tester.pumpAndSettle();
-
-      // Wait for edit screen
-      await tester.waitUntil(find.byIcon(Wirecons.check), findsOneWidget);
-
-      // Check for save screenshot button
-      expect(find.byIcon(Wirecons.check), findsOneWidget);
-      expect(find.byIcon(Wirecons.pencil), findsOneWidget);
-
-      await tester.tap(find.byIcon(Wirecons.check));
-      await tester.pumpAndSettle();
-
-      await tester.waitUntil(
-        find.byIcon(Wirecons.arrow_narrow_right),
-        findsOneWidget,
-      );
-
-      // TODO check that we see the screenshot
-      await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
-      await tester.pumpAndSettle();
-
-      await tester.enterText(find.byType(TextField), 'dash@wiredash.io');
-      await tester.pumpAndSettle();
-
-      // Submit
-      await tester.tap(find.byIcon(Wirecons.check));
-      await tester.pump();
+      await robot.skipScreenshot();
+      await robot.skipEmail();
       await tester.waitUntil(
         find.text('Thanks for your feedback!'),
         findsOneWidget,
@@ -268,70 +132,70 @@ void main() {
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback, isNotNull);
       expect(submittedFeedback!.labels, ['lbl-2']);
-      expect(submittedFeedback.message, 'feedback_text');
-      expect(submittedFeedback.email, 'dash@wiredash.io');
-      expect(latestCall['images'], hasLength(1));
+      expect(submittedFeedback.message, 'feedback with labels');
+    });
+
+    testWidgets('Send feedback with email', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(tester);
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.skipScreenshot();
+      await robot.enterEmail('dash@flutter.io');
+      await robot.submitFeedback();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback, isNotNull);
+      expect(submittedFeedback!.message, 'test message');
+      expect(submittedFeedback.email, 'dash@flutter.io');
+      expect(latestCall['images'], hasLength(0));
+    });
+
+    testWidgets('Send feedback with everything', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(
+        tester,
+        feedbackOptions: const WiredashFeedbackOptions(
+          labels: [
+            Label(id: 'lbl-1', title: 'One', description: 'First'),
+            Label(id: 'lbl-2', title: 'Two', description: 'Second'),
+          ],
+        ),
+      );
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+
+      await robot.selectLabel('Two');
+      await robot.goToNextStep();
+
+      await robot.enterScreenshotMode();
+      await robot.takeScreenshot();
+      await robot.confirmDrawing();
+      await robot.goToNextStep();
+
+      await robot.enterEmail('dash@flutter.io');
+      await robot.submitFeedback();
+
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback!.message, 'test message');
     });
   });
-}
-
-extension on WidgetTester {
-  /// Pumps and also drains the event queue, then pumps again and settles
-  Future<void> pumpHardAndSettle([
-    Duration duration = const Duration(milliseconds: 1),
-  ]) async {
-    await pumpAndSettle();
-    // pump event queue, trigger timers
-    await runAsync(() => Future.delayed(duration));
-  }
-
-  Future<void> waitUntil(
-    Finder finder,
-    Matcher matcher, {
-    Duration timeout = const Duration(seconds: 3),
-  }) async {
-    // print('waitUntil $finder matches within $timeout');
-    final stack = StackTrace.current;
-    final start = DateTime.now();
-    // await pumpAndSettle();
-    var attempt = 0;
-    while (true) {
-      attempt++;
-      if (matcher.matches(finder, {})) {
-        break;
-      }
-      if (finder.runtimeType.toString().contains('_TextFinder')) {
-        print('Text on screen (${DateTime.now().difference(start)}):');
-        print(allWidgets.whereType<Text>().map((e) => e.data).toList());
-      }
-
-      final now = DateTime.now();
-      if (now.isAfter(start.add(timeout))) {
-        print(stack);
-        if (finder.runtimeType.toString().contains('_TextFinder')) {
-          print('Text on screen:');
-          print(allWidgets.whereType<Text>().map((e) => e.data).toList());
-        }
-        throw 'Did not find $finder after $timeout (attempt: $attempt)';
-      }
-
-      final duration =
-          Duration(milliseconds: math.pow(attempt, math.e).toInt());
-      if (duration > const Duration(seconds: 1)) {
-        // show continuous updates
-        print(
-          'Waiting for (attempt: $attempt)\n'
-          '\tFinder: $finder to match\n'
-          '\tMatcher: $matcher',
-        );
-      }
-      if (attempt < 10) {
-        await pumpAndSettle(duration);
-      } else {
-        await pumpHardAndSettle(duration);
-      }
-    }
-  }
 }
 
 class _MockProjectCredentialValidator extends Fake
@@ -346,24 +210,5 @@ class _MockProjectCredentialValidator extends Fake
   }) async {
     validateInvocations
         .addMethodCall(namedArgs: {'projectId': projectId, 'secret': secret});
-  }
-}
-
-class _MockApi implements WiredashApi {
-  List<PersistedFeedbackItem> submissions = [];
-  MethodInvocationCatcher sendFeedbackInvocations =
-      MethodInvocationCatcher('sendFeedback');
-  @override
-  Future<void> sendFeedback(
-    PersistedFeedbackItem feedback, {
-    List<ImageBlob> images = const [],
-  }) async {
-    return sendFeedbackInvocations
-        .addMethodCall(namedArgs: {'images': images}, args: [feedback]);
-  }
-
-  @override
-  Future<ImageBlob> sendImage(Uint8List screenshot) async {
-    return ImageBlob({});
   }
 }


### PR DESCRIPTION
<img width="809" alt="Screen-Shot-2022-01-02-18-51-28 02" src="https://user-images.githubusercontent.com/1096485/147884791-d8e612c2-11ae-4f2d-9a40-356bbf9c44f8.png">


There is now a form around the `LarryPageView`. When the next button is pressed all form fields get validated before a user can proceed to the next page.
Added tests for it and refactored the widget tests by introducing a Robot (fyi @jxstxn1)

The wiredash widget tests are now better structured:
<img width="356" alt="Screen-Shot-2022-01-02-18-49-46 14" src="https://user-images.githubusercontent.com/1096485/147884856-a4370b5a-e4d4-490e-a593-57cf200ff7c9.png">