### PR TITLE
Keep track of the app widget and prevent losing state

### DIFF
--- a/lib/src/wiredash_widget.dart
+++ b/lib/src/wiredash_widget.dart
@@ -153,9 +153,9 @@ class Wiredash extends StatefulWidget {
 }
 
 class WiredashState extends State<Wiredash> {
-  final Key _appKey = const ValueKey('app');
+  final GlobalKey _appKey = GlobalKey(debugLabel: 'app');
 
-  final Key _backdropKey = const ValueKey('backdrop');
+  final GlobalKey _backdropKey = GlobalKey(debugLabel: 'backdrop');
 
   bool _isWiredashClosed = true;
 

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -1,0 +1,166 @@
+// ignore_for_file: avoid_print
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/feedback/data/persisted_feedback_item.dart';
+import 'package:wiredash/wiredash.dart';
+
+import 'util/mock_api.dart';
+import 'util/robot.dart';
+import 'util/wiredash_tester.dart';
+
+void main() {
+  group('Wiredash', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    testWidgets('Send text only feedback', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(tester);
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.skipScreenshot();
+      await robot.submitFeedback();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback!.message, 'test message');
+    });
+
+    testWidgets('Send feedback with screenshot', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(tester);
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.enterScreenshotMode();
+      await robot.takeScreenshot();
+      await robot.confirmDrawing();
+      await robot.goToNextStep();
+      await robot.submitFeedback();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback, isNotNull);
+      expect(submittedFeedback!.message, 'test message');
+      expect(latestCall['images'], hasLength(1));
+    });
+
+    testWidgets('Send feedback with labels', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(
+        tester,
+        feedbackOptions: const WiredashFeedbackOptions(
+          labels: [
+            Label(id: 'lbl-1', title: 'One', description: 'First'),
+            Label(id: 'lbl-2', title: 'Two', description: 'Second'),
+          ],
+        ),
+      );
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('feedback with labels');
+      await robot.goToNextStep();
+
+      // labels
+      expect(find.text('One'), findsOneWidget);
+      expect(find.text('Two'), findsOneWidget);
+      await robot.selectLabel('Two');
+      await robot.goToNextStep();
+
+      await robot.skipScreenshot();
+      await robot.submitFeedback();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback, isNotNull);
+      expect(submittedFeedback!.labels, ['lbl-2']);
+      expect(submittedFeedback.message, 'feedback with labels');
+    });
+
+    testWidgets('Send feedback with email', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(
+        tester,
+        feedbackOptions: const WiredashFeedbackOptions(
+          askForUserEmail: true,
+        ),
+      );
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.skipScreenshot();
+      await robot.enterEmail('dash@flutter.io');
+      await robot.goToNextStep();
+      await robot.submitFeedback();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback, isNotNull);
+      expect(submittedFeedback!.message, 'test message');
+      expect(submittedFeedback.email, 'dash@flutter.io');
+      expect(latestCall['images'], hasLength(0));
+    });
+
+    testWidgets('Send feedback with everything', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(
+        tester,
+        feedbackOptions: const WiredashFeedbackOptions(
+          askForUserEmail: true,
+          labels: [
+            Label(id: 'lbl-1', title: 'One', description: 'First'),
+            Label(id: 'lbl-2', title: 'Two', description: 'Second'),
+          ],
+        ),
+      );
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+
+      await robot.selectLabel('Two');
+      await robot.goToNextStep();
+
+      await robot.enterScreenshotMode();
+      await robot.takeScreenshot();
+      await robot.confirmDrawing();
+      await robot.goToNextStep();
+
+      await robot.enterEmail('dash@flutter.io');
+      await robot.goToNextStep();
+      await robot.submitFeedback();
+
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback!.message, 'test message');
+    });
+  });
+}

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -34,6 +34,7 @@ class WiredashTestRobot {
   static Future<WiredashTestRobot> launchApp(
     WidgetTester tester, {
     WiredashFeedbackOptions? feedbackOptions,
+    Widget Function(BuildContext)? builder,
   }) async {
     SharedPreferences.setMockInitialValues({});
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -53,13 +54,14 @@ class WiredashTestRobot {
         ),
         child: MaterialApp(
           home: Builder(
-            builder: (context) {
-              return Scaffold(
-                floatingActionButton: FloatingActionButton(
-                  onPressed: Wiredash.of(context).show,
-                ),
-              );
-            },
+            builder: builder ??
+                (context) {
+                  return Scaffold(
+                    floatingActionButton: FloatingActionButton(
+                      onPressed: Wiredash.of(context).show,
+                    ),
+                  );
+                },
           ),
         ),
       ),
@@ -96,6 +98,15 @@ class WiredashTestRobot {
     await tester.pumpAndSettle();
     expect(find.byType(WiredashFeedbackFlow), findsOneWidget);
     print('opened Wiredash');
+  }
+
+  Future<void> closeWiredash() async {
+    // tap app which is located at the bottom of the screen
+    final bottomRight = tester.getBottomRight(find.byType(Wiredash));
+    await tester.tapAt(Offset(bottomRight.dx / 2, bottomRight.dy - 20));
+    await tester.pumpAndSettle();
+    expect(find.byType(WiredashFeedbackFlow), findsNothing);
+    print('closed Wiredash');
   }
 
   Future<void> enterFeedbackMessage(String message) async {


### PR DESCRIPTION
Dumb bug, the widget tree is changing when open/closing Wiredash but we did not set a GlobalKey to maintain the widget state of the app.

Added a test for this (`'Do not lose state of app on open/close'`)

Split wiredash_widget and feedback_flow tests 

