### PR TITLE
Asking for user email is now optional

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,8 @@ class _WiredashExampleAppState extends State<WiredashExampleApp> {
       feedbackOptions: WiredashFeedbackOptions(
         collectMetaData: (metaData) => metaData
           ..userEmail = 'dash@wiredash.io'
-          ..custom['isPremium'] = false,
+          ..custom['isPremium'] = false
+          ..custom['nested'] = {'wire': 'dash'},
         askForUserEmail: true,
         labels: [
           Label(
@@ -69,16 +70,16 @@ class _WiredashExampleAppState extends State<WiredashExampleApp> {
             title: 'Bug',
           ),
           Label(
-            id: 'lbl-2r98yask',
-            title: 'Abfall',
+            id: 'lbl-6543df23s',
+            title: 'Improvement',
           ),
           Label(
             id: 'lbl-de3w2fds',
-            title: 'Backend',
+            title: 'UX/UI',
           ),
           Label(
             id: 'lbl-2r98yas4',
-            title: 'Da muss Frederik noch mal ran',
+            title: 'Payment',
           ),
         ],
       ),

--- a/lib/src/common/options/feedback_options.dart
+++ b/lib/src/common/options/feedback_options.dart
@@ -1,12 +1,41 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:wiredash/src/feedback/data/label.dart';
 
+/// Options that adjust the flow a user has to take when giving feedback
 class WiredashFeedbackOptions {
+  /// The labels a user can select
+  ///
+  /// Please visit the Wiredash Console to get your label ids
+  /// https://console.wiredash.io/
+  /// Settings -> Labels
+  ///
+  /// When `null` the label selection step isn't shown at all
+  ///
+  /// Localization is the responsibility of wiredash. Please localize the
+  /// labels yourself, you know best if and how they should be translated.
   final List<Label>? labels;
 
+  /// When `true` a step asking the user for their email address is shown
+  ///
+  /// Defaults to false, does not show the email address step.
   final bool askForUserEmail;
 
+  /// Enrich the user feedback with custom metadata
+  ///
+  /// This function is called by Wiredash when the user (optional) takes a
+  /// screenshot or right before submitting feedback.
+  ///
+  /// Mutate the incoming `metaData` object and add or override values
+  ///
+  /// ```dart
+  /// feedbackOptions: WiredashFeedbackOptions(
+  ///   collectMetaData: (metaData) => metaData
+  ///     ..userEmail = 'dash@wiredash.io'
+  ///     ..custom['isPremium'] = false
+  ///     ..custom['nested'] = {'wire': 'dash'},
+  /// ```
   final FutureOr<CustomizableWiredashMetaData> Function(
     CustomizableWiredashMetaData metaData,
   )? collectMetaData;
@@ -31,11 +60,36 @@ class WiredashFeedbackOptions {
 /// This object is intended to be mutable, making it trivial to change
 /// properties.
 class CustomizableWiredashMetaData {
+  /// The id of the user, allowing you to match the feedback with the userIds
+  /// of you application
+  ///
+  /// Might be a nickname, a uuid, or an email-address
   String? userId;
+
+  /// The email address auto-fills the email address step
+  ///
+  /// This is the best way to contact the user and can be different from
+  /// [userId]
   String? userEmail;
+
+  /// The "name" of the version, i.e. a semantic version 1.5.10-debug
+  ///
+  /// This field is prefilled with the environment variable `BUILD_VERSION`
   String? buildVersion;
+
+  /// The build number of this version, usually an int
+  ///
+  /// This field is prefilled with the environment variable `BUILD_NUMBER`
   String? buildNumber;
+
+  /// The commit that was used to build this app
+  ///
+  /// This field is prefilled with the environment variable `BUILD_COMMIT`
   String? buildCommit;
+
+  /// Supported data types are String, int, double, bool, List, Map.
+  ///
+  /// Values that can't be encoded using `jsonEncode` will be omitted.
   Map<String, Object?> custom = {};
 
   @override

--- a/lib/src/common/options/feedback_options.dart
+++ b/lib/src/common/options/feedback_options.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:wiredash/src/feedback/data/label.dart';
 

--- a/lib/src/common/theme/wiredash_theme_data.dart
+++ b/lib/src/common/theme/wiredash_theme_data.dart
@@ -150,7 +150,7 @@ class WiredashThemeData {
         fontFamily: fontFamily,
         fontSize: 14,
         color: primaryTextColor,
-        fontWeight: FontWeight.w500,
+        fontWeight: FontWeight.bold,
       );
 
   TextStyle get bodyTextStyle => TextStyle(

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -20,7 +20,8 @@ enum FeedbackFlowStatus {
   screenshotDrawing,
   screenshotSaving,
   email,
-  submitting
+  submit,
+  submitting,
 }
 
 class FeedbackModel with ChangeNotifier {
@@ -93,7 +94,10 @@ class FeedbackModel with ChangeNotifier {
         // doesn't support rendering to canvas
         stack.add(FeedbackFlowStatus.screenshotsOverview);
       }
-      stack.add(FeedbackFlowStatus.email);
+      if (_services.wiredashWidget.feedbackOptions?.askForUserEmail == true) {
+        stack.add(FeedbackFlowStatus.email);
+      }
+      stack.add(FeedbackFlowStatus.submit);
     }
     if (submitting || submitted || submissionError != null) {
       stack.add(FeedbackFlowStatus.submitting);
@@ -230,6 +234,12 @@ class FeedbackModel with ChangeNotifier {
         _feedbackFlowStatus = newStatus;
         notifyListeners();
         break;
+
+      case FeedbackFlowStatus.submit:
+        _feedbackFlowStatus = newStatus;
+        notifyListeners();
+        break;
+
       case FeedbackFlowStatus.submitting:
         _feedbackFlowStatus = newStatus;
         notifyListeners();

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -11,6 +11,7 @@ import 'package:wiredash/src/feedback/ui/steps/step_2_labels.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_3_screenshot_overview.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_5_email.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_6_submit.dart';
+import 'package:wiredash/src/feedback/ui/steps/step_7_submitting.dart';
 
 class WiredashFeedbackFlow extends StatefulWidget {
   const WiredashFeedbackFlow({Key? key}) : super(key: key);
@@ -101,8 +102,11 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
           if (status == FeedbackFlowStatus.email) {
             return const Step5Email();
           }
-          if (status == FeedbackFlowStatus.submitting) {
+          if (status == FeedbackFlowStatus.submit) {
             return const Step6Submit();
+          }
+          if (status == FeedbackFlowStatus.submitting) {
+            return const Step7SubmittingAndError();
           }
           throw 'Unknown step $status at index $index';
         }();
@@ -164,6 +168,7 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
         return 3;
       case FeedbackFlowStatus.email:
         return 4;
+      case FeedbackFlowStatus.submit:
       case FeedbackFlowStatus.submitting:
         return 5;
     }

--- a/lib/src/feedback/ui/feedback_navigation.dart
+++ b/lib/src/feedback/ui/feedback_navigation.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
 import 'package:wiredash/src/common/widgets/translate_transition.dart';
@@ -206,6 +207,14 @@ class _FeedbackNavigationState extends State<FeedbackNavigation>
           label: 'Go back',
           onTap: () => context.feedbackModel.goToPreviousStep(),
         );
+
+      case FeedbackFlowStatus.submit:
+        return TronButton(
+          color: context.theme.secondaryColor,
+          icon: Wirecons.arrow_narrow_left,
+          label: 'Go back',
+          onTap: () => context.feedbackModel.goToPreviousStep(),
+        );
       case FeedbackFlowStatus.submitting:
         return null;
     }
@@ -274,13 +283,22 @@ class _FeedbackNavigationState extends State<FeedbackNavigation>
       case FeedbackFlowStatus.email:
         return TronButton(
           color: context.theme.primaryColor,
-          icon: Wirecons.check,
+          icon: Wirecons.arrow_narrow_right,
           label: 'Next',
           onTap: () {
             if (context.feedbackModel.validateForm()) {
-              context.feedbackModel.submitFeedback();
+              context.feedbackModel.goToNextStep();
             }
           },
+        );
+      case FeedbackFlowStatus.submit:
+        return TronButton(
+          color: context.theme.primaryColor,
+          label: 'Submit',
+          onTap: () {
+            context.feedbackModel.submitFeedback();
+          },
+          icon: Wirecons.check,
         );
       case FeedbackFlowStatus.submitting:
         final error = context.feedbackModel.submissionError;

--- a/lib/src/feedback/ui/steps/step_5_email.dart
+++ b/lib/src/feedback/ui/steps/step_5_email.dart
@@ -63,7 +63,7 @@ class _Step5EmailState extends State<Step5Email> with TickerProviderStateMixin {
                     style: context.theme.bodyTextStyle,
                     onFieldSubmitted: (_) {
                       if (context.feedbackModel.validateForm()) {
-                        context.feedbackModel.submitFeedback();
+                        context.feedbackModel.goToNextStep();
                       }
                     },
                     validator: (data) {

--- a/lib/src/feedback/ui/steps/step_6_submit.dart
+++ b/lib/src/feedback/ui/steps/step_6_submit.dart
@@ -1,6 +1,7 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
-import 'package:wiredash/src/common/widgets/wirecons.dart';
+import 'package:wiredash/src/feedback/data/persisted_feedback_item.dart';
 import 'package:wiredash/src/feedback/feedback_model_provider.dart';
 import 'package:wiredash/src/feedback/ui/feedback_flow.dart';
 
@@ -14,110 +15,137 @@ class Step6Submit extends StatefulWidget {
 class _Step6SubmitState extends State<Step6Submit> {
   @override
   Widget build(BuildContext context) {
+    final model = context.feedbackModel;
     return StepPageScaffold(
       child: SafeArea(
-        child: Builder(
-          builder: (context) {
-            final submitting = context.feedbackModel.submitting;
-            if (submitting) {
-              return ScrollBox(
-                child: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const SizedBox(
-                        height: 24,
-                      ),
-                      Icon(
-                        Wirecons.arrow_right,
-                        size: 48,
-                        color: context.theme.primaryColor,
-                      ),
-                      const SizedBox(
-                        height: 20,
-                      ),
-                      Text(
-                        'Submitting your feedback',
-                        textAlign: TextAlign.center,
-                        style: context.theme.titleTextStyle,
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            }
-
-            final error = context.feedbackModel.submissionError;
-            if (error != null) {
-              return ScrollBox(
-                child: Center(
-                  child: Column(
-                    children: [
-                      const SizedBox(
-                        height: 36,
-                      ),
-                      Icon(
-                        Wirecons.x_circle,
-                        size: 48,
-                        color: context.theme.primaryColor,
-                      ),
-                      const SizedBox(height: 16),
-                      Text(
-                        'Feedback submission failed',
-                        style: context.theme.titleTextStyle,
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: 32),
-                      Theme(
-                        data: ThemeData(
-                          dividerColor: Colors.transparent,
-                        ),
-                        child: ExpansionTile(
-                          title: Text(
-                            'Click to open error details',
-                            style: context.theme.bodyTextStyle,
-                          ),
-                          children: [
-                            Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 16),
-                              child: Text(error.toString()),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            }
-
-            return ScrollBox(
-              child: Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 36),
+            Text(
+              'Submit your feedback',
+              style: context.theme.titleTextStyle,
+              textAlign: TextAlign.left,
+            ),
+            Expanded(
+              child: ScrollBox(
                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const SizedBox(
-                      height: 24,
-                    ),
-                    Icon(
-                      Wirecons.check,
-                      size: 48,
-                      color: context.theme.primaryColor,
-                    ),
-                    const SizedBox(
-                      height: 20,
-                    ),
+                    const SizedBox(height: 8),
                     Text(
-                      'Thanks for your feedback!',
-                      textAlign: TextAlign.center,
-                      style: context.theme.titleTextStyle,
+                      'Please review your data before submission. '
+                      'You can navigate back to adjust your feedback',
+                      style: context.theme.body2TextStyle,
+                      textAlign: TextAlign.left,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Details',
+                      style: context.theme.bodyTextStyle.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.left,
+                    ),
+                    FutureBuilder<PersistedFeedbackItem>(
+                      future: model.createFeedback(),
+                      builder: (context, snapshot) {
+                        final data = snapshot.data;
+                        if (data == null) {
+                          return const SizedBox();
+                        }
+                        return Column(
+                          children: [
+                            ListTile(
+                              contentPadding: EdgeInsets.zero,
+                              title: const Text('Message'),
+                              subtitle: Text(data.message),
+                            ),
+                            if (model.selectedLabels.isNotEmpty)
+                              ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: const Text('Labels'),
+                                subtitle: Text(
+                                  model.selectedLabels
+                                      .map((it) => it.title)
+                                      .join(', '),
+                                ),
+                              ),
+                            if (model.hasScreenshots)
+                              const ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: Text('Screenshots'),
+                                // TODO add exact number
+                                subtitle: Text('1 Screenshot'),
+                              ),
+                            if (data.email != null)
+                              ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: const Text('Contact email'),
+                                subtitle: Text(data.email ?? ''),
+                              ),
+                            ListTile(
+                              contentPadding: EdgeInsets.zero,
+                              title: const Text('Locale'),
+                              subtitle: Text(
+                                data.appInfo.appLocale,
+                              ),
+                            ),
+                            if (data.deviceInfo.userAgent != null)
+                              ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: const Text('User agent'),
+                                subtitle: Text('${data.deviceInfo.userAgent}'),
+                              ),
+                            if (!kIsWeb)
+                              ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: const Text('Platform'),
+                                subtitle: Text(
+                                  '${data.deviceInfo.platformOS} '
+                                  '${data.deviceInfo.platformOSVersion} '
+                                  '(${data.deviceInfo.platformLocale})',
+                                ),
+                              ),
+                            ListTile(
+                              contentPadding: EdgeInsets.zero,
+                              title: const Text('Build Info'),
+                              subtitle: Text(
+                                [
+                                  data.buildInfo.compilationMode,
+                                  data.buildInfo.buildNumber,
+                                  data.buildInfo.buildVersion,
+                                  data.buildInfo.buildCommit
+                                ].where((it) => it != null).join(', '),
+                              ),
+                            ),
+                            if (!kIsWeb)
+                              ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: const Text('Dart version'),
+                                subtitle:
+                                    Text('${data.deviceInfo.platformVersion}'),
+                              ),
+                            if (data.customMetaData != null)
+                              ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                title: const Text('Custom metaData'),
+                                subtitle: Text(
+                                  data.customMetaData!.entries
+                                      .map((it) => '${it.key}=${it.value}, ')
+                                      .join(),
+                                ),
+                              ),
+                          ],
+                        );
+                      },
                     ),
                   ],
                 ),
               ),
-            );
-          },
+            ),
+          ],
         ),
       ),
     );

--- a/lib/src/feedback/ui/steps/step_7_submitting.dart
+++ b/lib/src/feedback/ui/steps/step_7_submitting.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:wiredash/src/common/theme/wiredash_theme.dart';
+import 'package:wiredash/src/common/widgets/wirecons.dart';
+import 'package:wiredash/src/feedback/feedback_model_provider.dart';
+import 'package:wiredash/src/feedback/ui/feedback_flow.dart';
+
+class Step7SubmittingAndError extends StatefulWidget {
+  const Step7SubmittingAndError({Key? key}) : super(key: key);
+
+  @override
+  State<Step7SubmittingAndError> createState() =>
+      _Step7SubmittingAndErrorState();
+}
+
+class _Step7SubmittingAndErrorState extends State<Step7SubmittingAndError> {
+  @override
+  Widget build(BuildContext context) {
+    return StepPageScaffold(
+      child: SafeArea(
+        child: Builder(
+          builder: (context) {
+            final submitting = context.feedbackModel.submitting;
+            if (submitting) {
+              return ScrollBox(
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const SizedBox(
+                        height: 24,
+                      ),
+                      Icon(
+                        Wirecons.arrow_right,
+                        size: 48,
+                        color: context.theme.primaryColor,
+                      ),
+                      const SizedBox(
+                        height: 20,
+                      ),
+                      Text(
+                        'Submitting your feedback',
+                        textAlign: TextAlign.center,
+                        style: context.theme.titleTextStyle,
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }
+
+            final error = context.feedbackModel.submissionError;
+            if (error != null) {
+              return ScrollBox(
+                child: Center(
+                  child: Column(
+                    children: [
+                      const SizedBox(
+                        height: 36,
+                      ),
+                      Icon(
+                        Wirecons.x_circle,
+                        size: 48,
+                        color: context.theme.primaryColor,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Feedback submission failed',
+                        style: context.theme.titleTextStyle,
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 32),
+                      Theme(
+                        data: ThemeData(
+                          dividerColor: Colors.transparent,
+                        ),
+                        child: ExpansionTile(
+                          title: Text(
+                            'Click to open error details',
+                            style: context.theme.bodyTextStyle,
+                          ),
+                          children: [
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: Text(error.toString()),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }
+
+            return ScrollBox(
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const SizedBox(
+                      height: 24,
+                    ),
+                    Icon(
+                      Wirecons.check,
+                      size: 48,
+                      color: context.theme.primaryColor,
+                    ),
+                    const SizedBox(
+                      height: 20,
+                    ),
+                    Text(
+                      'Thanks for your feedback!',
+                      textAlign: TextAlign.center,
+                      style: context.theme.titleTextStyle,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/test/email_validation_test.dart
+++ b/test/email_validation_test.dart
@@ -46,7 +46,7 @@ void main() {
       );
     });
 
-    testWidgets('Don not ask for email', (tester) async {
+    testWidgets('Do not ask for email', (tester) async {
       final robot = await WiredashTestRobot.launchApp(tester);
 
       await robot.openWiredash();

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -18,6 +18,7 @@ import 'package:wiredash/src/feedback/ui/steps/step_1_feedback_message.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_2_labels.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_3_screenshot_overview.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_5_email.dart';
+import 'package:wiredash/src/feedback/ui/steps/step_6_submit.dart';
 import 'package:wiredash/src/wiredash_widget.dart';
 
 import 'mock_api.dart';
@@ -131,7 +132,7 @@ class WiredashTestRobot {
   }
 
   Future<void> submitFeedback() async {
-    expect(find.byType(Step5Email), findsOneWidget);
+    expect(find.byType(Step6Submit), findsOneWidget);
     await tester.tap(find.byIcon(Wirecons.check));
     print('submit feedback');
     await tester.pump();
@@ -139,19 +140,27 @@ class WiredashTestRobot {
 
   Future<void> skipEmail() async {
     expect(find.byType(Step5Email), findsOneWidget);
-    await tester.tap(find.byIcon(Wirecons.check));
-    print('Skipped email');
-    await tester.pump();
+    await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
+    await tester.pumpAndSettle();
+
+    final newStatus = services.feedbackModel.feedbackFlowStatus;
+    print('Skipped email, next $newStatus');
   }
 
   Future<void> submitEmailViaButton() async {
-    await tester.tap(find.byIcon(Wirecons.check));
-    await tester.pump();
+    await tester.tap(find.byIcon(Wirecons.arrow_narrow_right));
+    await tester.pumpAndSettle();
+
+    final newStatus = services.feedbackModel.feedbackFlowStatus;
+    print('Submitted email, next $newStatus');
   }
 
   Future<void> submitEmailViaKeyboard() async {
     await tester.testTextInput.receiveAction(TextInputAction.send);
-    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final newStatus = services.feedbackModel.feedbackFlowStatus;
+    print('Submitted email, next $newStatus');
   }
 
   Future<void> goToNextStep() async {

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -65,7 +65,7 @@ void main() {
       await robot.enterFeedbackMessage('test message');
       await robot.goToNextStep();
       await robot.skipScreenshot();
-      await robot.skipEmail();
+      await robot.submitFeedback();
       await tester.waitUntil(
         find.text('Thanks for your feedback!'),
         findsOneWidget,
@@ -87,7 +87,7 @@ void main() {
       await robot.takeScreenshot();
       await robot.confirmDrawing();
       await robot.goToNextStep();
-      await robot.skipEmail();
+      await robot.submitFeedback();
       await tester.waitUntil(
         find.text('Thanks for your feedback!'),
         findsOneWidget,
@@ -123,7 +123,7 @@ void main() {
       await robot.goToNextStep();
 
       await robot.skipScreenshot();
-      await robot.skipEmail();
+      await robot.submitFeedback();
       await tester.waitUntil(
         find.text('Thanks for your feedback!'),
         findsOneWidget,
@@ -136,7 +136,12 @@ void main() {
     });
 
     testWidgets('Send feedback with email', (tester) async {
-      final robot = await WiredashTestRobot.launchApp(tester);
+      final robot = await WiredashTestRobot.launchApp(
+        tester,
+        feedbackOptions: const WiredashFeedbackOptions(
+          askForUserEmail: true,
+        ),
+      );
       final mockApi = MockWiredashApi();
       robot.mockWiredashApi(mockApi);
 
@@ -145,6 +150,7 @@ void main() {
       await robot.goToNextStep();
       await robot.skipScreenshot();
       await robot.enterEmail('dash@flutter.io');
+      await robot.goToNextStep();
       await robot.submitFeedback();
       await tester.waitUntil(
         find.text('Thanks for your feedback!'),
@@ -162,6 +168,7 @@ void main() {
       final robot = await WiredashTestRobot.launchApp(
         tester,
         feedbackOptions: const WiredashFeedbackOptions(
+          askForUserEmail: true,
           labels: [
             Label(id: 'lbl-1', title: 'One', description: 'First'),
             Label(id: 'lbl-2', title: 'Two', description: 'Second'),
@@ -185,6 +192,7 @@ void main() {
       await robot.goToNextStep();
 
       await robot.enterEmail('dash@flutter.io');
+      await robot.goToNextStep();
       await robot.submitFeedback();
 
       await tester.waitUntil(


### PR DESCRIPTION
- Asking for user email is now optional. To enable it set `WiredashFeedbackOptions(askForUserEmail: true)`

The email screen was our final screen before submission. Without it being required, it felt wrong sending feedback after skipping the screenshot. Therefore I added a  new "summary" screen before submission:

<img width="456" alt="Screen-Shot-2022-01-02-20-19-48 25" src="https://user-images.githubusercontent.com/1096485/147886963-42d0dac0-0518-4c44-8d9c-83e00a2ee72c.png">

