### PR TITLE
Fix double / partial feedback submit

### DIFF
--- a/lib/src/common/device_info/device_info.dart
+++ b/lib/src/common/device_info/device_info.dart
@@ -1,7 +1,8 @@
-import 'dart:ui' show Brightness, WindowPadding;
+import 'dart:ui' show Brightness;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:wiredash/src/feedback/data/pending_feedback_item.dart';
 
 export 'dart:ui' show Brightness;
 
@@ -25,7 +26,7 @@ class FlutterDeviceInfo {
   /// Area not covered with system UI
   ///
   /// https://api.flutter.dev/flutter/dart-ui/FlutterView/padding.html
-  final WindowPadding padding;
+  final WiredashWindowPadding padding;
 
   /// The dimensions of the rectangle into which the scene rendered in this
   /// view will be drawn on the screen, in physical pixels.
@@ -71,13 +72,13 @@ class FlutterDeviceInfo {
   final double textScaleFactor;
 
   /// https://api.flutter.dev/flutter/dart-ui/FlutterView/viewInsets.html
-  final WindowPadding viewInsets;
+  final WiredashWindowPadding viewInsets;
 
   /// Area where Android does not intercept i.e. for the back button gesture
   /// (swipe from the side of the screen)
   ///
   /// https://api.flutter.dev/flutter/dart-ui/FlutterView/systemGestureInsets.html
-  final WindowPadding gestureInsets;
+  final WiredashWindowPadding gestureInsets;
 
   /// When in web, the full user agent String of the browser
   ///
@@ -105,7 +106,7 @@ class FlutterDeviceInfo {
     String? deviceId,
     String? platformLocale,
     List<String>? platformSupportedLocales,
-    WindowPadding? padding,
+    WiredashWindowPadding? padding,
     Size? physicalSize,
     Rect? physicalGeometry,
     double? pixelRatio,
@@ -113,10 +114,10 @@ class FlutterDeviceInfo {
     String? platformOSVersion,
     String? platformVersion,
     double? textScaleFactor,
-    WindowPadding? viewInsets,
+    WiredashWindowPadding? viewInsets,
     String? userAgent,
     Brightness? platformBrightness,
-    WindowPadding? gestureInsets,
+    WiredashWindowPadding? gestureInsets,
   }) {
     return FlutterDeviceInfo(
       platformLocale: platformLocale ?? this.platformLocale,

--- a/lib/src/common/device_info/device_info_generator.dart
+++ b/lib/src/common/device_info/device_info_generator.dart
@@ -7,6 +7,7 @@ import 'package:wiredash/src/common/device_info/device_info.dart';
 import 'package:wiredash/src/common/device_info/device_info_generator_stub.dart'
     if (dart.library.html) 'package:wiredash/src/common/device_info/dart_html_device_info_generator.dart'
     if (dart.library.io) 'package:wiredash/src/common/device_info/dart_io_device_info_generator.dart';
+import 'package:wiredash/src/feedback/data/pending_feedback_item.dart';
 
 abstract class DeviceInfoGenerator {
   /// Loads a [DeviceInfoGenerator] based on the environment by calling the
@@ -35,14 +36,15 @@ abstract class DeviceInfoGenerator {
       platformLocale: windowLocale().toLanguageTag(),
       platformSupportedLocales:
           windowLocales().map((it) => it.toLanguageTag()).toList(),
-      padding: window.padding,
+      padding: WiredashWindowPadding.fromWindowPadding(window.padding),
       physicalSize: window.physicalSize,
       physicalGeometry: window.physicalGeometry,
       pixelRatio: window.devicePixelRatio,
       textScaleFactor: window.textScaleFactor,
-      viewInsets: window.viewInsets,
+      viewInsets: WiredashWindowPadding.fromWindowPadding(window.viewInsets),
       platformBrightness: window.platformBrightness,
-      gestureInsets: window.systemGestureInsets,
+      gestureInsets:
+          WiredashWindowPadding.fromWindowPadding(window.systemGestureInsets),
     );
   }
 

--- a/lib/src/feedback/data/pending_feedback_item.dart
+++ b/lib/src/feedback/data/pending_feedback_item.dart
@@ -300,7 +300,8 @@ extension _SerializeDeviceInfo on FlutterDeviceInfo {
   }
 }
 
-/// [WindowPadding] doesn't offer a public constructor
+/// [WindowPadding] doesn't offer a public constructor and doesn't implement
+/// ==() and hashCode
 class WiredashWindowPadding implements WindowPadding {
   const WiredashWindowPadding({
     required this.left,
@@ -315,6 +316,15 @@ class WiredashWindowPadding implements WindowPadding {
       top: (json[1] as num).toDouble(),
       right: (json[2] as num).toDouble(),
       bottom: (json[3] as num).toDouble(),
+    );
+  }
+
+  factory WiredashWindowPadding.fromWindowPadding(WindowPadding padding) {
+    return WiredashWindowPadding(
+      left: padding.left,
+      top: padding.top,
+      right: padding.right,
+      bottom: padding.bottom,
     );
   }
 

--- a/lib/src/feedback/data/pending_feedback_item_storage.dart
+++ b/lib/src/feedback/data/pending_feedback_item_storage.dart
@@ -146,18 +146,25 @@ class PendingFeedbackItemStorage {
       list.remove(removed);
       list.add(item);
 
-      final oldDiskAttachments = removed.feedbackItem.attachments
-          .where((element) => element.file.isOnDisk);
+      final List<PersistedAttachment> oldDiskAttachments = removed
+          .feedbackItem.attachments
+          .where((element) => element.file.isOnDisk)
+          .toList();
       final newDiskAttachments = item.feedbackItem.attachments
-          .where((element) => element.file.isOnDisk);
+          .where((element) => element.file.isOnDisk)
+          .toList();
       final uploaded = oldDiskAttachments
           .where((element) => !newDiskAttachments.contains(element))
           .toList();
+
+      print("Old: ${oldDiskAttachments}");
+      print("New: ${newDiskAttachments}");
 
       /// Delete local files of attachments that have been uploaded
       for (final u in uploaded) {
         final screenshot = _fs.file(u.file.pathToFile);
         if (await screenshot.exists()) {
+          print("Deleting $screenshot");
           await screenshot.delete();
         }
       }

--- a/lib/src/feedback/data/pending_feedback_item_storage.dart
+++ b/lib/src/feedback/data/pending_feedback_item_storage.dart
@@ -157,14 +157,10 @@ class PendingFeedbackItemStorage {
           .where((element) => !newDiskAttachments.contains(element))
           .toList();
 
-      print("Old: ${oldDiskAttachments}");
-      print("New: ${newDiskAttachments}");
-
       /// Delete local files of attachments that have been uploaded
       for (final u in uploaded) {
         final screenshot = _fs.file(u.file.pathToFile);
         if (await screenshot.exists()) {
-          print("Deleting $screenshot");
           await screenshot.delete();
         }
       }

--- a/lib/src/feedback/data/retrying_feedback_submitter.dart
+++ b/lib/src/feedback/data/retrying_feedback_submitter.dart
@@ -137,13 +137,13 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
           PersistedAttachment oldAttachment,
           PersistedAttachment? update,
         ) async {
-          final atts = item.feedbackItem.attachments.toList()
+          final atts = copy.feedbackItem.attachments.toList()
             ..remove(oldAttachment);
           if (update != null) {
             atts.add(update);
           }
-          copy = item.copyWith(
-            feedbackItem: item.feedbackItem.copyWith(attachments: atts),
+          copy = copy.copyWith(
+            feedbackItem: copy.feedbackItem.copyWith(attachments: atts),
           );
 
           await _pendingFeedbackItemStorage.updatePendingItem(copy);
@@ -191,7 +191,10 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
         await _api.sendFeedback(copy.feedbackItem);
 
         // ignore: avoid_print
-        print('Feedback submitted ✌️ ${item.feedbackItem.message}');
+        print(
+          'Feedback with ${copy.feedbackItem.attachments.length} screenshots submitted ✌️\n'
+          'message: ${copy.feedbackItem.message}',
+        );
         await _pendingFeedbackItemStorage.clearPendingItem(item.id);
         break;
       } on UnauthenticatedWiredashApiException catch (e, stack) {

--- a/lib/src/feedback/ui/steps/step_3_screenshot_overview.dart
+++ b/lib/src/feedback/ui/steps/step_3_screenshot_overview.dart
@@ -123,7 +123,7 @@ class Step3WithGallery extends StatelessWidget {
                   for (final att in context.feedbackModel.attachments)
                     Padding(
                       padding: const EdgeInsets.only(right: 16),
-                      child: _Attachment(attachment: att),
+                      child: AttachmentPreview(attachment: att),
                     ),
                   if (context.feedbackModel.attachments.length < 3)
                     const _NewAttachment(),
@@ -154,8 +154,8 @@ class Step3WithGallery extends StatelessWidget {
   }
 }
 
-class _Attachment extends StatelessWidget {
-  const _Attachment({
+class AttachmentPreview extends StatelessWidget {
+  const AttachmentPreview({
     Key? key,
     required this.attachment,
   }) : super(key: key);

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -3,6 +3,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/feedback/data/persisted_feedback_item.dart';
+import 'package:wiredash/src/feedback/ui/steps/step_3_screenshot_overview.dart';
 import 'package:wiredash/wiredash.dart';
 
 import 'util/mock_api.dart';
@@ -56,6 +57,34 @@ void main() {
       expect(submittedFeedback, isNotNull);
       expect(submittedFeedback!.message, 'test message');
       expect(submittedFeedback.attachments, hasLength(1));
+    });
+
+    testWidgets('Send feedback with multiple screenshots', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(tester);
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.enterScreenshotMode();
+      await robot.takeScreenshot();
+      await robot.confirmDrawing();
+      await robot.enterScreenshotMode();
+      await robot.takeScreenshot();
+      await robot.confirmDrawing();
+      expect(find.byType(AttachmentPreview), findsNWidgets(2));
+      await robot.goToNextStep();
+      await robot.submitFeedback();
+      await tester.waitUntil(
+        find.text('Thanks for your feedback!'),
+        findsOneWidget,
+      );
+      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback, isNotNull);
+      expect(submittedFeedback!.message, 'test message');
+      expect(submittedFeedback.attachments, hasLength(2));
     });
 
     testWidgets('Send feedback with labels', (tester) async {

--- a/test/util/mock_api.dart
+++ b/test/util/mock_api.dart
@@ -24,6 +24,8 @@ class MockWiredashApi implements WiredashApi {
     String? filename,
     MediaType? contentType,
   }) async {
-    return AttachmentId(Random().nextDouble().toString());
+    return AttachmentId(
+      Random().nextDouble().toString().replaceFirst('0.', ''),
+    );
   }
 }

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -206,8 +206,15 @@ class WiredashTestRobot {
 
   Future<void> enterScreenshotMode() async {
     expect(find.byType(Step3ScreenshotOverview), findsOneWidget);
-    expect(find.byType(Step3NotAttachments), findsOneWidget);
-    await tester.tap(find.text('Add screenshot'));
+    final noAttachemntsResult =
+        find.byType(Step3NotAttachments).evaluate().toList();
+    if (noAttachemntsResult.isNotEmpty) {
+      expect(find.byType(Step3NotAttachments), findsOneWidget);
+      await tester.tap(find.text('Add screenshot'));
+    } else {
+      expect(find.byType(Step3WithGallery), findsOneWidget);
+      await tester.tap(find.byIcon(Wirecons.plus), warnIfMissed: false);
+    }
 
     await tester.waitUntil(find.byType(ScreenshotBar), findsOneWidget);
     await tester.waitUntil(find.byIcon(Wirecons.camera), findsOneWidget);


### PR DESCRIPTION
Sometimes a feedback is submitted with just 1/3 screenshots. It then also may happen that a feedback is submitted multiple times to the backend. (Tested with `1.0.0-alpha.5` on macos)

- Fix updating the pending item while uploading a screenshot
- Always use WiredashWindowPadding which is comparable. PersistedFeedbackItems are now equals after serialize/dezerialize
- `RetryingFeedbackSubmitter#updateAttachment` now updates `copy` instead of `item`

Hopefully fixes #186