### PR TITLE
Don't wrap client app in Overlay

### DIFF
--- a/lib/src/common/network/wiredash_api.dart
+++ b/lib/src/common/network/wiredash_api.dart
@@ -27,7 +27,7 @@ class WiredashApi {
   final Future<String> Function() _deviceIdProvider;
 
   static const String _host = 'https://api.wiredash.io/sdk';
-  // static const String _host = 'https://dev-api.wiredash.io/sdk';
+  // static const String _host = 'https://api.wiredash.dev/sdk';
 
   /// Uploads an image to the Wiredash image hosting
   ///

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -194,9 +194,11 @@ class ScrollBox extends StatefulWidget {
 class _ScrollBoxState extends State<ScrollBox> {
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      data: ThemeData(brightness: Brightness.light),
-      child: widget.child,
+    return DefaultTextEditingShortcuts(
+      child: Theme(
+        data: ThemeData(brightness: Brightness.light),
+        child: widget.child,
+      ),
     );
   }
 }

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -194,19 +194,9 @@ class ScrollBox extends StatefulWidget {
 class _ScrollBoxState extends State<ScrollBox> {
   @override
   Widget build(BuildContext context) {
-    final controller = StepInformation.of(context).innerScrollController;
     return Theme(
       data: ThemeData(brightness: Brightness.light),
-      child: Scrollbar(
-        interactive: false,
-        controller: controller,
-        isAlwaysShown: true,
-        child: SingleChildScrollView(
-          controller: controller,
-          padding: widget.padding,
-          child: widget.child,
-        ),
-      ),
+      child: widget.child,
     );
   }
 }

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -12,6 +12,8 @@ import 'package:wiredash/src/feedback/ui/steps/step_3_screenshot_overview.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_5_email.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_6_submit.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_7_submitting.dart';
+import 'package:wiredash/src/not_a_widgets_app.dart';
+import 'package:wiredash/src/wiredash_model_provider.dart';
 
 class WiredashFeedbackFlow extends StatefulWidget {
   const WiredashFeedbackFlow({Key? key}) : super(key: key);
@@ -194,10 +196,14 @@ class ScrollBox extends StatefulWidget {
 class _ScrollBoxState extends State<ScrollBox> {
   @override
   Widget build(BuildContext context) {
-    return DefaultTextEditingShortcuts(
-      child: Theme(
-        data: ThemeData(brightness: Brightness.light),
-        child: widget.child,
+    return MaterialSupportLayer(
+      locale:
+          context.wiredashModel.services.wiredashWidget.options?.currentLocale,
+      child: DefaultTextEditingShortcuts(
+        child: Theme(
+          data: ThemeData(brightness: Brightness.light),
+          child: widget.child,
+        ),
       ),
     );
   }

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -126,14 +126,20 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
       onTap: () {
         Focus.maybeOf(context)?.unfocus();
       },
-      child: Stack(
-        children: [
-          Form(
-            key: feedbackModel.stepFormKey,
-            child: larryPageView,
+      child: MaterialSupportLayer(
+        locale: context
+            .wiredashModel.services.wiredashWidget.options?.currentLocale,
+        child: DefaultTextEditingShortcuts(
+          child: Stack(
+            children: [
+              Form(
+                key: feedbackModel.stepFormKey,
+                child: larryPageView,
+              ),
+              _buildProgressIndicator(),
+            ],
           ),
-          _buildProgressIndicator(),
-        ],
+        ),
       ),
     );
   }
@@ -196,12 +202,16 @@ class ScrollBox extends StatefulWidget {
 class _ScrollBoxState extends State<ScrollBox> {
   @override
   Widget build(BuildContext context) {
-    return MaterialSupportLayer(
-      locale:
-          context.wiredashModel.services.wiredashWidget.options?.currentLocale,
-      child: DefaultTextEditingShortcuts(
-        child: Theme(
-          data: ThemeData(brightness: Brightness.light),
+    final controller = StepInformation.of(context).innerScrollController;
+    return Theme(
+      data: ThemeData(brightness: Brightness.light),
+      child: Scrollbar(
+        interactive: false,
+        controller: controller,
+        isAlwaysShown: true,
+        child: SingleChildScrollView(
+          controller: controller,
+          padding: widget.padding,
           child: widget.child,
         ),
       ),

--- a/lib/src/feedback/ui/feedback_flow.dart
+++ b/lib/src/feedback/ui/feedback_flow.dart
@@ -12,7 +12,7 @@ import 'package:wiredash/src/feedback/ui/steps/step_3_screenshot_overview.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_5_email.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_6_submit.dart';
 import 'package:wiredash/src/feedback/ui/steps/step_7_submitting.dart';
-import 'package:wiredash/src/not_a_widgets_app.dart';
+import 'package:wiredash/src/support/material_support_layer.dart';
 import 'package:wiredash/src/wiredash_model_provider.dart';
 
 class WiredashFeedbackFlow extends StatefulWidget {

--- a/lib/src/feedback/ui/steps/step_6_submit.dart
+++ b/lib/src/feedback/ui/steps/step_6_submit.dart
@@ -27,7 +27,7 @@ class _Step6SubmitState extends State<Step6Submit> {
               style: context.theme.titleTextStyle,
               textAlign: TextAlign.left,
             ),
-            Expanded(
+            Flexible(
               child: ScrollBox(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,

--- a/lib/src/feedback/wiredash_model.dart
+++ b/lib/src/feedback/wiredash_model.dart
@@ -10,6 +10,7 @@ import 'package:wiredash/src/wiredash_widget.dart';
 class WiredashModel with ChangeNotifier {
   WiredashModel(this.services);
 
+  // TODO make private?
   final WiredashServices services;
 
   CustomizableWiredashMetaData? _metaData;

--- a/lib/src/not_a_widgets_app.dart
+++ b/lib/src/not_a_widgets_app.dart
@@ -23,18 +23,18 @@ class NotAWidgetsApp extends StatefulWidget {
 }
 
 class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
-  OverlayEntry? entry;
+  OverlayEntry? _entry;
 
   @override
   void didUpdateWidget(covariant NotAWidgetsApp oldWidget) {
     super.didUpdateWidget(oldWidget);
-    entry?.markNeedsBuild();
+    _entry?.markNeedsBuild();
   }
 
   @override
   Widget build(BuildContext context) {
     // Overlay is required for text edit functions such as copy/paste on mobile
-    entry = OverlayEntry(
+    _entry = OverlayEntry(
       builder: (context) {
         // use a stateful widget as direct child or hot reload will not
         // work for that widget
@@ -42,7 +42,9 @@ class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
       },
     );
 
-    Widget child = Overlay(initialEntries: [entry!]);
+    Widget child = Overlay(initialEntries: [_entry!]);
+    // Widget child = widget.child;
+    // return child;
 
     // Any Text requires a directionality
     child = Directionality(
@@ -58,12 +60,6 @@ class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
         ],
         child: child,
       ),
-    );
-
-    // Both DefaultTextEditingShortcuts and DefaultTextEditingActions are
-    // required to make text edits like deletion of characters possible on macOS
-    child = DefaultTextEditingShortcuts(
-      child: child,
     );
 
     // Inject a MediaQuery with information from the app window

--- a/lib/src/not_a_widgets_app.dart
+++ b/lib/src/not_a_widgets_app.dart
@@ -1,39 +1,75 @@
+// ignore_for_file: join_return_with_assignment
+
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
-/// Wrapper for widgets like [TextField] that expect,
-/// but don't have a [WidgetsApp] as parent.
+/// Wrapper with default that most widgets required that are now wrapped by a
+/// [WidgetsApp]
 class NotAWidgetsApp extends StatefulWidget {
   const NotAWidgetsApp({
     required this.child,
     this.textDirection,
-    this.locale,
     Key? key,
   }) : super(key: key);
 
   final Widget child;
 
   final TextDirection? textDirection;
-  final Locale? locale;
 
   @override
   State<NotAWidgetsApp> createState() => _NotAWidgetsAppState();
 }
 
 class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
+  @override
+  Widget build(BuildContext context) {
+    Widget child = widget.child;
+
+    // Any Text requires a directionality
+    child = Directionality(
+      textDirection: widget.textDirection ?? TextDirection.ltr,
+      child: child,
+    );
+
+    // Inject a MediaQuery with information from the app window
+    child = MediaQuery.fromWindow(
+      child: child,
+    );
+
+    return child;
+  }
+}
+
+/// Provides parent Widgets that are required by material widgets that are
+/// not wrapped into an [MaterialApp]
+class MaterialSupportLayer extends StatefulWidget {
+  const MaterialSupportLayer({
+    Key? key,
+    required this.child,
+    this.locale,
+  }) : super(key: key);
+
+  final Widget child;
+  final Locale? locale;
+
+  @override
+  State<MaterialSupportLayer> createState() => _MaterialSupportLayerState();
+}
+
+class _MaterialSupportLayerState extends State<MaterialSupportLayer> {
   OverlayEntry? _entry;
 
   @override
-  void didUpdateWidget(covariant NotAWidgetsApp oldWidget) {
+  void didUpdateWidget(covariant MaterialSupportLayer oldWidget) {
     super.didUpdateWidget(oldWidget);
     _entry?.markNeedsBuild();
   }
 
   @override
   Widget build(BuildContext context) {
-    // Overlay is required for text edit functions such as copy/paste on mobile
+    //Overlay is required for text edit functions such as copy/paste on mobile
     _entry = OverlayEntry(
       builder: (context) {
         // use a stateful widget as direct child or hot reload will not
@@ -43,27 +79,16 @@ class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
     );
 
     Widget child = Overlay(initialEntries: [_entry!]);
-    // Widget child = widget.child;
-    // return child;
 
-    // Any Text requires a directionality
-    child = Directionality(
-      textDirection: widget.textDirection ?? TextDirection.ltr,
-      // Localizations required for Flutter UI widgets.
-      // I.e. copy/paste dialogs for TextFields
-      child: Localizations(
-        locale: widget.locale ?? window.locale,
-        delegates: const [
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        child: child,
-      ),
-    );
-
-    // Inject a MediaQuery with information from the app window
-    child = MediaQuery.fromWindow(
+    // Localizations required for Flutter UI widgets.
+    // I.e. copy/paste dialogs for TextFields
+    child = Localizations(
+      locale: widget.locale ?? window.locale,
+      delegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       child: child,
     );
 
@@ -72,7 +97,6 @@ class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
       color: Colors.transparent,
       child: child,
     );
-
     return child;
   }
 }

--- a/lib/src/support/material_support_layer.dart
+++ b/lib/src/support/material_support_layer.dart
@@ -5,43 +5,6 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
-/// Wrapper with default that most widgets required that are now wrapped by a
-/// [WidgetsApp]
-class NotAWidgetsApp extends StatefulWidget {
-  const NotAWidgetsApp({
-    required this.child,
-    this.textDirection,
-    Key? key,
-  }) : super(key: key);
-
-  final Widget child;
-
-  final TextDirection? textDirection;
-
-  @override
-  State<NotAWidgetsApp> createState() => _NotAWidgetsAppState();
-}
-
-class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
-  @override
-  Widget build(BuildContext context) {
-    Widget child = widget.child;
-
-    // Any Text requires a directionality
-    child = Directionality(
-      textDirection: widget.textDirection ?? TextDirection.ltr,
-      child: child,
-    );
-
-    // Inject a MediaQuery with information from the app window
-    child = MediaQuery.fromWindow(
-      child: child,
-    );
-
-    return child;
-  }
-}
-
 /// Provides parent Widgets that are required by material widgets that are
 /// not wrapped into an [MaterialApp]
 class MaterialSupportLayer extends StatefulWidget {

--- a/lib/src/support/not_a_widgets_app.dart
+++ b/lib/src/support/not_a_widgets_app.dart
@@ -1,0 +1,40 @@
+// ignore_for_file: join_return_with_assignment
+
+import 'package:flutter/material.dart';
+
+/// Wrapper with default that most widgets required that are now wrapped by a
+/// [WidgetsApp]
+class NotAWidgetsApp extends StatefulWidget {
+  const NotAWidgetsApp({
+    required this.child,
+    this.textDirection,
+    Key? key,
+  }) : super(key: key);
+
+  final Widget child;
+
+  final TextDirection? textDirection;
+
+  @override
+  State<NotAWidgetsApp> createState() => _NotAWidgetsAppState();
+}
+
+class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
+  @override
+  Widget build(BuildContext context) {
+    Widget child = widget.child;
+
+    // Any Text requires a directionality
+    child = Directionality(
+      textDirection: widget.textDirection ?? TextDirection.ltr,
+      child: child,
+    );
+
+    // Inject a MediaQuery with information from the app window
+    child = MediaQuery.fromWindow(
+      child: child,
+    );
+
+    return child;
+  }
+}

--- a/lib/src/wiredash_widget.dart
+++ b/lib/src/wiredash_widget.dart
@@ -11,7 +11,7 @@ import 'package:wiredash/src/feedback/backdrop/wiredash_backdrop.dart';
 import 'package:wiredash/src/feedback/feedback_model_provider.dart';
 import 'package:wiredash/src/feedback/picasso/picasso.dart';
 import 'package:wiredash/src/feedback/picasso/picasso_provider.dart';
-import 'package:wiredash/src/not_a_widgets_app.dart';
+import 'package:wiredash/src/support/not_a_widgets_app.dart';
 import 'package:wiredash/src/wiredash_model_provider.dart';
 import 'package:wiredash/wiredash.dart';
 

--- a/lib/src/wiredash_widget.dart
+++ b/lib/src/wiredash_widget.dart
@@ -241,7 +241,6 @@ class WiredashState extends State<Wiredash> {
     );
 
     final Widget backdrop = NotAWidgetsApp(
-      locale: widget.options?.currentLocale,
       textDirection: widget.options?.textDirection,
       child: WiredashLocalizations(
         child: WiredashTheme(


### PR DESCRIPTION
Wiredash requires an `Overlay` to show Copy/Paste controls when giving feedback. 
That Overlay also wrapped the clients app and cause some side effects. I moved it into the feedback flow along with other widgets that are only required because we use some Material widgets. 

Extracted `MaterialSupportLayer` out of `NotAWidgetsApp`