### PR TITLE
Restore state when closing - reopening Wiredash

### DIFF
--- a/lib/src/feedback/feedback_flow.dart
+++ b/lib/src/feedback/feedback_flow.dart
@@ -21,6 +21,13 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
   int _index = 0;
 
   @override
+  void initState() {
+    super.initState();
+    _index =
+        FeedbackModelProvider.of(context, listen: false).currentStepIndex ?? 0;
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_index >= context.feedbackModel.steps.length) {

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -45,7 +45,7 @@ void main() {
 
       // Pressing next shows error
       await robot.goToNextStep();
-      selectByType(LarryPageView)
+      larryPageView
           .childByType(Step1FeedbackMessage)
           .text('Please enter a feedback message')
           .existsOnce();
@@ -54,12 +54,8 @@ void main() {
       await robot.enterFeedbackMessage('test message');
       await robot.goToNextStep();
 
-      selectByType(LarryPageView)
-          .childByType(Step1FeedbackMessage)
-          .doesNotExist();
-      selectByType(LarryPageView)
-          .childByType(Step3ScreenshotOverview)
-          .existsOnce();
+      larryPageView.childByType(Step1FeedbackMessage).doesNotExist();
+      larryPageView.childByType(Step3ScreenshotOverview).existsOnce();
     });
 
     testWidgets('Send feedback with screenshot', (tester) async {
@@ -218,5 +214,24 @@ void main() {
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback!.message, 'test message');
     });
+
+    testWidgets('Restore flow state when reopening', (tester) async {
+      final robot = await WiredashTestRobot.launchApp(tester);
+      final mockApi = MockWiredashApi();
+      robot.mockWiredashApi(mockApi);
+
+      await robot.openWiredash();
+      await robot.enterFeedbackMessage('test message');
+      await robot.goToNextStep();
+      await robot.skipScreenshot();
+      larryPageView.childByType(Step6Submit).existsOnce();
+
+      await robot.closeWiredash();
+      await robot.openWiredash();
+      larryPageView.childByType(Step6Submit).existsOnce();
+    });
   });
 }
+
+final larryPageView =
+    selectByType(WiredashFeedbackFlow).childByType(LarryPageView);


### PR DESCRIPTION
There has been reports of crashes - see below - that where caused by the feedback flow not reflecting the actual state when reopening wiredash. This is now fixed. Added a test for it

```
When the exception was thrown, this was the stack: 
#0      FeedbackModel.goToNextStep (package:wiredash/src/feedback/feedback_model.dart:197:7)
#1      _TronButtonState._handleTapUp (package:wiredash/src/core/widgets/tron/tron_button.dart:212:19)
#2      TapGestureRecognizer.handleTapUp.<anonymous closure> (package:flutter/src/gestures/tap.dart:611:57)
#3      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:198:24)
#4      TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:611:11)
#5      BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:298:5)
#6      BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:269:7)
#7      GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:157:27)
#8      GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:443:20)
#9      GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:419:22)
#10     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:322:11)
#11     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:374:7)
#12     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:338:5)
#13     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:296:7)
#14     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:279:7)
#18     _invoke1 (dart:ui/hooks.dart:170:10)
#19     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:331:7)
#20     _dispatchPointerDataPacket (dart:ui/hooks.dart:94:31)
```