### PR TITLE
Fix "Warning: Missing asset in fonts for Inter"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,11 +54,11 @@ flutter:
     - family: Inter
       fonts:
         - asset: lib/assets/fonts/Inter-Regular.ttf
-        - weight: 400
+          weight: 400
         - asset: lib/assets/fonts/Inter-SemiBold.ttf
-        - weight: 600
+          weight: 600
         - asset: lib/assets/fonts/Inter-Bold.ttf
-        - weight: 700
+          weight: 700
     - family: Wirecons
       fonts:
         - asset: lib/assets/fonts/Wirecons.ttf


### PR DESCRIPTION
There has been an annoying warning when building an app, including wiredash.

![Screen-Shot-2022-04-22-01-08-03 61](https://user-images.githubusercontent.com/1096485/164565617-653b5fbb-96a8-45a6-8506-d4b55bc0e0a7.png)
 
Sorry for that, my YAML is no good 😬