### PR TITLE
Add inheritMaterialTheme and inheritCupertinoTheme to show()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Hide backdrop content in screenshot mode
 * [#165](https://github.com/wiredashio/wiredash-sdk/pull/165) Validate email address
 * [#166](https://github.com/wiredashio/wiredash-sdk/pull/166) Make email address optional. Set `WiredashFeedbackOptions(askForUserEmail: true)` to enable it
+* [#167](https://github.com/wiredashio/wiredash-sdk/pull/167) New `inheritMaterialTheme` and `inheritCupertinoTheme` properties for `Wiredash.of(context).show()` to inherit the theme
 
 ## 1.0.0-alpha.1 - A Whole New World
 * Completely rewritten UI layer

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -139,7 +139,7 @@ class _HomePage extends StatelessWidget {
         /// Since the `Wiredash` widget is at the root of the widget tree this
         /// method can be accessed from anywhere in the code.
         onPressed: () {
-          Wiredash.of(context).show(context);
+          Wiredash.of(context).show(inheritMaterialTheme: true);
         },
         child: Icon(Icons.feedback_outlined),
       ),

--- a/lib/src/common/utils/context_cache.dart
+++ b/lib/src/common/utils/context_cache.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import 'package:wiredash/wiredash.dart';
+
+/// Use to bind the [BuildContext] to the current [Wiredash] widget
+final Expando _expando = Expando();
+
+extension WiredashWithBuildContext on Wiredash {
+  /// The context that is attached to the Wiredash widget using
+  /// `Wiredash.of(context)`
+  BuildContext? get showBuildContext {
+    return _expando[this] as BuildContext?;
+  }
+
+  /// Attach a [BuildContext] to the this [Wiredash] widget
+  ///
+  /// This setter creates a weak reference to the context. It is free for
+  /// garbage collection once the [Wiredash] widget gets garbage collected
+  set showBuildContext(BuildContext? context) {
+    _expando[this] = context;
+  }
+}

--- a/lib/src/feedback/wiredash_model.dart
+++ b/lib/src/feedback/wiredash_model.dart
@@ -4,6 +4,8 @@ import 'package:wiredash/src/common/options/feedback_options.dart';
 import 'package:wiredash/src/common/services/services.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme_data.dart';
 import 'package:wiredash/src/feedback/data/retrying_feedback_submitter.dart';
+import 'package:wiredash/src/wiredash_controller.dart';
+import 'package:wiredash/src/wiredash_widget.dart';
 
 class WiredashModel with ChangeNotifier {
   WiredashModel(this.services);
@@ -29,6 +31,12 @@ class WiredashModel with ChangeNotifier {
     notifyListeners();
   }
 
+  /// Temporary theme that overrides the `Wiredash.theme` property for the
+  /// current 'show' session
+  ///
+  /// Also see
+  /// - [Wiredash.of]
+  /// - [WiredashController.show]
   WiredashThemeData? _themeFromContext;
   WiredashThemeData? get themeFromContext => _themeFromContext;
 

--- a/lib/src/wiredash_widget.dart
+++ b/lib/src/wiredash_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:wiredash/src/common/options/wiredash_options.dart';
 import 'package:wiredash/src/common/services/services.dart';
 import 'package:wiredash/src/common/theme/wiredash_theme.dart';
+import 'package:wiredash/src/common/utils/context_cache.dart';
 import 'package:wiredash/src/common/utils/project_credential_validator.dart';
 import 'package:wiredash/src/common/widgets/screencapture.dart';
 import 'package:wiredash/src/feedback/backdrop/backdrop_controller_provider.dart';
@@ -121,7 +122,9 @@ class Wiredash extends StatefulWidget {
   static WiredashController? maybeOf(BuildContext context) {
     final state = context.findAncestorStateOfType<WiredashState>();
     if (state == null) return null;
-
+    // cache context in a short lived object like the widget
+    // it gets later retrieved by the `show()` method to read the theme
+    state.widget.showBuildContext = context;
     return WiredashController(state._services.wiredashModel);
   }
 
@@ -135,7 +138,13 @@ class Wiredash extends StatefulWidget {
   /// ```
   static WiredashController of(BuildContext context) {
     final state = context.findAncestorStateOfType<WiredashState>();
-    return WiredashController(state!._services.wiredashModel);
+    if (state == null) {
+      throw StateError('Could not find WiredashState in ancestors');
+    }
+    // cache context in a short lived object like the widget
+    // it gets later retrieved by the `show()` method to read the theme
+    state.widget.showBuildContext = context;
+    return WiredashController(state._services.wiredashModel);
   }
 }
 

--- a/lib/src/wiredash_widget.dart
+++ b/lib/src/wiredash_widget.dart
@@ -210,8 +210,8 @@ class WiredashState extends State<Wiredash> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = widget.theme ??
-        _services.wiredashModel.themeFromContext ??
+    final theme = _services.wiredashModel.themeFromContext ??
+        widget.theme ??
         WiredashThemeData();
 
     // Assign app an key so it doesn't lose state when wrapped, unwrapped


### PR DESCRIPTION
It is impossible to detect if a user-configured cupertino theme is present or not. Thus users should inform wiredash about which theme to grab the values from

Add `inheritMaterialTheme` and `inheritCupertinoTheme` to `show` method

```dart
Wiredash.of(context).show();
Wiredash.of(context).show(inheritMaterialTheme: true);
Wiredash.of(context).show(inheritCupertinoTheme: true);
```

It's a breaking change, but that's ok for an alpha