### PR TITLE
Don't wrap app with Wiredash widgets when wiredash is closed

### DIFF
--- a/lib/src/feedback/backdrop/wiredash_backdrop.dart
+++ b/lib/src/feedback/backdrop/wiredash_backdrop.dart
@@ -820,10 +820,10 @@ class BackdropController extends ChangeNotifier {
     return _state != null;
   }
 
-  _WiredashBackdropState? __state;
-  _WiredashBackdropState? get _state => __state;
+  _WiredashBackdropState? _stateField;
+  _WiredashBackdropState? get _state => _stateField;
   set _state(_WiredashBackdropState? value) {
-    __state = value;
+    _stateField = value;
     safeNotifyListeners();
   }
 
@@ -868,7 +868,7 @@ class BackdropController extends ChangeNotifier {
 
   /// Only calls [notifyListeners()] when
   void safeNotifyListeners() {
-    if (__state != null) {
+    if (_stateField != null) {
       notifyListeners();
     }
   }

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -334,8 +334,7 @@ class FeedbackModel with ChangeNotifier {
 
   Future<void> returnToAppPostSubmit() async {
     if (submitted == false) return;
-    await _services.backdropController.animateToClosed();
-    _services.discardFeedback();
+    await _services.wiredashModel.hide(discardFeedback: true);
   }
 
   Future<PersistedFeedbackItem> createFeedback() async {

--- a/lib/src/feedback/picasso/picasso.dart
+++ b/lib/src/feedback/picasso/picasso.dart
@@ -83,6 +83,10 @@ class _PicassoState extends State<Picasso> {
   }
 
   Widget _buildAllPreviousStrokes(BuildContext context) {
+    // 98.2% useful based on metrics in Flutter Inspector 👌
+    // Diagnosis:
+    // > this is an outstandingly useful repaint boundary and should
+    // > definitely be kept
     return RepaintBoundary(
       child: SizedBox.expand(
         child: StreamBuilder<List<Stroke?>>(

--- a/lib/src/feedback/wiredash_model.dart
+++ b/lib/src/feedback/wiredash_model.dart
@@ -77,7 +77,7 @@ class WiredashModel with ChangeNotifier {
     isWiredashActive = true;
 
     // wait for backdropController to have a valid state
-    await postFrameCallbackStream()
+    await _postFrameCallbackStream()
         .map((element) => services.backdropController.hasState)
         .firstWhere((element) => element);
 
@@ -126,7 +126,7 @@ class _DisposableValueNotifier<T> extends ValueNotifier<T> {
   }
 }
 
-Stream<Duration> postFrameCallbackStream() async* {
+Stream<Duration> _postFrameCallbackStream() async* {
   while (true) {
     final completer = Completer<Duration>();
     WidgetsBinding.instance!.addPostFrameCallback((Duration timestamp) {

--- a/lib/src/feedback/wiredash_model.dart
+++ b/lib/src/feedback/wiredash_model.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/common/options/feedback_options.dart';
 import 'package:wiredash/src/common/services/services.dart';
@@ -33,6 +34,16 @@ class WiredashModel with ChangeNotifier {
     notifyListeners();
   }
 
+  bool _isWiredashActive = false;
+
+  /// True when wiredash is opening/open/closing
+  bool get isWiredashActive => _isWiredashActive;
+
+  set isWiredashActive(bool isWiredashActive) {
+    _isWiredashActive = isWiredashActive;
+    notifyListeners();
+  }
+
   /// Temporary theme that overrides the `Wiredash.theme` property for the
   /// current 'show' session
   ///
@@ -61,13 +72,22 @@ class WiredashModel with ChangeNotifier {
 
   /// Opens wiredash behind the app
   Future<void> show() async {
-    if (services.backdropController.isWiredashActive) return;
+    if (isWiredashActive) return;
+
+    isWiredashActive = true;
+
+    // wait for backdropController to have a valid state
+    await postFrameCallbackStream()
+        .map((element) => services.backdropController.hasState)
+        .firstWhere((element) => element);
+
     await services.backdropController.animateToOpen();
   }
 
   /// Closes wiredash
   Future<void> hide({bool discardFeedback = false}) async {
     await services.backdropController.animateToClosed();
+    isWiredashActive = false;
     if (discardFeedback) {
       services.discardFeedback();
     }
@@ -103,5 +123,15 @@ class _DisposableValueNotifier<T> extends ValueNotifier<T> {
   void dispose() {
     onDispose();
     super.dispose();
+  }
+}
+
+Stream<Duration> postFrameCallbackStream() async* {
+  while (true) {
+    final completer = Completer<Duration>();
+    WidgetsBinding.instance!.addPostFrameCallback((Duration timestamp) {
+      completer.complete(timestamp);
+    });
+    yield await completer.future;
   }
 }


### PR DESCRIPTION
Wiredash creates a quite big widget tree wrapping your app (All widgets are necessary). This change reduces the widgets wrapping your app to just 2 (`Wiredash` and `KeyedSubtree`) while Wiredash is closed

This change resulted in much better performance of the wrapped app of one of our customers on low-end devices (iPhone SE).

Also fixes #181 

## Technical details

It was quite challenging because `Wiredash.of(context).show()` is now delayed by 1 frame, allowing us to wrap the app in `WiredashBackdrop` allowing us to animate it.
 