### PR TITLE
Rework automatic theming

### DIFF
--- a/example/lib/main_customizer.dart
+++ b/example/lib/main_customizer.dart
@@ -117,6 +117,12 @@ class _CustomizePageState extends State<CustomizePage> {
                         screen: Wiredash(
                           projectId: "Project ID from console.wiredash.io",
                           secret: "API Key from console.wiredash.io",
+                          feedbackOptions: WiredashFeedbackOptions(
+                            labels: [
+                              Label(id: 'asdf', title: 'Bug'),
+                              Label(id: 'qwer', title: 'Feature Request'),
+                            ],
+                          ),
                           theme: WiredashThemeData(
                             brightness: context
                                 .findAncestorStateOfType<_CustomizerAppState>()!
@@ -187,6 +193,10 @@ class ThemeModel extends ChangeNotifier {
   late final ColorModel secondaryBackground;
   late final ColorModel appBackground;
   late final ColorModel appHandleBackground;
+  late final ColorModel primaryContainerColor;
+  late final ColorModel textOnPrimaryContainerColor;
+  late final ColorModel secondaryContainerColor;
+  late final ColorModel textOnSecondaryContainerColor;
 
   static ThemeModel of(BuildContext context, {bool listen = true}) {
     if (listen) {
@@ -227,6 +237,22 @@ class ThemeModel extends ChangeNotifier {
       notifyListeners: notifyListeners,
       autoColor: () => autoThemeData.appHandleBackgroundColor,
     );
+    primaryContainerColor = ColorModel(
+      notifyListeners: notifyListeners,
+      autoColor: () => autoThemeData.primaryContainerColor,
+    );
+    textOnPrimaryContainerColor = ColorModel(
+      notifyListeners: notifyListeners,
+      autoColor: () => autoThemeData.primaryTextOnBackgroundColor,
+    );
+    secondaryContainerColor = ColorModel(
+      notifyListeners: notifyListeners,
+      autoColor: () => autoThemeData.secondaryContainerColor,
+    );
+    textOnSecondaryContainerColor = ColorModel(
+      notifyListeners: notifyListeners,
+      autoColor: () => autoThemeData.textOnSecondaryContainerColor,
+    );
     resetToDefaults();
   }
 
@@ -246,6 +272,18 @@ class ThemeModel extends ChangeNotifier {
     }
     if (!appHandleBackground.hasBeenManuallyAdjusted) {
       appHandleBackground.color = auto.appHandleBackgroundColor;
+    }
+    if (!primaryContainerColor.hasBeenManuallyAdjusted) {
+      primaryContainerColor.color = auto.primaryContainerColor;
+    }
+    if (!textOnPrimaryContainerColor.hasBeenManuallyAdjusted) {
+      textOnPrimaryContainerColor.color = auto.primaryTextOnBackgroundColor;
+    }
+    if (!secondaryContainerColor.hasBeenManuallyAdjusted) {
+      secondaryContainerColor.color = auto.secondaryContainerColor;
+    }
+    if (!textOnSecondaryContainerColor.hasBeenManuallyAdjusted) {
+      textOnSecondaryContainerColor.color = auto.secondaryTextOnBackgroundColor;
     }
   }
 
@@ -267,6 +305,10 @@ class ThemeModel extends ChangeNotifier {
     secondaryBackground.reset();
     appBackground.reset();
     appHandleBackground.reset();
+    primaryContainerColor.reset();
+    textOnPrimaryContainerColor.reset();
+    secondaryContainerColor.reset();
+    textOnSecondaryContainerColor.reset();
   }
 }
 
@@ -480,6 +522,73 @@ class _ThemeControlsState extends State<ThemeControls> {
                   padding: const EdgeInsets.only(top: 8.0),
                   child: WiredashColorPicker.bindColorModel(
                     model: context.watchThemeModel.appHandleBackground,
+                    withAlpha: true,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 20),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SelectableText(
+                  'primaryContainerColor',
+                  style: GoogleFonts.droidSansMono(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: WiredashColorPicker.bindColorModel(
+                    model: context.watchThemeModel.primaryContainerColor,
+                    withAlpha: true,
+                  ),
+                ),
+              ],
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SelectableText(
+                  'textOnPrimaryContainerColor',
+                  style: GoogleFonts.droidSansMono(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: WiredashColorPicker.bindColorModel(
+                    model: context.watchThemeModel.textOnPrimaryContainerColor,
+                    withAlpha: true,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 20),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SelectableText(
+                  'secondaryContainerColor',
+                  style: GoogleFonts.droidSansMono(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: WiredashColorPicker.bindColorModel(
+                    model: context.watchThemeModel.secondaryContainerColor,
+                    withAlpha: true,
+                  ),
+                ),
+              ],
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SelectableText(
+                  'secondaryTextOnBackgroundColor',
+                  style: GoogleFonts.droidSansMono(),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: WiredashColorPicker.bindColorModel(
+                    model:
+                        context.watchThemeModel.textOnSecondaryContainerColor,
                     withAlpha: true,
                   ),
                 ),

--- a/example/lib/main_customizer.dart
+++ b/example/lib/main_customizer.dart
@@ -468,6 +468,21 @@ class _WiredashColorPickerState extends State<WiredashColorPicker> {
     super.initState();
     _textEditingController =
         TextEditingController(text: colorToHex(widget.color));
+
+    _textEditingController.addListener(() {
+      final color = colorFromHex(_textEditingController.text);
+      if (color != null) {
+        widget.onColorChanged(color);
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(WiredashColorPicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.color != widget.color) {
+      _textEditingController.text = colorToHex(widget.color);
+    }
   }
 
   @override

--- a/example/lib/main_customizer.dart
+++ b/example/lib/main_customizer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:wiredash/wiredash.dart';
 import 'package:wiredash_example/marianos_clones/whatsapp_clone.dart';
 
@@ -96,6 +97,25 @@ class ThemeModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  Color _primaryBackgroundColor = WiredashThemeData().primaryBackgroundColor;
+
+  Color get primaryBackgroundColor => _primaryBackgroundColor;
+
+  set primaryBackgroundColor(Color primaryBackgroundCColor) {
+    _primaryBackgroundColor = primaryBackgroundCColor;
+    notifyListeners();
+  }
+
+  Color _secondaryBackgroundColor =
+      WiredashThemeData().secondaryBackgroundColor;
+
+  Color get secondaryBackgroundColor => _secondaryBackgroundColor;
+
+  set secondaryBackgroundColor(Color secondaryBackgroundColor) {
+    _secondaryBackgroundColor = secondaryBackgroundColor;
+    notifyListeners();
+  }
+
   static ThemeModel of(BuildContext context, {bool listen = true}) {
     if (listen) {
       return context
@@ -123,47 +143,135 @@ extension on BuildContext {
   ThemeModel get readThemeModel => ThemeModel.of(this, listen: false);
 }
 
-class ThemeControls extends StatelessWidget {
+class ThemeControls extends StatefulWidget {
   const ThemeControls({Key? key}) : super(key: key);
 
   @override
+  State<ThemeControls> createState() => _ThemeControlsState();
+}
+
+class _ThemeControlsState extends State<ThemeControls> {
+  @override
   Widget build(BuildContext context) {
+    _entry.markNeedsBuild();
     return Overlay(
-      initialEntries: [
-        OverlayEntry(
-          builder: (context) {
-            return Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('Primary Color'),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 8.0),
-                    child: WiredashColorPicker(
-                      color: context.watchThemeModel.primaryColor,
-                      onColorChanged: (color) {
-                        context.readThemeModel.primaryColor = color;
-                      },
-                    ),
+      initialEntries: [_entry],
+    );
+  }
+
+  late final _entry = OverlayEntry(builder: _buildEntryContent);
+
+  Widget _buildEntryContent(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SelectableText('Base Colors', style: TextStyle(fontSize: 20)),
+            SizedBox(height: 20),
+            Wrap(
+              spacing: 20,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SelectableText(
+                        'primaryColor',
+                        style: GoogleFonts.droidSansMono(),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: WiredashColorPicker(
+                          color: context.watchThemeModel.primaryColor,
+                          onColorChanged: (color) {
+                            context.readThemeModel.primaryColor = color;
+                          },
+                        ),
+                      ),
+                    ],
                   ),
-                  SizedBox(height: 20),
-                  Text('Secondary Color'),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 8.0),
-                    child: WiredashColorPicker(
-                      color: context.watchThemeModel.secondaryColor,
-                      onColorChanged: (color) {
-                        context.readThemeModel.secondaryColor = color;
-                      },
-                    ),
+                ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SelectableText(
+                        'secondaryColor',
+                        style: GoogleFonts.droidSansMono(),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: WiredashColorPicker(
+                          color: context.watchThemeModel.secondaryColor,
+                          onColorChanged: (color) {
+                            context.readThemeModel.secondaryColor = color;
+                          },
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            );
-          },
+                ),
+              ],
+            ),
+            SizedBox(height: 40),
+            SelectableText('Background Colors', style: TextStyle(fontSize: 20)),
+            SizedBox(height: 20),
+            Wrap(
+              spacing: 20,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SelectableText(
+                        'primaryBackgroundColor',
+                        style: GoogleFonts.droidSansMono(),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: WiredashColorPicker(
+                          withAlpha: true,
+                          color: context.watchThemeModel.primaryBackgroundColor,
+                          onColorChanged: (color) {
+                            context.readThemeModel.primaryBackgroundColor =
+                                color;
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SelectableText(
+                        'secondaryBackgroundColor',
+                        style: GoogleFonts.droidSansMono(),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: WiredashColorPicker(
+                          withAlpha: true,
+                          color:
+                              context.watchThemeModel.secondaryBackgroundColor,
+                          onColorChanged: (color) {
+                            context.readThemeModel.secondaryBackgroundColor =
+                                color;
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 20),
+          ],
         ),
-      ],
+      ),
     );
   }
 }
@@ -173,10 +281,12 @@ class WiredashColorPicker extends StatefulWidget {
     Key? key,
     required this.color,
     required this.onColorChanged,
+    this.withAlpha = false,
   }) : super(key: key);
 
   final Color color;
   final void Function(Color) onColorChanged;
+  final bool withAlpha;
 
   @override
   State<WiredashColorPicker> createState() => _WiredashColorPickerState();
@@ -215,16 +325,28 @@ class _WiredashColorPickerState extends State<WiredashColorPicker> {
                 SizedBox(
                   height: 32,
                   width: 50,
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(4),
-                    child: Material(
-                      color: widget.color,
+                  child: Material(
+                    elevation: 5,
+                    color: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
                       child: InkWell(
                         onTap: () {
                           openColorPicker();
                         },
-                        highlightColor: widget.color.withAlpha(20),
-                        child: Container(),
+                        child: Stack(
+                          children: [
+                            Positioned.fill(
+                              child: const CustomPaint(
+                                painter: CheckerPainter(),
+                              ),
+                            ),
+                            Container(color: widget.color),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -287,7 +409,7 @@ class _WiredashColorPickerState extends State<WiredashColorPicker> {
                         colorPickerWidth: 200,
                         portraitOnly: true,
                         pickerAreaHeightPercent: 0.7,
-                        enableAlpha: false,
+                        enableAlpha: widget.withAlpha,
                         displayThumbColor: true,
                         hexInputController: _textEditingController,
                         pickerColor: widget.color,
@@ -353,6 +475,10 @@ class DeviceFrame extends StatelessWidget {
                       theme: WiredashThemeData(
                         primaryColor: context.watchThemeModel.primaryColor,
                         secondaryColor: context.watchThemeModel.secondaryColor,
+                        primaryBackgroundColor:
+                            context.watchThemeModel.primaryBackgroundColor,
+                        secondaryBackgroundColor:
+                            context.watchThemeModel.secondaryBackgroundColor,
                       ),
                       child: child,
                     ),

--- a/example/lib/main_customizer.dart
+++ b/example/lib/main_customizer.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:wiredash/wiredash.dart';
+import 'package:wiredash_example/marianos_clones/whatsapp_clone.dart';
+
+void main() {
+  runApp(const CustomizerApp());
+}
+
+class CustomizerApp extends StatelessWidget {
+  const CustomizerApp();
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      color: Colors.lightBlue,
+      theme: ThemeData.light().copyWith(
+        primaryColor: Colors.lightBlue,
+      ),
+      home: const CustomizePage(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+class CustomizePage extends StatefulWidget {
+  const CustomizePage({Key? key}) : super(key: key);
+
+  @override
+  State<CustomizePage> createState() => _CustomizePageState();
+}
+
+class _CustomizePageState extends State<CustomizePage> {
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    return Scaffold(
+      body: MinSize(
+        minWidth: 800,
+        child: Row(
+          children: [
+            Expanded(
+              child: Container(
+                color: Colors.white,
+                child: ThemeControls(),
+              ),
+            ),
+            Material(
+              elevation: 4,
+              color: Colors.white,
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  right: 10,
+                  left: 16,
+                  top: 8,
+                  bottom: 8,
+                ),
+                child: DeviceFrame(
+                  child: WhatsApp(),
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ThemeControls extends StatelessWidget {
+  const ThemeControls({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Primary Color'),
+        ],
+      ),
+    );
+  }
+}
+
+class DeviceFrame extends StatelessWidget {
+  const DeviceFrame({
+    Key? key,
+    required this.child,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 400,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(26),
+        color: Colors.black,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.only(
+          top: 22,
+          bottom: 16,
+          left: 10,
+          right: 10,
+        ),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            color: Colors.white,
+          ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return MediaQuery(
+                data: MediaQuery.of(context).copyWith(
+                  size: Size(
+                    constraints.maxWidth,
+                    constraints.maxHeight,
+                  ),
+                ),
+                child: PrimaryScrollController(
+                  controller: ScrollController(),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(16),
+                    child: Wiredash(
+                      projectId: "Project ID from console.wiredash.io",
+                      secret: "API Key from console.wiredash.io",
+                      child: child,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Starts scrolling [child] vertically and horizontally when the widget sizes
+/// reaches below [minWidth] or [minHeight]
+class MinSize extends StatefulWidget {
+  const MinSize({
+    Key? key,
+    this.minWidth,
+    this.minHeight,
+    required this.child,
+  }) : super(key: key);
+
+  final Widget child;
+
+  final double? minWidth;
+
+  final double? minHeight;
+
+  @override
+  State<MinSize> createState() => _MinSizeState();
+}
+
+class _MinSizeState extends State<MinSize> {
+  late final _verticalController = ScrollController();
+  late final _horizontalController = ScrollController();
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shouldScrollVertical = widget.minHeight != null &&
+            constraints.maxHeight <= widget.minHeight!;
+        final contentHeight =
+            shouldScrollVertical ? widget.minHeight : constraints.maxHeight;
+        final verticalPhysics = shouldScrollVertical
+            ? const AlwaysScrollableScrollPhysics()
+            : const NeverScrollableScrollPhysics();
+
+        final shouldScrollHorizontal =
+            widget.minWidth != null && constraints.maxWidth <= widget.minWidth!;
+        final contentWidth =
+            shouldScrollHorizontal ? widget.minWidth : constraints.maxWidth;
+        final horizontalPhysics = shouldScrollHorizontal
+            ? const AlwaysScrollableScrollPhysics()
+            : const NeverScrollableScrollPhysics();
+
+        return Scrollbar(
+          controller: _verticalController,
+          thumbVisibility: shouldScrollVertical,
+          child: SingleChildScrollView(
+            controller: _verticalController,
+            scrollDirection: Axis.vertical,
+            physics: verticalPhysics,
+            child: Scrollbar(
+              interactive: true,
+              controller: _horizontalController,
+              thumbVisibility: shouldScrollHorizontal,
+              child: SingleChildScrollView(
+                controller: _horizontalController,
+                scrollDirection: Axis.horizontal,
+                physics: horizontalPhysics,
+                child: UnconstrainedBox(
+                  child: SizedBox(
+                    height: contentHeight,
+                    width: contentWidth,
+                    child: widget.child,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/example/lib/main_customizer.dart
+++ b/example/lib/main_customizer.dart
@@ -138,6 +138,16 @@ class _CustomizePageState extends State<CustomizePage> {
                                 context.watchThemeModel.appBackground.color,
                             appHandleBackgroundColor: context
                                 .watchThemeModel.appHandleBackground.color,
+                            primaryContainerColor: context
+                                .watchThemeModel.primaryContainerColor.color,
+                            textOnPrimaryContainerColor: context.watchThemeModel
+                                .textOnPrimaryContainerColor.color,
+                            secondaryContainerColor: context
+                                .watchThemeModel.secondaryContainerColor.color,
+                            textOnSecondaryContainerColor: context
+                                .watchThemeModel
+                                .textOnSecondaryContainerColor
+                                .color,
                           ),
                           child: WhatsApp(),
                         ),
@@ -447,14 +457,86 @@ class _ThemeControlsState extends State<ThemeControls> {
             SizedBox(height: 20),
             Divider(),
             SizedBox(height: 20),
-            SelectableText('Background Colors', style: TextStyle(fontSize: 20)),
+            SelectableText('Swatches', style: TextStyle(fontSize: 20)),
             SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                context.readThemeModel.autoGenerate();
-              },
-              child: Text('Auto-generate'),
+            Wrap(
+              spacing: 20,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'primaryContainerColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker.bindColorModel(
+                        model: context.watchThemeModel.primaryContainerColor,
+                        withAlpha: true,
+                      ),
+                    ),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'textOnPrimaryContainerColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker.bindColorModel(
+                        model:
+                            context.watchThemeModel.textOnPrimaryContainerColor,
+                        withAlpha: true,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
             ),
+            Wrap(
+              spacing: 20,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'secondaryContainerColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker.bindColorModel(
+                        model: context.watchThemeModel.secondaryContainerColor,
+                        withAlpha: true,
+                      ),
+                    ),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'secondaryTextOnBackgroundColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker.bindColorModel(
+                        model: context
+                            .watchThemeModel.textOnSecondaryContainerColor,
+                        withAlpha: true,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            SizedBox(height: 20),
+            SelectableText('Background Colors', style: TextStyle(fontSize: 20)),
             SizedBox(height: 20),
             Wrap(
               spacing: 20,
@@ -528,72 +610,6 @@ class _ThemeControlsState extends State<ThemeControls> {
               ],
             ),
             SizedBox(height: 20),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SelectableText(
-                  'primaryContainerColor',
-                  style: GoogleFonts.droidSansMono(),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
-                  child: WiredashColorPicker.bindColorModel(
-                    model: context.watchThemeModel.primaryContainerColor,
-                    withAlpha: true,
-                  ),
-                ),
-              ],
-            ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SelectableText(
-                  'textOnPrimaryContainerColor',
-                  style: GoogleFonts.droidSansMono(),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
-                  child: WiredashColorPicker.bindColorModel(
-                    model: context.watchThemeModel.textOnPrimaryContainerColor,
-                    withAlpha: true,
-                  ),
-                ),
-              ],
-            ),
-            SizedBox(height: 20),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SelectableText(
-                  'secondaryContainerColor',
-                  style: GoogleFonts.droidSansMono(),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
-                  child: WiredashColorPicker.bindColorModel(
-                    model: context.watchThemeModel.secondaryContainerColor,
-                    withAlpha: true,
-                  ),
-                ),
-              ],
-            ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SelectableText(
-                  'secondaryTextOnBackgroundColor',
-                  style: GoogleFonts.droidSansMono(),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
-                  child: WiredashColorPicker.bindColorModel(
-                    model:
-                        context.watchThemeModel.textOnSecondaryContainerColor,
-                    withAlpha: true,
-                  ),
-                ),
-              ],
-            ),
             SizedBox(height: 300),
           ],
         ),

--- a/example/lib/main_customizer.dart
+++ b/example/lib/main_customizer.dart
@@ -36,16 +36,17 @@ class _CustomizerAppState extends State<CustomizerApp> {
   @override
   void initState() {
     super.initState();
-    _lightModel.addListener(_lightUpdate);
+    _lightModel.addListener(_colorUpdate);
+    _darkModel.addListener(_colorUpdate);
   }
 
-  void _lightUpdate() {
-    _lightModel.autoGenerate();
-
+  void _colorUpdate() {
     // dark model
     if (!_darkModel.primary.hasBeenManuallyAdjusted) {
       _darkModel.primary.color = _lightModel.primary.color;
     }
+    _lightModel.autoGenerate();
+    _darkModel.autoGenerate();
   }
 
   @override

--- a/example/lib/main_customizer.dart
+++ b/example/lib/main_customizer.dart
@@ -228,7 +228,7 @@ class ThemeModel extends ChangeNotifier {
 
   void resetToDefaults() {
     final defaultData = WiredashThemeData.fromColor(
-      primaryColor: primaryColor,
+      primaryColor: WiredashThemeData().primaryColor,
       brightness: brightness,
     );
     primaryColor = defaultData.primaryColor;
@@ -285,45 +285,41 @@ class _ThemeControlsState extends State<ThemeControls> {
             Wrap(
               spacing: 20,
               children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SelectableText(
-                        'primaryColor',
-                        style: GoogleFonts.droidSansMono(),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'primaryColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker(
+                        color: context.watchThemeModel.primaryColor,
+                        onColorChanged: (color) {
+                          context.readThemeModel.primaryColor = color;
+                        },
                       ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8.0),
-                        child: WiredashColorPicker(
-                          color: context.watchThemeModel.primaryColor,
-                          onColorChanged: (color) {
-                            context.readThemeModel.primaryColor = color;
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SelectableText(
-                        'secondaryColor',
-                        style: GoogleFonts.droidSansMono(),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'secondaryColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker(
+                        color: context.watchThemeModel.secondaryColor,
+                        onColorChanged: (color) {
+                          context.readThemeModel.secondaryColor = color;
+                        },
                       ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8.0),
-                        child: WiredashColorPicker(
-                          color: context.watchThemeModel.secondaryColor,
-                          onColorChanged: (color) {
-                            context.readThemeModel.secondaryColor = color;
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -350,12 +346,6 @@ class _ThemeControlsState extends State<ThemeControls> {
               children: [
                 ElevatedButton(
                   onPressed: () {
-                    context.readThemeModel.autoGenerate();
-                  },
-                  child: Text('Auto-generate'),
-                ),
-                ElevatedButton(
-                  onPressed: () {
                     context.readThemeModel.resetToDefaults();
                   },
                   child: Text('Reset'),
@@ -367,53 +357,54 @@ class _ThemeControlsState extends State<ThemeControls> {
             SizedBox(height: 20),
             SelectableText('Background Colors', style: TextStyle(fontSize: 20)),
             SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                context.readThemeModel.autoGenerate();
+              },
+              child: Text('Auto-generate'),
+            ),
+            SizedBox(height: 20),
             Wrap(
               spacing: 20,
               children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SelectableText(
-                        'primaryBackgroundColor',
-                        style: GoogleFonts.droidSansMono(),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'primaryBackgroundColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker(
+                        withAlpha: true,
+                        color: context.watchThemeModel.primaryBackgroundColor,
+                        onColorChanged: (color) {
+                          context.readThemeModel.primaryBackgroundColor = color;
+                        },
                       ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8.0),
-                        child: WiredashColorPicker(
-                          withAlpha: true,
-                          color: context.watchThemeModel.primaryBackgroundColor,
-                          onColorChanged: (color) {
-                            context.readThemeModel.primaryBackgroundColor =
-                                color;
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SelectableText(
-                        'secondaryBackgroundColor',
-                        style: GoogleFonts.droidSansMono(),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SelectableText(
+                      'secondaryBackgroundColor',
+                      style: GoogleFonts.droidSansMono(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: WiredashColorPicker(
+                        withAlpha: true,
+                        color: context.watchThemeModel.secondaryBackgroundColor,
+                        onColorChanged: (color) {
+                          context.readThemeModel.secondaryBackgroundColor =
+                              color;
+                        },
                       ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8.0),
-                        child: WiredashColorPicker(
-                          withAlpha: true,
-                          color:
-                              context.watchThemeModel.secondaryBackgroundColor,
-                          onColorChanged: (color) {
-                            context.readThemeModel.secondaryBackgroundColor =
-                                color;
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/example/lib/main_netflix.dart
+++ b/example/lib/main_netflix.dart
@@ -4,9 +4,6 @@ import 'package:wiredash/wiredash.dart';
 import 'package:wiredash_example/marianos_clones/netflix_clone.dart';
 
 void main() {
-  /// NOTE: This example only works with flutter web
-  assert(kIsWeb);
-
   final app = Wiredash(
     projectId: "Project ID from console.wiredash.io",
     secret: "API Key from console.wiredash.io",

--- a/example/lib/main_whatsapp.dart
+++ b/example/lib/main_whatsapp.dart
@@ -6,9 +6,11 @@ void main() {
   final app = Wiredash(
     projectId: "Project ID from console.wiredash.io",
     secret: "API Key from console.wiredash.io",
-    theme: WiredashThemeData(
+    theme: WiredashThemeData.fromColor(
       primaryColor: WhatsappUtils.appBarMobile,
-      secondaryColor: WhatsappUtils.softGreen,
+      brightness: Brightness.light,
+    ).copyWith(
+      secondaryColor: Color(0xFFD6F5ED),
       primaryBackgroundColor: WhatsappUtils.chatBackground,
       secondaryBackgroundColor: WhatsappUtils.chatBackground2,
     ),

--- a/example/lib/marianos_clones/netflix_clone.dart
+++ b/example/lib/marianos_clones/netflix_clone.dart
@@ -17,6 +17,7 @@ class Netflix extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      useInheritedMediaQuery: true,
       debugShowCheckedModeBanner: false,
       home: InitScreen(),
       theme: ThemeData().copyWith(

--- a/example/lib/marianos_clones/whatsapp_clone.dart
+++ b/example/lib/marianos_clones/whatsapp_clone.dart
@@ -1140,6 +1140,7 @@ class ChatScreenState extends State<ChatScreen> {
     final size = MediaQuery.of(context).size;
     _isMobile = size.width < 720;
     _smallDevice = size.width < 360;
+    print('mq: ${MediaQuery.of(context)}');
     return Scaffold(
       appBar: _conversation != null
           ? _appBar(_conversation!.user, size, _isMobile)
@@ -1534,82 +1535,88 @@ class ChatScreenState extends State<ChatScreen> {
   PreferredSize _appBar(User user, Size size, bool isMobile) {
     return PreferredSize(
       preferredSize: Size(size.width, 60),
-      child: SizedBox(
-        height: 60,
-        child: Material(
-          color: isMobile
-              ? WhatsappUtils.appBarMobile
-              : WhatsappUtils.appBarLaptop,
-          child: Row(
-            children: [
-              SizedBox(width: isMobile ? 10 : 20),
-              if (isMobile)
-                InkResponse(
-                  onTap: () => Navigator.of(context).pop(),
-                  child: Padding(
-                    padding: const EdgeInsets.only(right: 10),
-                    child: Icon(
-                      Icons.arrow_back,
-                      color: WhatsappUtils.appBarIconMobile,
-                      size: _smallDevice ? 15 : 25,
+      child: Material(
+        color:
+            isMobile ? WhatsappUtils.appBarMobile : WhatsappUtils.appBarLaptop,
+        child: SafeArea(
+          child: SizedBox(
+            height: 60,
+            child: Row(
+              children: [
+                SizedBox(width: isMobile ? 10 : 20),
+                if (isMobile)
+                  InkResponse(
+                    onTap: () => Navigator.of(context).pop(),
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 10),
+                      child: Icon(
+                        Icons.arrow_back,
+                        color: WhatsappUtils.appBarIconMobile,
+                        size: _smallDevice ? 15 : 25,
+                      ),
                     ),
                   ),
-                ),
-              _avatar(_smallDevice),
-              SizedBox(width: _smallDevice ? 10 : 20),
-              if (_conversation != null)
-                GestureDetector(
-                  onTap: () {
-                    if (widget.contact != null) {
-                      _visible = !_visible;
-                      widget.contact!.currentState!.setUser(user);
-                      widget.contact!.currentState!.setVisible(_visible);
-                    } else {
-                      Navigator.of(widget.context).push(
-                        AnimatedRoute(
-                          widget: ContactScreen(user: user, visible: true),
-                          anim: isMobile
-                              ? PageAnimation.FADE_SCALE
-                              : PageAnimation.FROM_RIGHT,
-                        ),
-                      );
-                    }
-                  },
-                  child: SizedBox(
-                    height: _smallDevice ? 36 : 40,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        SizedBox(height: 2),
-                        Expanded(
-                          child: Text(
-                            _conversation!.user.name,
-                            style: TextStyle(
-                              fontSize: _smallDevice ? 14 : 16,
-                              color: isMobile ? Colors.white : Colors.black,
+                _avatar(_smallDevice),
+                SizedBox(width: _smallDevice ? 10 : 20),
+                if (_conversation != null)
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () {
+                        if (widget.contact != null) {
+                          _visible = !_visible;
+                          widget.contact!.currentState!.setUser(user);
+                          widget.contact!.currentState!.setVisible(_visible);
+                        } else {
+                          Navigator.of(widget.context).push(
+                            AnimatedRoute(
+                              widget: ContactScreen(user: user, visible: true),
+                              anim: isMobile
+                                  ? PageAnimation.FADE_SCALE
+                                  : PageAnimation.FROM_RIGHT,
                             ),
-                          ),
+                          );
+                        }
+                      },
+                      child: SizedBox(
+                        height: _smallDevice ? 36 : 40,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            SizedBox(height: 2),
+                            Expanded(
+                              child: Text(
+                                _conversation!.user.name,
+                                style: TextStyle(
+                                  fontSize: _smallDevice ? 14 : 16,
+                                  color: isMobile ? Colors.white : Colors.black,
+                                ),
+                                maxLines: 1,
+                              ),
+                            ),
+                            Text(
+                              _conversation!.user.online
+                                  ? 'online'
+                                  : 'last seen at ${_parseTime(_conversation!.user.lastConnection)}',
+                              style: TextStyle(
+                                color:
+                                    isMobile ? Colors.white : Colors.grey[700],
+                                fontSize: _smallDevice ? 12 : 13,
+                              ),
+                              maxLines: 1,
+                            ),
+                            SizedBox(height: 1),
+                          ],
                         ),
-                        Text(
-                          _conversation!.user.online
-                              ? 'online'
-                              : 'last seen at ${_parseTime(_conversation!.user.lastConnection)}',
-                          style: TextStyle(
-                            color: isMobile ? Colors.white : Colors.grey[700],
-                            fontSize: _smallDevice ? 12 : 13,
-                          ),
-                        ),
-                        SizedBox(height: 1),
-                      ],
+                      ),
                     ),
-                  ),
-                )
-              else
-                SizedBox(),
-              Expanded(child: SizedBox()),
-              for (var action in _isMobile ? _mobileActions : _laptopActions)
-                action
-            ],
+                  )
+                else
+                  SizedBox(),
+                // Expanded(child: SizedBox()),
+                for (var action in _isMobile ? _mobileActions : _laptopActions)
+                  action
+              ],
+            ),
           ),
         ),
       ),
@@ -1819,62 +1826,69 @@ class _ContactsScreenState extends State<ContactsScreen> {
       preferredSize: Size(size.width, widget.isMobile ? 60 : 110),
       child: widget.isMobile
           ? Container(
-              height: 60,
               color: WhatsappUtils.appBarMobile,
-              child: Row(
-                children: [
-                  SizedBox(width: smallDevice ? 15 : 25),
-                  InkResponse(
-                    onTap: () => Navigator.of(context).pop(),
-                    child: Icon(
-                      Icons.arrow_back,
-                      color: Colors.white,
-                      size: smallDevice ? 15 : 25,
-                    ),
+              child: SafeArea(
+                child: SizedBox(
+                  height: 60,
+                  child: Row(
+                    children: [
+                      SizedBox(width: smallDevice ? 15 : 25),
+                      InkResponse(
+                        onTap: () => Navigator.of(context).pop(),
+                        child: Icon(
+                          Icons.arrow_back,
+                          color: Colors.white,
+                          size: smallDevice ? 15 : 25,
+                        ),
+                      ),
+                      SizedBox(width: smallDevice ? 15 : 25),
+                      Text(
+                        'Select contact',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: smallDevice ? 14 : 18,
+                        ),
+                      ),
+                      Expanded(child: SizedBox()),
+                      WhatsappUtils.action(
+                        Icons.search,
+                        () {},
+                        widget.isMobile,
+                        smallDevice: smallDevice,
+                      ),
+                      WhatsappUtils.action(
+                        Icons.more_vert,
+                        () {},
+                        widget.isMobile,
+                        smallDevice: smallDevice,
+                      )
+                    ],
                   ),
-                  SizedBox(width: smallDevice ? 15 : 25),
-                  Text(
-                    'Select contact',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: smallDevice ? 14 : 18,
-                    ),
-                  ),
-                  Expanded(child: SizedBox()),
-                  WhatsappUtils.action(
-                    Icons.search,
-                    () {},
-                    widget.isMobile,
-                    smallDevice: smallDevice,
-                  ),
-                  WhatsappUtils.action(
-                    Icons.more_vert,
-                    () {},
-                    widget.isMobile,
-                    smallDevice: smallDevice,
-                  )
-                ],
+                ),
               ),
             )
           : Container(
               height: 110,
               color: WhatsappUtils.softGreen,
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 20),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    SizedBox(width: 25),
-                    InkResponse(
-                      onTap: () => Navigator.of(context).pop(),
-                      child: Icon(Icons.arrow_back, color: Colors.white),
-                    ),
-                    SizedBox(width: 25),
-                    Text(
-                      'New chat',
-                      style: TextStyle(color: Colors.white, fontSize: 18),
-                    ),
-                  ],
+              child: SafeArea(
+                bottom: false,
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 20),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      SizedBox(width: 25),
+                      InkResponse(
+                        onTap: () => Navigator.of(context).pop(),
+                        child: Icon(Icons.arrow_back, color: Colors.white),
+                      ),
+                      SizedBox(width: 25),
+                      Text(
+                        'New chat',
+                        style: TextStyle(color: Colors.white, fontSize: 18),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -2156,27 +2170,30 @@ class ContactScreenState extends State<ContactScreen> {
                       ),
                       Material(
                         color: Colors.transparent,
-                        child: SizedBox(
-                          height: 60,
-                          width: size.width,
-                          child: Row(
-                            children: [
-                              SizedBox(width: 20),
-                              InkResponse(
-                                onTap: () => Navigator.of(context).pop(),
-                                child:
-                                    Icon(Icons.arrow_back, color: Colors.white),
-                              ),
-                              Expanded(child: Container()),
-                              InkResponse(
-                                onTap: () {},
-                                child: Icon(
-                                  Icons.more_vert,
-                                  color: Colors.white,
+                        child: SafeArea(
+                          bottom: false,
+                          child: SizedBox(
+                            height: 60,
+                            width: size.width,
+                            child: Row(
+                              children: [
+                                SizedBox(width: 20),
+                                InkResponse(
+                                  onTap: () => Navigator.of(context).pop(),
+                                  child: Icon(Icons.arrow_back,
+                                      color: Colors.white),
                                 ),
-                              ),
-                              SizedBox(width: 20),
-                            ],
+                                Expanded(child: Container()),
+                                InkResponse(
+                                  onTap: () {},
+                                  child: Icon(
+                                    Icons.more_vert,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                                SizedBox(width: 20),
+                              ],
+                            ),
                           ),
                         ),
                       ),
@@ -2191,28 +2208,32 @@ class ContactScreenState extends State<ContactScreen> {
 
   PreferredSize _appBar(Size size) {
     final isTablet = size.width < 1100;
+    print("mq2: ${MediaQuery.of(context)}");
     return PreferredSize(
       preferredSize: Size(size.width, 60),
       child: Material(
         color: WhatsappUtils.appBarLaptop,
-        child: SizedBox(
-          height: 60,
-          child: Row(
-            children: [
-              SizedBox(width: 20),
-              InkResponse(
-                onTap: () => isTablet
-                    ? Navigator.of(context).pop()
-                    : setState(() => _isVisible = false),
-                child: Icon(Icons.close, color: WhatsappUtils.appBarIconLaptop),
-              ),
-              SizedBox(width: 20),
-              Text(
-                'Contact info',
-                style: TextStyle(fontSize: 16, color: Colors.black),
-              ),
-              Expanded(child: SizedBox()),
-            ],
+        child: SafeArea(
+          child: SizedBox(
+            height: 60,
+            child: Row(
+              children: [
+                SizedBox(width: 20),
+                InkResponse(
+                  onTap: () => isTablet
+                      ? Navigator.of(context).pop()
+                      : setState(() => _isVisible = false),
+                  child:
+                      Icon(Icons.close, color: WhatsappUtils.appBarIconLaptop),
+                ),
+                SizedBox(width: 20),
+                Text(
+                  'Contact info',
+                  style: TextStyle(fontSize: 16, color: Colors.black),
+                ),
+                Expanded(child: SizedBox()),
+              ],
+            ),
           ),
         ),
       ),

--- a/example/lib/marianos_clones/whatsapp_clone.dart
+++ b/example/lib/marianos_clones/whatsapp_clone.dart
@@ -616,45 +616,48 @@ class ChatsScreenState extends State<ChatsScreen> {
       child: Material(
         color:
             isMobile ? WhatsappUtils.appBarMobile : WhatsappUtils.appBarLaptop,
-        child: Column(
-          children: [
-            Expanded(
-              child: Row(
-                children: [
-                  if (isMobile)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 15),
-                      child: Text(
-                        'WhatsApp',
-                        style: TextStyle(fontSize: 20, color: Colors.white),
-                      ),
-                    )
-                  else
-                    GestureDetector(
-                      onTap: () => Navigator.of(context).push(
-                        AnimatedRoute(
-                          widget:
-                              ProfileScreen(user: WhatsappUtils.currentUser),
-                          anim: PageAnimation.FROM_LEFT,
+        child: SafeArea(
+          child: Column(
+            children: [
+              Expanded(
+                child: Row(
+                  children: [
+                    if (isMobile)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 15),
+                        child: Text(
+                          'WhatsApp',
+                          style: TextStyle(fontSize: 20, color: Colors.white),
+                        ),
+                      )
+                    else
+                      GestureDetector(
+                        onTap: () => Navigator.of(context).push(
+                          AnimatedRoute(
+                            widget:
+                                ProfileScreen(user: WhatsappUtils.currentUser),
+                            anim: PageAnimation.FROM_LEFT,
+                          ),
+                        ),
+                        child: _avatar(
+                          WhatsappUtils.rFlutterDev.avatar,
+                          EdgeInsets.symmetric(horizontal: 15, vertical: 6),
                         ),
                       ),
-                      child: _avatar(
-                        WhatsappUtils.rFlutterDev.avatar,
-                        EdgeInsets.symmetric(horizontal: 15, vertical: 6),
-                      ),
-                    ),
-                  Expanded(child: SizedBox()),
-                  for (var action in isMobile ? _mobileActions : _laptopActions)
-                    action
-                ],
+                    Expanded(child: SizedBox()),
+                    for (var action
+                        in isMobile ? _mobileActions : _laptopActions)
+                      action
+                  ],
+                ),
               ),
-            ),
-            if (isMobile) _tabsSection() else _searchSection(),
-            if (isMobile)
-              SizedBox()
-            else
-              Container(height: 1, color: Colors.grey[300]),
-          ],
+              if (isMobile) _tabsSection() else _searchSection(),
+              if (isMobile)
+                SizedBox()
+              else
+                Container(height: 1, color: Colors.grey[300]),
+            ],
+          ),
         ),
       ),
     );

--- a/example/lib/marianos_clones/whatsapp_clone.dart
+++ b/example/lib/marianos_clones/whatsapp_clone.dart
@@ -11,6 +11,7 @@ class WhatsApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      useInheritedMediaQuery: true,
       title: 'WhatsApp',
       home: HomeScreen(),
       debugShowCheckedModeBanner: false,
@@ -428,6 +429,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget _leftSection(BuildContext context, bool isMobile,
       ConversationCallback callback, RefreshCallback refresh) {
     return MaterialApp(
+      useInheritedMediaQuery: true,
       title: 'WhatsApp',
       initialRoute: '/',
       routes: {

--- a/example/lib/marianos_clones/whatsapp_clone.dart
+++ b/example/lib/marianos_clones/whatsapp_clone.dart
@@ -525,11 +525,23 @@ class ChatsScreenState extends State<ChatsScreen> {
           return ChatItem(
             conversation: item,
             isMobile: widget.isMobile,
-            callback: (item) {
-              if (item == feedbackChat) {
+            callback: (chat) {
+              if (chat == feedbackChat) {
                 Wiredash.of(context).show();
               } else {
-                widget.callback?.call(item);
+                if (widget.isMobile) {
+                  Navigator.of(context).push(
+                    AnimatedRoute(
+                      widget: ChatScreen(
+                        context: context,
+                        conversation: chat,
+                        refresh: widget.refresh,
+                      ),
+                      anim: PageAnimation.FADE_SCALE,
+                    ),
+                  );
+                }
+                widget.callback?.call(chat);
               }
             },
             refresh: widget.refresh,
@@ -880,21 +892,7 @@ class _ChatItemState extends State<ChatItem> {
     return Material(
       child: InkWell(
         onTap: () {
-          if (widget.isMobile) {
-            Navigator.of(context).push(
-              AnimatedRoute(
-                widget: ChatScreen(
-                  context: context,
-                  conversation: widget.conversation,
-                  refresh: widget.refresh,
-                ),
-                anim: PageAnimation.FADE_SCALE,
-              ),
-            );
-            widget.callback?.call(widget.conversation);
-          } else {
-            widget.callback?.call(widget.conversation);
-          }
+          widget.callback?.call(widget.conversation);
         },
         child: MouseRegion(
           onHover: (_) => setState(() => _isHover = true),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=2.5.0 <4.0.0"
 
 dependencies:
+  device_frame: ^1.0.0
   flutter:
     sdk: flutter
   flutter_colorpicker: ^1.0.3

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_colorpicker: ^1.0.3
 
   wiredash:
     path: ../

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_colorpicker: ^1.0.3
+  google_fonts: ^2.3.2
 
   wiredash:
     path: ../

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_colorpicker: ^1.0.3
-  google_fonts: ^2.3.2
+  google_fonts: ^2.0.0
 
   wiredash:
     path: ../

--- a/lib/src/core/support/not_a_widgets_app.dart
+++ b/lib/src/core/support/not_a_widgets_app.dart
@@ -50,10 +50,13 @@ class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
       child: child,
     );
 
-    // Inject a MediaQuery with information from the app window
-    child = MediaQuery.fromWindow(
-      child: child,
-    );
+    final parentMq = MediaQuery.maybeOf(context);
+    if (parentMq == null) {
+      // Inject a MediaQuery with information from the app window
+      child = MediaQuery.fromWindow(
+        child: child,
+      );
+    }
 
     return child;
   }

--- a/lib/src/core/theme/color_ext.dart
+++ b/lib/src/core/theme/color_ext.dart
@@ -22,6 +22,56 @@ extension ColorBrightness on Color {
     return hslDark.toColor();
   }
 
+  Color withHslSaturation(double saturation) {
+    assert(saturation >= 0 && saturation <= 1);
+    return HSLColor.fromColor(this).withSaturation(saturation).toColor();
+  }
+
+  Color withHsvSaturation(double saturation) {
+    assert(saturation >= 0 && saturation <= 1);
+    return HSVColor.fromColor(this).withSaturation(saturation).toColor();
+  }
+
+  Color adjustHslSaturation(double Function(double saturation) fn) {
+    final hslColor = HSLColor.fromColor(this);
+    return hslColor.withSaturation(fn(hslColor.saturation)).toColor();
+  }
+
+  Color adjustHsvSaturation(double Function(double saturation) fn) {
+    final hsvColor = HSVColor.fromColor(this);
+    return hsvColor.withSaturation(fn(hsvColor.saturation)).toColor();
+  }
+
+  Color withHue(double hue) {
+    assert(hue >= 0 && hue <= 1);
+    return HSLColor.fromColor(this).withHue(hue).toColor();
+  }
+
+  Color shiftHue(double shift) {
+    final hslColor = HSLColor.fromColor(this);
+    return hslColor.withHue((hslColor.hue + shift) % 360).toColor();
+  }
+
+  Color adjustHue(double Function(double hue) fn) {
+    final hslColor = HSLColor.fromColor(this);
+    return hslColor.withHue(fn(hslColor.hue)).toColor();
+  }
+
+  Color withLightness(double lightness) {
+    assert(lightness >= 0 && lightness <= 1);
+    return HSLColor.fromColor(this).withLightness(lightness).toColor();
+  }
+
+  Color adjustValue(double Function(double value) fn) {
+    final hsvColor = HSVColor.fromColor(this);
+    return hsvColor.withValue(fn(hsvColor.value)).toColor();
+  }
+
+  Color withValue(double value) {
+    assert(value >= 0 && value <= 1);
+    return HSVColor.fromColor(this).withValue(value).toColor();
+  }
+
   Color saturate([double amount = .1]) {
     assert(amount >= 0 && amount <= 1);
 

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -14,7 +14,9 @@ class WiredashThemeData {
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
     Color? primaryContainerColor,
+    Color? textOnPrimaryContainerColor,
     Color? secondaryContainerColor,
+    Color? textOnSecondaryContainerColor,
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
@@ -30,7 +32,9 @@ class WiredashThemeData {
       primaryBackgroundColor: primaryBackgroundColor,
       secondaryBackgroundColor: secondaryBackgroundColor,
       primaryContainerColor: primaryContainerColor,
+      textOnPrimaryContainerColor: textOnPrimaryContainerColor,
       secondaryContainerColor: secondaryContainerColor,
+      textOnSecondaryContainerColor: textOnSecondaryContainerColor,
       appBackgroundColor: appBackgroundColor,
       appHandleBackgroundColor: appHandleBackgroundColor,
       errorColor: errorColor,
@@ -65,7 +69,9 @@ class WiredashThemeData {
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
     Color? primaryContainerColor,
+    Color? textOnPrimaryContainerColor,
     Color? secondaryContainerColor,
+    Color? textOnSecondaryContainerColor,
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
@@ -78,7 +84,9 @@ class WiredashThemeData {
         _primaryBackgroundColor = primaryBackgroundColor,
         _secondaryBackgroundColor = secondaryBackgroundColor,
         _primaryContainerColor = primaryContainerColor,
+        _textOnPrimaryContainerColor = textOnPrimaryContainerColor,
         _secondaryContainerColor = secondaryContainerColor,
+        _textOnSecondaryContainerColor = textOnSecondaryContainerColor,
         _appBackgroundColor = appBackgroundColor,
         _appHandleBackgroundColor = appHandleBackgroundColor,
         _errorColor = errorColor,
@@ -87,12 +95,20 @@ class WiredashThemeData {
   final Brightness brightness;
   bool get isLight => brightness == Brightness.light;
 
+  // --- Primary --- //
   final Color primaryColor;
   MaterialColorTone? __primaryTone;
   MaterialColorTone get _primaryTone {
     return __primaryTone ??= MaterialColorTone(primaryColor, brightness);
   }
 
+  final Color? _textOnPrimary;
+  Color get textOnPrimaryColor {
+    final tone = isLight ? 100 : 0;
+    return _textOnPrimary ?? _primaryTone.primaryTone(tone);
+  }
+
+  // --- Secondary --- //
   final Color? _secondaryColor;
   Color get secondaryColor => _secondaryColor ?? _secondaryTone.baseColor;
   MaterialColorTone? __secondaryTone;
@@ -104,30 +120,28 @@ class WiredashThemeData {
               return primaryColor
                   // .shiftHue(-10)
                   // .withValue(0.98)
-                  .adjustValue((value) =>
-                      KeyPointInterpolator({0: 0.70, 1: 0.90})
-                          .interpolate(value))
-                  .adjustHsvSaturation((saturation) =>
-                      KeyPointInterpolator({0: 0.12, 1: 0.2})
-                          .interpolate(saturation));
+                  .adjustValue(
+                    (value) => KeyPointInterpolator({0: 0.70, 1: 0.90})
+                        .interpolate(value),
+                  )
+                  .adjustHsvSaturation(
+                    (saturation) => KeyPointInterpolator({0: 0.12, 1: 0.2})
+                        .interpolate(saturation),
+                  );
             } else {
               return primaryColor
-                  .adjustValue((value) =>
-                      KeyPointInterpolator({0: 0.00, 1: 0.50})
-                          .interpolate(value))
-                  .adjustHsvSaturation((saturation) =>
-                      KeyPointInterpolator({0: 0.02, 1: 0.2})
-                          .interpolate(saturation));
+                  .adjustValue(
+                    (value) => KeyPointInterpolator({0: 0.00, 1: 0.50})
+                        .interpolate(value),
+                  )
+                  .adjustHsvSaturation(
+                    (saturation) => KeyPointInterpolator({0: 0.02, 1: 0.2})
+                        .interpolate(saturation),
+                  );
             }
           }(),
       brightness,
     );
-  }
-
-  final Color? _textOnPrimary;
-  Color get textOnPrimaryColor {
-    final tone = isLight ? 100 : 0;
-    return _textOnPrimary ?? _primaryTone.primaryTone(tone);
   }
 
   final Color? _textOnSecondary;
@@ -136,30 +150,35 @@ class WiredashThemeData {
     return _textOnSecondary ?? _secondaryTone.primaryTone(tone);
   }
 
+  // --- primaryContainer --- //
   final Color? _primaryContainerColor;
   Color get primaryContainerColor {
     return _primaryContainerColor ?? _primaryTone.primaryContainer;
   }
 
+  final Color? _textOnPrimaryContainerColor;
   Color get textOnPrimaryContainerColor {
-    return _primaryTone.onPrimaryContainer;
+    return _textOnPrimaryContainerColor ?? _primaryTone.onPrimaryContainer;
   }
 
+  // --- secondadryContainer --- //
   final Color? _secondaryContainerColor;
   Color get secondaryContainerColor =>
-      _secondaryContainerColor ?? _secondaryTone.secondaryContainer;
+      _secondaryContainerColor ?? _secondaryTone.primaryContainer;
 
+  final Color? _textOnSecondaryContainerColor;
   Color get textOnSecondaryContainerColor {
-    return _secondaryTone.onSecondaryContainer;
+    return _textOnSecondaryContainerColor ?? _secondaryTone.onPrimaryContainer;
   }
 
+  // --- Background --- //
   final Color? _primaryBackgroundColor;
   Color get primaryBackgroundColor {
     if (brightness == Brightness.light) {
       return _primaryBackgroundColor ?? _primaryTone.primaryTone(100);
     } else {
       return _primaryBackgroundColor ??
-          primaryColor.withHslSaturation(0.04).withLightness(0.2);
+          primaryColor.withHslSaturation(0.08).withLightness(0.2);
     }
   }
 
@@ -169,31 +188,8 @@ class WiredashThemeData {
       return _secondaryBackgroundColor ?? _primaryTone.primaryTone(98);
     } else {
       return _secondaryBackgroundColor ??
-          secondaryColor.withHslSaturation(0.0).withLightness(0.1);
+          secondaryColor.withHslSaturation(0.0).withLightness(0.05);
     }
-  }
-
-  Color get surfaceColor {
-    return _primaryTone.surface;
-  }
-
-  Color get primaryTextOnSurfaceColor {
-    return _primaryTone.onSurface;
-  }
-
-  Color get secondaryTextOnSurfaceColor {
-    return _primaryTone.onSurface.withOpacity(0.8);
-  }
-
-  final Color? _errorColor;
-  Color get errorColor => _errorColor ?? _primaryTone.error;
-
-  final Color? _appBackgroundColor;
-  Color get appBackgroundColor {
-    return _appBackgroundColor ??
-        (brightness == Brightness.light
-            ? const Color(0xfff5f6f8)
-            : const Color(0xff3d3e3e));
   }
 
   Color get primaryTextOnBackgroundColor {
@@ -214,11 +210,36 @@ class WiredashThemeData {
     return Color(palette.neutralVariant.get(tone));
   }
 
+  final Color? _appBackgroundColor;
+  Color get appBackgroundColor {
+    return _appBackgroundColor ??
+        (brightness == Brightness.light
+            ? const Color(0xfff5f6f8)
+            : const Color(0xff3d3e3e));
+  }
+
   /// The color of the app handle, the "Return to app" bar above the app
   final Color? _appHandleBackgroundColor;
   Color get appHandleBackgroundColor {
     return _appHandleBackgroundColor ?? _primaryTone.primaryTone(20);
   }
+
+  // --- Surface --- //
+  Color get surfaceColor {
+    return _primaryTone.surface;
+  }
+
+  Color get primaryTextOnSurfaceColor {
+    return _primaryTone.onSurface;
+  }
+
+  Color get secondaryTextOnSurfaceColor {
+    return _primaryTone.onSurface.withOpacity(0.8);
+  }
+
+  // --- Error --- //
+  final Color? _errorColor;
+  Color get errorColor => _errorColor ?? _primaryTone.error;
 
   final DeviceClass deviceClass;
   final Size windowSize;
@@ -355,7 +376,10 @@ class WiredashThemeData {
           textOnPrimaryColor == other.textOnPrimaryColor &&
           textOnSecondaryColor == other.textOnSecondaryColor &&
           primaryBackgroundColor == other.primaryBackgroundColor &&
+          textOnPrimaryContainerColor == other.textOnPrimaryContainerColor &&
           secondaryBackgroundColor == other.secondaryBackgroundColor &&
+          textOnSecondaryContainerColor ==
+              other.textOnSecondaryContainerColor &&
           primaryContainerColor == other.primaryContainerColor &&
           secondaryContainerColor == other.secondaryContainerColor &&
           appBackgroundColor == other.appBackgroundColor &&
@@ -375,7 +399,9 @@ class WiredashThemeData {
       primaryBackgroundColor.hashCode ^
       secondaryBackgroundColor.hashCode ^
       primaryContainerColor.hashCode ^
+      textOnPrimaryContainerColor.hashCode ^
       secondaryContainerColor.hashCode ^
+      textOnSecondaryContainerColor.hashCode ^
       appBackgroundColor.hashCode ^
       appHandleBackgroundColor.hashCode ^
       errorColor.hashCode ^
@@ -394,7 +420,9 @@ class WiredashThemeData {
         'primaryBackgroundColor: $primaryBackgroundColor, '
         'secondaryBackgroundColor: $secondaryBackgroundColor, '
         'primaryContainerColor: $primaryContainerColor, '
+        'textOnPrimaryContainerColor: $textOnPrimaryContainerColor, '
         'secondaryContainerColor: $secondaryContainerColor, '
+        'textOnSecondaryContainerColor: $textOnSecondaryContainerColor, '
         'appBackgroundColor: $appBackgroundColor, '
         'appHandleBackgroundColor: $appHandleBackgroundColor, '
         'errorColor: $errorColor, '
@@ -411,7 +439,9 @@ class WiredashThemeData {
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
     Color? primaryContainerColor,
+    Color? textOnPrimaryContainerColor,
     Color? secondaryContainerColor,
+    Color? textOnSecondaryContainerColor,
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
@@ -429,8 +459,12 @@ class WiredashThemeData {
           secondaryBackgroundColor ?? this.secondaryBackgroundColor,
       primaryContainerColor:
           primaryContainerColor ?? this.primaryContainerColor,
+      textOnPrimaryContainerColor:
+          textOnPrimaryContainerColor ?? this.textOnPrimaryContainerColor,
       secondaryContainerColor:
           secondaryContainerColor ?? this.secondaryContainerColor,
+      textOnSecondaryContainerColor:
+          textOnSecondaryContainerColor ?? this.textOnSecondaryContainerColor,
       appBackgroundColor: appBackgroundColor ?? this.appBackgroundColor,
       appHandleBackgroundColor:
           appHandleBackgroundColor ?? this.appHandleBackgroundColor,

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -519,6 +519,7 @@ enum DeviceClass {
   desktopLarge1440
 }
 
+/// Based on the theory in https://m3.material.io/styles/color/dynamic-color/user-generated-color
 class MaterialColorTone {
   MaterialColorTone(this.baseColor, this.brightness)
       : palette = CorePalette.of(baseColor.value);

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -96,9 +96,9 @@ class WiredashThemeData {
     if (brightness == Brightness.light) {
       final secondary = secondaryColor ??
           primaryHsv
-              .withSaturation((primaryHsv.saturation * 0.4).clamp(0.0, 0.2))
+              .withSaturation(0.17)
               .withHue((primaryHsl.hue - 10) % 360)
-              .withValue((primaryHsv.value + 0.3).clamp(0.1, 1.0))
+              .withValue((primaryHsv.value * 2).clamp(0.2, 0.8))
               .toColor();
       return theme.copyWith(
         secondaryColor: secondary,

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show Brightness;
 
 import 'package:flutter/rendering.dart';
+import 'package:material_color_utilities/material_color_utilities.dart';
 import 'package:wiredash/src/core/theme/color_ext.dart';
 import 'package:wiredash/src/core/theme/key_point_interpolator.dart';
 
@@ -10,73 +11,31 @@ class WiredashThemeData {
     DeviceClass deviceClass = DeviceClass.handsetLarge400,
     Color? primaryColor,
     Color? secondaryColor,
-    Color? textOnPrimary,
-    Color? textOnSecondary,
-    Color? primaryTextColor,
-    Color? secondaryTextColor,
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
+    Color? primaryContainerColor,
+    Color? secondaryContainerColor,
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
     String? fontFamily,
     Size? windowSize,
   }) {
-    final primary = primaryColor ?? const Color(0xff1A56DB);
-    final secondary = secondaryColor ?? const Color(0xffE8EEFB);
-
-    final textOnPrimaryColor = textOnPrimary ??
-        (primary.brightness == Brightness.dark
-            ? const Color(0xff030A1C)
-            : const Color(0xffe3e3e3));
-    final textOnSecondaryColor = textOnSecondary ??
-        (secondary.brightness == Brightness.dark
-            ? const Color(0xff8C93A2)
-            : const Color(0xb0a4a4a4));
-
-    if (brightness == Brightness.light) {
-      return WiredashThemeData._(
-        brightness: brightness,
-        deviceClass: deviceClass,
-        primaryColor: primary,
-        secondaryColor: secondary,
-        textOnPrimary: textOnPrimaryColor,
-        textOnSecondary: textOnSecondaryColor,
-        primaryTextColor: primaryTextColor ?? const Color(0xff030A1C),
-        secondaryTextColor: secondaryTextColor ?? const Color(0xff8C93A2),
-        primaryBackgroundColor:
-            primaryBackgroundColor ?? const Color(0xffffffff),
-        secondaryBackgroundColor:
-            secondaryBackgroundColor ?? const Color(0xfff5f6f8),
-        appBackgroundColor: appBackgroundColor ?? const Color(0xfff5f6f8),
-        appHandleBackgroundColor:
-            appHandleBackgroundColor ?? const Color(0xfff5f6f8),
-        errorColor: errorColor ?? const Color(0xffff5c6a),
-        fontFamily: fontFamily ?? _fontFamily,
-        windowSize: windowSize ?? Size.zero,
-      );
-    } else {
-      return WiredashThemeData._(
-        brightness: brightness,
-        deviceClass: deviceClass,
-        primaryColor: primary,
-        secondaryColor: secondary,
-        textOnPrimary: textOnPrimaryColor,
-        textOnSecondary: textOnSecondaryColor,
-        primaryTextColor: primaryTextColor ?? const Color(0xffe3e3e3),
-        secondaryTextColor: secondaryTextColor ?? const Color(0xb0a4a4a4),
-        primaryBackgroundColor:
-            primaryBackgroundColor ?? const Color(0xffffffff),
-        secondaryBackgroundColor:
-            secondaryBackgroundColor ?? const Color(0xfff5f6f8),
-        appBackgroundColor: appBackgroundColor ?? const Color(0xff3d3e3e),
-        appHandleBackgroundColor:
-            appHandleBackgroundColor ?? const Color(0xff3d3e3e),
-        errorColor: errorColor ?? const Color(0xffdb000a),
-        fontFamily: fontFamily ?? _fontFamily,
-        windowSize: windowSize ?? Size.zero,
-      );
-    }
+    return WiredashThemeData._(
+      primaryColor: primaryColor ?? const Color(0xff1A56DB),
+      secondaryColor: secondaryColor,
+      brightness: brightness,
+      deviceClass: deviceClass,
+      windowSize: windowSize ?? Size.zero,
+      primaryBackgroundColor: primaryBackgroundColor,
+      secondaryBackgroundColor: secondaryBackgroundColor,
+      primaryContainerColor: primaryContainerColor,
+      secondaryContainerColor: secondaryContainerColor,
+      appBackgroundColor: appBackgroundColor,
+      appHandleBackgroundColor: appHandleBackgroundColor,
+      errorColor: errorColor,
+      fontFamily: fontFamily,
+    );
   }
 
   factory WiredashThemeData.fromColor({
@@ -87,162 +46,258 @@ class WiredashThemeData {
     if (secondaryColor?.value == primaryColor.value) {
       secondaryColor = null;
     }
-    final primaryHsl = HSLColor.fromColor(primaryColor);
-    final primaryHsv = HSVColor.fromColor(primaryColor);
 
-    final theme =
-        WiredashThemeData(brightness: brightness, primaryColor: primaryColor);
+    final theme = WiredashThemeData(
+      brightness: brightness,
+      primaryColor: primaryColor,
+      secondaryColor: secondaryColor,
+    );
 
-    if (brightness == Brightness.light) {
-      final secondary = secondaryColor ??
-          primaryHsv
-              .withSaturation(0.17)
-              .withHue((primaryHsl.hue - 10) % 360)
-              .withValue((primaryHsv.value * 2).clamp(0.2, 0.8))
-              .toColor();
-      return theme.copyWith(
-        secondaryColor: secondary,
-        primaryBackgroundColor:
-            primaryHsl.withSaturation(1.0).withLightness(1.0).toColor(),
-        secondaryBackgroundColor:
-            primaryHsl.withSaturation(.8).withLightness(0.95).toColor(),
-        appHandleBackgroundColor: primaryHsl.withLightness(0.1).toColor(),
-      );
-    } else {
-      final secondary = secondaryColor ??
-          primaryHsl
-              .withHue((primaryHsl.hue - 10) % 360)
-              .withSaturation((primaryHsl.saturation * 0.2).clamp(0.1, 1.0))
-              .withLightness((primaryHsl.lightness * 0.5).clamp(0.1, 1.0))
-              .toColor();
-      return theme.copyWith(
-        secondaryColor: secondary,
-        primaryBackgroundColor:
-            primaryHsl.withSaturation(0.04).withLightness(0.2).toColor(),
-        secondaryBackgroundColor:
-            primaryHsl.withSaturation(0.0).withLightness(0.1).toColor(),
-        appHandleBackgroundColor: primaryHsl
-            .withHue((primaryHsl.hue + 10) % 360)
-            .withLightness((primaryHsl.lightness * 0.5).clamp(0.2, 0.4))
-            .withSaturation((primaryHsl.saturation * 1.4).clamp(0.1, 1.0))
-            .toColor(),
-      );
-    }
+    return theme;
   }
 
   WiredashThemeData._({
     required this.brightness,
     required this.primaryColor,
-    required this.secondaryColor,
-    required this.textOnPrimary,
-    required this.textOnSecondary,
-    required this.primaryTextColor,
-    required this.secondaryTextColor,
-    required this.primaryBackgroundColor,
-    required this.secondaryBackgroundColor,
-    required this.appBackgroundColor,
-    required this.appHandleBackgroundColor,
-    required this.errorColor,
+    Color? secondaryColor,
+    Color? textOnPrimary,
+    Color? textOnSecondary,
+    Color? primaryBackgroundColor,
+    Color? secondaryBackgroundColor,
+    Color? primaryContainerColor,
+    Color? secondaryContainerColor,
+    Color? appBackgroundColor,
+    Color? appHandleBackgroundColor,
+    Color? errorColor,
+    String? fontFamily,
     required this.deviceClass,
-    required this.fontFamily,
     required this.windowSize,
-  });
+  })  : _secondaryColor = secondaryColor,
+        _textOnPrimary = textOnPrimary,
+        _textOnSecondary = textOnSecondary,
+        _primaryBackgroundColor = primaryBackgroundColor,
+        _secondaryBackgroundColor = secondaryBackgroundColor,
+        _primaryContainerColor = primaryContainerColor,
+        _secondaryContainerColor = secondaryContainerColor,
+        _appBackgroundColor = appBackgroundColor,
+        _appHandleBackgroundColor = appHandleBackgroundColor,
+        _errorColor = errorColor,
+        _fontFamily = fontFamily;
 
   final Brightness brightness;
+  bool get isLight => brightness == Brightness.light;
 
   final Color primaryColor;
-  final Color secondaryColor;
+  MaterialColorTone? __primaryTone;
+  MaterialColorTone get _primaryTone {
+    return __primaryTone ??= MaterialColorTone(primaryColor, brightness);
+  }
 
-  final Color textOnPrimary;
-  final Color textOnSecondary;
+  final Color? _secondaryColor;
+  Color get secondaryColor => _secondaryColor ?? _secondaryTone.baseColor;
+  MaterialColorTone? __secondaryTone;
+  MaterialColorTone get _secondaryTone {
+    return __secondaryTone ??= MaterialColorTone(
+      _secondaryColor ??
+          () {
+            if (isLight) {
+              return primaryColor
+                  // .shiftHue(-10)
+                  // .withValue(0.98)
+                  .adjustValue((value) =>
+                      KeyPointInterpolator({0: 0.70, 1: 0.90})
+                          .interpolate(value))
+                  .adjustHsvSaturation((saturation) =>
+                      KeyPointInterpolator({0: 0.12, 1: 0.2})
+                          .interpolate(saturation));
+            } else {
+              return primaryColor
+                  .adjustValue((value) =>
+                      KeyPointInterpolator({0: 0.00, 1: 0.50})
+                          .interpolate(value))
+                  .adjustHsvSaturation((saturation) =>
+                      KeyPointInterpolator({0: 0.02, 1: 0.2})
+                          .interpolate(saturation));
+            }
+          }(),
+      brightness,
+    );
+  }
 
-  final Color primaryTextColor;
-  final Color secondaryTextColor;
+  final Color? _textOnPrimary;
+  Color get textOnPrimaryColor {
+    final tone = isLight ? 100 : 0;
+    return _textOnPrimary ?? _primaryTone.primaryTone(tone);
+  }
 
-  final Color primaryBackgroundColor;
-  final Color secondaryBackgroundColor;
-  final Color errorColor;
+  final Color? _textOnSecondary;
+  Color get textOnSecondaryColor {
+    final tone = isLight ? 99 : 1;
+    return _textOnSecondary ?? _secondaryTone.primaryTone(tone);
+  }
 
-  final Color appBackgroundColor;
+  final Color? _primaryContainerColor;
+  Color get primaryContainerColor {
+    return _primaryContainerColor ?? _primaryTone.primaryContainer;
+  }
+
+  Color get textOnPrimaryContainerColor {
+    return _primaryTone.onPrimaryContainer;
+  }
+
+  final Color? _secondaryContainerColor;
+  Color get secondaryContainerColor =>
+      _secondaryContainerColor ?? _secondaryTone.secondaryContainer;
+
+  Color get textOnSecondaryContainerColor {
+    return _secondaryTone.onSecondaryContainer;
+  }
+
+  final Color? _primaryBackgroundColor;
+  Color get primaryBackgroundColor {
+    if (brightness == Brightness.light) {
+      return _primaryBackgroundColor ?? _primaryTone.primaryTone(100);
+    } else {
+      return _primaryBackgroundColor ??
+          primaryColor.withHslSaturation(0.04).withLightness(0.2);
+    }
+  }
+
+  final Color? _secondaryBackgroundColor;
+  Color get secondaryBackgroundColor {
+    if (brightness == Brightness.light) {
+      return _secondaryBackgroundColor ?? _primaryTone.primaryTone(98);
+    } else {
+      return _secondaryBackgroundColor ??
+          secondaryColor.withHslSaturation(0.0).withLightness(0.1);
+    }
+  }
+
+  Color get surfaceColor {
+    return _primaryTone.surface;
+  }
+
+  Color get primaryTextOnSurfaceColor {
+    return _primaryTone.onSurface;
+  }
+
+  Color get secondaryTextOnSurfaceColor {
+    return _primaryTone.onSurface.withOpacity(0.8);
+  }
+
+  final Color? _errorColor;
+  Color get errorColor => _errorColor ?? _primaryTone.error;
+
+  final Color? _appBackgroundColor;
+  Color get appBackgroundColor {
+    return _appBackgroundColor ??
+        (brightness == Brightness.light
+            ? const Color(0xfff5f6f8)
+            : const Color(0xff3d3e3e));
+  }
+
+  Color get primaryTextOnBackgroundColor {
+    final merged =
+        Color.lerp(primaryBackgroundColor, secondaryBackgroundColor, 0.5)!;
+    final palette = CorePalette.of(merged.value);
+
+    final tone = isLight ? 10 : 100;
+    return Color(palette.neutralVariant.get(tone));
+  }
+
+  Color get secondaryTextOnBackgroundColor {
+    final merged =
+        Color.lerp(primaryBackgroundColor, secondaryBackgroundColor, 0.5)!;
+    final palette = CorePalette.of(merged.value);
+
+    final tone = isLight ? 40 : 70;
+    return Color(palette.neutralVariant.get(tone));
+  }
 
   /// The color of the app handle, the "Return to app" bar above the app
-  final Color appHandleBackgroundColor;
+  final Color? _appHandleBackgroundColor;
+  Color get appHandleBackgroundColor {
+    return _appHandleBackgroundColor ?? _primaryTone.primaryTone(20);
+  }
 
   final DeviceClass deviceClass;
   final Size windowSize;
 
-  final String fontFamily;
+  final String? _fontFamily;
+  String get fontFamily {
+    return _fontFamily ?? _defaultFontFamily;
+  }
 
-  static const _fontFamily = 'Inter';
-  static const _packageName = 'wiredash';
+  static const _defaultFontFamily = 'Inter';
 
-  String? get packageName => fontFamily == _fontFamily ? _packageName : null;
+  String? get _packageName =>
+      fontFamily == _defaultFontFamily ? 'wiredash' : null;
 
   TextStyle get headlineTextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: windowSize.shortestSide > 480 ? 32 : 24,
-        color: primaryTextColor,
+        color: primaryTextOnSurfaceColor,
         fontWeight: FontWeight.bold,
       );
 
   TextStyle get appbarTitle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: 16,
-        color: primaryTextColor,
+        color: primaryTextOnSurfaceColor,
         fontWeight: FontWeight.bold,
       );
 
   TextStyle get titleTextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: 20,
-        color: primaryTextColor,
+        color: primaryTextOnSurfaceColor,
         fontWeight: FontWeight.bold,
       );
 
   TextStyle get tronButtonTextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: 14,
-        color: primaryTextColor,
+        color: primaryTextOnSurfaceColor,
         fontWeight: FontWeight.w600,
       );
 
   TextStyle get bodyTextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: windowSize.shortestSide > 480 ? 16 : 14,
-        color: primaryTextColor,
+        color: primaryTextOnSurfaceColor,
         fontWeight: FontWeight.normal,
       );
 
   TextStyle get body2TextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: windowSize.shortestSide > 480 ? 16 : 14,
-        color: secondaryTextColor,
+        color: secondaryTextOnSurfaceColor,
         fontWeight: FontWeight.normal,
       );
 
   TextStyle get captionTextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: 12,
-        color: secondaryTextColor,
+        color: secondaryTextOnSurfaceColor,
         fontWeight: FontWeight.normal,
       );
 
   TextStyle get inputTextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: 14,
-        color: primaryTextColor,
+        color: primaryTextOnSurfaceColor,
       );
 
   TextStyle get inputErrorTextStyle => TextStyle(
-        package: packageName,
+        package: _packageName,
         fontFamily: fontFamily,
         fontSize: 12,
         color: errorColor,
@@ -289,22 +344,6 @@ class WiredashThemeData {
     return keypoints.interpolate(height);
   }
 
-  Color get primaryContainerColor {
-    if (brightness == Brightness.dark) {
-      return primaryColor.desaturate(0.4).darken(0.2);
-    } else {
-      return primaryColor.desaturate(0.4).lighten(0.3);
-    }
-  }
-
-  Color get secondaryContainerColor {
-    if (brightness == Brightness.dark) {
-      return secondaryColor.desaturate(0.4).darken(0.2);
-    } else {
-      return secondaryColor.desaturate(0.4).darken(0.2);
-    }
-  }
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -313,12 +352,12 @@ class WiredashThemeData {
           brightness == other.brightness &&
           primaryColor == other.primaryColor &&
           secondaryColor == other.secondaryColor &&
-          textOnPrimary == other.textOnPrimary &&
-          textOnSecondary == other.textOnSecondary &&
-          primaryTextColor == other.primaryTextColor &&
-          secondaryTextColor == other.secondaryTextColor &&
+          textOnPrimaryColor == other.textOnPrimaryColor &&
+          textOnSecondaryColor == other.textOnSecondaryColor &&
           primaryBackgroundColor == other.primaryBackgroundColor &&
           secondaryBackgroundColor == other.secondaryBackgroundColor &&
+          primaryContainerColor == other.primaryContainerColor &&
+          secondaryContainerColor == other.secondaryContainerColor &&
           appBackgroundColor == other.appBackgroundColor &&
           appHandleBackgroundColor == other.appHandleBackgroundColor &&
           errorColor == other.errorColor &&
@@ -331,12 +370,12 @@ class WiredashThemeData {
       brightness.hashCode ^
       primaryColor.hashCode ^
       secondaryColor.hashCode ^
-      textOnPrimary.hashCode ^
-      textOnSecondary.hashCode ^
-      primaryTextColor.hashCode ^
-      secondaryTextColor.hashCode ^
+      textOnPrimaryColor.hashCode ^
+      textOnSecondaryColor.hashCode ^
       primaryBackgroundColor.hashCode ^
       secondaryBackgroundColor.hashCode ^
+      primaryContainerColor.hashCode ^
+      secondaryContainerColor.hashCode ^
       appBackgroundColor.hashCode ^
       appHandleBackgroundColor.hashCode ^
       errorColor.hashCode ^
@@ -350,14 +389,14 @@ class WiredashThemeData {
         'brightness: $brightness, '
         'primaryColor: $primaryColor, '
         'secondaryColor: $secondaryColor, '
-        'textOnPrimary: $textOnPrimary, '
-        'textOnSecondary: $textOnSecondary, '
-        'primaryTextColor: $primaryTextColor, '
-        'secondaryTextColor: $secondaryTextColor, '
+        'textOnPrimaryColor: $textOnPrimaryColor, '
+        'textOnSecondaryColor: $textOnSecondaryColor, '
         'primaryBackgroundColor: $primaryBackgroundColor, '
         'secondaryBackgroundColor: $secondaryBackgroundColor, '
+        'primaryContainerColor: $primaryContainerColor, '
+        'secondaryContainerColor: $secondaryContainerColor, '
         'appBackgroundColor: $appBackgroundColor, '
-        'appBackgroundColor: $appHandleBackgroundColor, '
+        'appHandleBackgroundColor: $appHandleBackgroundColor, '
         'errorColor: $errorColor, '
         'deviceClass: $deviceClass, '
         'fontFamily: $fontFamily, '
@@ -369,12 +408,10 @@ class WiredashThemeData {
     Brightness? brightness,
     Color? primaryColor,
     Color? secondaryColor,
-    Color? textOnPrimary,
-    Color? textOnSecondary,
-    Color? primaryTextColor,
-    Color? secondaryTextColor,
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
+    Color? primaryContainerColor,
+    Color? secondaryContainerColor,
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
@@ -386,14 +423,14 @@ class WiredashThemeData {
       brightness: brightness ?? this.brightness,
       primaryColor: primaryColor ?? this.primaryColor,
       secondaryColor: secondaryColor ?? this.secondaryColor,
-      textOnPrimary: textOnPrimary ?? this.textOnPrimary,
-      textOnSecondary: textOnSecondary ?? this.textOnSecondary,
-      primaryTextColor: primaryTextColor ?? this.primaryTextColor,
-      secondaryTextColor: secondaryTextColor ?? this.secondaryTextColor,
       primaryBackgroundColor:
           primaryBackgroundColor ?? this.primaryBackgroundColor,
       secondaryBackgroundColor:
           secondaryBackgroundColor ?? this.secondaryBackgroundColor,
+      primaryContainerColor:
+          primaryContainerColor ?? this.primaryContainerColor,
+      secondaryContainerColor:
+          secondaryContainerColor ?? this.secondaryContainerColor,
       appBackgroundColor: appBackgroundColor ?? this.appBackgroundColor,
       appHandleBackgroundColor:
           appHandleBackgroundColor ?? this.appHandleBackgroundColor,
@@ -446,4 +483,48 @@ enum DeviceClass {
   /// MacBook Pro 16" 2019 (medium scale) width: 1536
   /// MacBook Pro 15" 2018 width: 1440
   desktopLarge1440
+}
+
+class MaterialColorTone {
+  MaterialColorTone(this.baseColor, this.brightness)
+      : palette = CorePalette.of(baseColor.value);
+  final Color baseColor;
+  final CorePalette palette;
+  final Brightness brightness;
+  bool get _isLight => brightness == Brightness.light;
+
+  Color primaryTone(int tone) => Color(palette.primary.get(tone));
+  Color get primary => primaryTone(_isLight ? 40 : 80);
+  Color get onPrimary => primaryTone(_isLight ? 100 : 20);
+  Color get primaryContainer => primaryTone(_isLight ? 90 : 30);
+  Color get onPrimaryContainer => primaryTone(_isLight ? 10 : 90);
+
+  Color secondaryTone(int tone) => Color(palette.secondary.get(tone));
+  Color get secondary => secondaryTone(_isLight ? 40 : 80);
+  Color get onSecondary => secondaryTone(_isLight ? 100 : 20);
+  Color get secondaryContainer => secondaryTone(_isLight ? 90 : 30);
+  Color get onSecondaryContainer => secondaryTone(_isLight ? 10 : 90);
+
+  Color tertiaryTone(int tone) => Color(palette.tertiary.get(tone));
+  Color get tertiary => tertiaryTone(_isLight ? 40 : 80);
+  Color get onTertiary => tertiaryTone(_isLight ? 100 : 20);
+  Color get tertiaryContainer => tertiaryTone(_isLight ? 90 : 30);
+  Color get onTertiaryContainer => tertiaryTone(_isLight ? 10 : 90);
+
+  Color errorTone(int tone) => Color(palette.error.get(tone));
+  Color get error => errorTone(_isLight ? 40 : 80);
+  Color get onError => errorTone(_isLight ? 100 : 20);
+  Color get errorContainer => errorTone(_isLight ? 90 : 30);
+  Color get onErrorContainer => errorTone(_isLight ? 10 : 90);
+
+  Color neutralTone(int tone) => Color(palette.neutral.get(tone));
+  Color get background => neutralTone(_isLight ? 10 : 90);
+  Color get onBackground => neutralTone(_isLight ? 10 : 90);
+  Color get surface => neutralTone(_isLight ? 99 : 10);
+  Color get onSurface => neutralTone(_isLight ? 10 : 90);
+
+  Color neutralVariantTone(int tone) => Color(palette.neutralVariant.get(tone));
+  Color get surfaceVariant => neutralVariantTone(_isLight ? 90 : 30);
+  Color get onSurfaceVaraiant => neutralVariantTone(_isLight ? 30 : 80);
+  Color get outline => neutralVariantTone(_isLight ? 50 : 60);
 }

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -10,21 +10,38 @@ class WiredashThemeData {
     DeviceClass deviceClass = DeviceClass.handsetLarge400,
     Color? primaryColor,
     Color? secondaryColor,
+    Color? textOnPrimary,
+    Color? textOnSecondary,
     Color? primaryTextColor,
     Color? secondaryTextColor,
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
     Color? appBackgroundColor,
+    Color? appHandleBackgroundColor,
     Color? errorColor,
     String? fontFamily,
     Size? windowSize,
   }) {
+    final primary = primaryColor ?? const Color(0xff1A56DB);
+    final secondary = secondaryColor ?? const Color(0xffE8EEFB);
+
+    final textOnPrimaryColor = textOnPrimary ??
+        (primary.brightness == Brightness.dark
+            ? const Color(0xff030A1C)
+            : const Color(0xffe3e3e3));
+    final textOnSecondaryColor = textOnSecondary ??
+        (secondary.brightness == Brightness.dark
+            ? const Color(0xff8C93A2)
+            : const Color(0xb0a4a4a4));
+
     if (brightness == Brightness.light) {
       return WiredashThemeData._(
         brightness: brightness,
         deviceClass: deviceClass,
-        primaryColor: primaryColor ?? const Color(0xff1A56DB),
-        secondaryColor: secondaryColor ?? const Color(0xffE8EEFB),
+        primaryColor: primary,
+        secondaryColor: secondary,
+        textOnPrimary: textOnPrimaryColor,
+        textOnSecondary: textOnSecondaryColor,
         primaryTextColor: primaryTextColor ?? const Color(0xff030A1C),
         secondaryTextColor: secondaryTextColor ?? const Color(0xff8C93A2),
         primaryBackgroundColor:
@@ -32,6 +49,8 @@ class WiredashThemeData {
         secondaryBackgroundColor:
             secondaryBackgroundColor ?? const Color(0xfff5f6f8),
         appBackgroundColor: appBackgroundColor ?? const Color(0xfff5f6f8),
+        appHandleBackgroundColor:
+            appHandleBackgroundColor ?? const Color(0xfff5f6f8),
         errorColor: errorColor ?? const Color(0xffff5c6a),
         fontFamily: fontFamily ?? _fontFamily,
         windowSize: windowSize ?? Size.zero,
@@ -40,8 +59,10 @@ class WiredashThemeData {
       return WiredashThemeData._(
         brightness: brightness,
         deviceClass: deviceClass,
-        primaryColor: primaryColor ?? const Color(0xff1A56DB),
-        secondaryColor: secondaryColor ?? const Color(0xffE8EEFB),
+        primaryColor: primary,
+        secondaryColor: secondary,
+        textOnPrimary: textOnPrimaryColor,
+        textOnSecondary: textOnSecondaryColor,
         primaryTextColor: primaryTextColor ?? const Color(0xffe3e3e3),
         secondaryTextColor: secondaryTextColor ?? const Color(0xb0a4a4a4),
         primaryBackgroundColor:
@@ -49,6 +70,8 @@ class WiredashThemeData {
         secondaryBackgroundColor:
             secondaryBackgroundColor ?? const Color(0xfff5f6f8),
         appBackgroundColor: appBackgroundColor ?? const Color(0xff3d3e3e),
+        appHandleBackgroundColor:
+            appHandleBackgroundColor ?? const Color(0xff3d3e3e),
         errorColor: errorColor ?? const Color(0xffdb000a),
         fontFamily: fontFamily ?? _fontFamily,
         windowSize: windowSize ?? Size.zero,
@@ -73,8 +96,8 @@ class WiredashThemeData {
       final secondary = secondaryColor ??
           primaryHsl
               .withHue((primaryHsl.hue - 10) % 360)
-              .withSaturation(.60)
-              .withLightness(.90)
+              .withSaturation((primaryHsl.saturation * 0.3).clamp(0.1, 1.0))
+              .withLightness((primaryHsl.lightness * 1.2).clamp(0.1, 1.0))
               .toColor();
       return theme.copyWith(
         secondaryColor: secondary,
@@ -82,13 +105,14 @@ class WiredashThemeData {
             primaryHsl.withSaturation(1.0).withLightness(1.0).toColor(),
         secondaryBackgroundColor:
             primaryHsl.withSaturation(.8).withLightness(0.95).toColor(),
+        appHandleBackgroundColor: primaryHsl.withLightness(0.1).toColor(),
       );
     } else {
       final secondary = secondaryColor ??
           primaryHsl
               .withHue((primaryHsl.hue - 10) % 360)
-              .withSaturation(.1)
-              .withLightness(.1)
+              .withSaturation((primaryHsl.saturation * 0.2).clamp(0.1, 1.0))
+              .withLightness((primaryHsl.lightness * 0.5).clamp(0.1, 1.0))
               .toColor();
       return theme.copyWith(
         secondaryColor: secondary,
@@ -96,6 +120,7 @@ class WiredashThemeData {
             primaryHsl.withSaturation(0.04).withLightness(0.2).toColor(),
         secondaryBackgroundColor:
             primaryHsl.withSaturation(0.0).withLightness(0.1).toColor(),
+        appHandleBackgroundColor: primaryHsl.withLightness(0.3).toColor(),
       );
     }
   }
@@ -104,11 +129,14 @@ class WiredashThemeData {
     required this.brightness,
     required this.primaryColor,
     required this.secondaryColor,
+    required this.textOnPrimary,
+    required this.textOnSecondary,
     required this.primaryTextColor,
     required this.secondaryTextColor,
     required this.primaryBackgroundColor,
     required this.secondaryBackgroundColor,
     required this.appBackgroundColor,
+    required this.appHandleBackgroundColor,
     required this.errorColor,
     required this.deviceClass,
     required this.fontFamily,
@@ -120,6 +148,9 @@ class WiredashThemeData {
   final Color primaryColor;
   final Color secondaryColor;
 
+  final Color textOnPrimary;
+  final Color textOnSecondary;
+
   final Color primaryTextColor;
   final Color secondaryTextColor;
 
@@ -128,6 +159,9 @@ class WiredashThemeData {
   final Color errorColor;
 
   final Color appBackgroundColor;
+
+  /// The color of the app handle, the "Return to app" bar above the app
+  final Color appHandleBackgroundColor;
 
   final DeviceClass deviceClass;
   final Size windowSize;
@@ -274,11 +308,14 @@ class WiredashThemeData {
           brightness == other.brightness &&
           primaryColor == other.primaryColor &&
           secondaryColor == other.secondaryColor &&
+          textOnPrimary == other.textOnPrimary &&
+          textOnSecondary == other.textOnSecondary &&
           primaryTextColor == other.primaryTextColor &&
           secondaryTextColor == other.secondaryTextColor &&
           primaryBackgroundColor == other.primaryBackgroundColor &&
           secondaryBackgroundColor == other.secondaryBackgroundColor &&
           appBackgroundColor == other.appBackgroundColor &&
+          appHandleBackgroundColor == other.appHandleBackgroundColor &&
           errorColor == other.errorColor &&
           deviceClass == other.deviceClass &&
           windowSize == other.windowSize &&
@@ -289,11 +326,14 @@ class WiredashThemeData {
       brightness.hashCode ^
       primaryColor.hashCode ^
       secondaryColor.hashCode ^
+      textOnPrimary.hashCode ^
+      textOnSecondary.hashCode ^
       primaryTextColor.hashCode ^
       secondaryTextColor.hashCode ^
       primaryBackgroundColor.hashCode ^
       secondaryBackgroundColor.hashCode ^
       appBackgroundColor.hashCode ^
+      appHandleBackgroundColor.hashCode ^
       errorColor.hashCode ^
       deviceClass.hashCode ^
       windowSize.hashCode ^
@@ -305,11 +345,14 @@ class WiredashThemeData {
         'brightness: $brightness, '
         'primaryColor: $primaryColor, '
         'secondaryColor: $secondaryColor, '
+        'textOnPrimary: $textOnPrimary, '
+        'textOnSecondary: $textOnSecondary, '
         'primaryTextColor: $primaryTextColor, '
         'secondaryTextColor: $secondaryTextColor, '
         'primaryBackgroundColor: $primaryBackgroundColor, '
         'secondaryBackgroundColor: $secondaryBackgroundColor, '
         'appBackgroundColor: $appBackgroundColor, '
+        'appBackgroundColor: $appHandleBackgroundColor, '
         'errorColor: $errorColor, '
         'deviceClass: $deviceClass, '
         'fontFamily: $fontFamily, '
@@ -321,11 +364,14 @@ class WiredashThemeData {
     Brightness? brightness,
     Color? primaryColor,
     Color? secondaryColor,
+    Color? textOnPrimary,
+    Color? textOnSecondary,
     Color? primaryTextColor,
     Color? secondaryTextColor,
     Color? primaryBackgroundColor,
     Color? secondaryBackgroundColor,
     Color? appBackgroundColor,
+    Color? appHandleBackgroundColor,
     Color? errorColor,
     DeviceClass? deviceClass,
     String? fontFamily,
@@ -335,6 +381,8 @@ class WiredashThemeData {
       brightness: brightness ?? this.brightness,
       primaryColor: primaryColor ?? this.primaryColor,
       secondaryColor: secondaryColor ?? this.secondaryColor,
+      textOnPrimary: textOnPrimary ?? this.textOnPrimary,
+      textOnSecondary: textOnSecondary ?? this.textOnSecondary,
       primaryTextColor: primaryTextColor ?? this.primaryTextColor,
       secondaryTextColor: secondaryTextColor ?? this.secondaryTextColor,
       primaryBackgroundColor:
@@ -342,6 +390,8 @@ class WiredashThemeData {
       secondaryBackgroundColor:
           secondaryBackgroundColor ?? this.secondaryBackgroundColor,
       appBackgroundColor: appBackgroundColor ?? this.appBackgroundColor,
+      appHandleBackgroundColor:
+          appHandleBackgroundColor ?? this.appHandleBackgroundColor,
       errorColor: errorColor ?? this.errorColor,
       deviceClass: deviceClass ?? this.deviceClass,
       fontFamily: fontFamily ?? this.fontFamily,

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -88,16 +88,17 @@ class WiredashThemeData {
       secondaryColor = null;
     }
     final primaryHsl = HSLColor.fromColor(primaryColor);
+    final primaryHsv = HSVColor.fromColor(primaryColor);
 
     final theme =
         WiredashThemeData(brightness: brightness, primaryColor: primaryColor);
 
     if (brightness == Brightness.light) {
       final secondary = secondaryColor ??
-          primaryHsl
+          primaryHsv
+              .withSaturation((primaryHsv.saturation * 0.4).clamp(0.0, 0.2))
               .withHue((primaryHsl.hue - 10) % 360)
-              .withSaturation((primaryHsl.saturation * 0.3).clamp(0.1, 1.0))
-              .withLightness((primaryHsl.lightness * 1.2).clamp(0.1, 1.0))
+              .withValue((primaryHsv.value + 0.3).clamp(0.1, 1.0))
               .toColor();
       return theme.copyWith(
         secondaryColor: secondary,
@@ -120,7 +121,11 @@ class WiredashThemeData {
             primaryHsl.withSaturation(0.04).withLightness(0.2).toColor(),
         secondaryBackgroundColor:
             primaryHsl.withSaturation(0.0).withLightness(0.1).toColor(),
-        appHandleBackgroundColor: primaryHsl.withLightness(0.3).toColor(),
+        appHandleBackgroundColor: primaryHsl
+            .withHue((primaryHsl.hue + 10) % 360)
+            .withLightness((primaryHsl.lightness * 0.5).clamp(0.2, 0.4))
+            .withSaturation((primaryHsl.saturation * 1.4).clamp(0.1, 1.0))
+            .toColor(),
       );
     }
   }

--- a/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
+++ b/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
@@ -8,9 +8,13 @@ class FakeAppStatusBar extends StatelessWidget {
   const FakeAppStatusBar({
     Key? key,
     required this.height,
+    required this.color,
+    required this.textColor,
   }) : super(key: key);
 
   final double height;
+  final Color color;
+  final Color textColor;
 
   @override
   Widget build(BuildContext context) {
@@ -33,8 +37,8 @@ class FakeAppStatusBar extends StatelessWidget {
       ),
       child: Container(
         height: height,
-        decoration: const BoxDecoration(
-          color: Colors.black12,
+        decoration: BoxDecoration(
+          color: color,
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(

--- a/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
+++ b/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
@@ -9,18 +9,20 @@ class FakeAppStatusBar extends StatelessWidget {
     Key? key,
     required this.height,
     required this.color,
-    required this.textColor,
   }) : super(key: key);
 
   final double height;
   final Color color;
-  final Color textColor;
 
   @override
   Widget build(BuildContext context) {
     final isMobile = defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS;
     final double barContentHeight = math.min(isMobile ? 14 : 16, height);
+
+    final luminance = color.computeLuminance();
+    final blackOrWhite =
+        luminance < 0.4 ? const Color(0xffffffff) : const Color(0xff000000);
 
     return DefaultTextStyle(
       style: TextStyle(
@@ -31,8 +33,7 @@ class FakeAppStatusBar extends StatelessWidget {
             color: Color.fromARGB(30, 0, 0, 0),
           ),
         ],
-        // TODO make the fake systemChromeUi style customizable in WiredashTheme
-        color: Colors.white,
+        color: blackOrWhite,
         fontSize: barContentHeight,
       ),
       child: Container(
@@ -57,6 +58,7 @@ class FakeAppStatusBar extends StatelessWidget {
                         'assets/images/logo_white.png',
                         package: 'wiredash',
                         height: barContentHeight + 5,
+                        color: blackOrWhite,
                       ),
                       SizedBox(width: 0.5 * barContentHeight),
                       const Text('Wiredash'),

--- a/lib/src/core/widgets/backdrop/step_page_scaffold.dart
+++ b/lib/src/core/widgets/backdrop/step_page_scaffold.dart
@@ -144,12 +144,14 @@ class StepPageScaffoldState extends State<StepPageScaffold> {
                       SizedBox(
                         height: 16,
                         child: VerticalDivider(
-                          color: context.theme.captionTextStyle.color,
+                          color: context.theme.secondaryTextOnBackgroundColor,
                         ),
                       ),
                       Expanded(
                         child: DefaultTextStyle(
-                          style: context.theme.captionTextStyle,
+                          style: context.theme.captionTextStyle.copyWith(
+                            color: context.theme.secondaryTextOnBackgroundColor,
+                          ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           child: widget.shortTitle!,
@@ -168,8 +170,8 @@ class StepPageScaffoldState extends State<StepPageScaffold> {
                           return TronIcon(
                             Wirecons.x,
                             color: Color.lerp(
-                              context.theme.secondaryTextColor,
-                              context.theme.primaryTextColor,
+                              context.theme.primaryTextOnBackgroundColor,
+                              context.theme.secondaryTextOnBackgroundColor,
                               anims.hoveredAnim.value,
                             ),
                           );
@@ -199,9 +201,14 @@ class StepPageScaffoldState extends State<StepPageScaffold> {
                           });
                         },
                         child: _reallyTimer == null
-                            ? widget.discardLabel!
+                            ? DefaultTextStyle(
+                                style: context.theme.captionTextStyle.copyWith(
+                                  color: context
+                                      .theme.secondaryTextOnBackgroundColor,
+                                ),
+                                child: widget.discardLabel!)
                             : DefaultTextStyle(
-                                style: TextStyle(
+                                style: context.theme.captionTextStyle.copyWith(
                                   color: context.theme.errorColor,
                                 ),
                                 child: widget.discardConfirmLabel ??
@@ -334,7 +341,9 @@ class StepIndicator extends StatelessWidget {
         const SizedBox(width: 12),
         Text(
           'Step $currentStep of $total',
-          style: context.theme.captionTextStyle,
+          style: context.theme.captionTextStyle.copyWith(
+            color: context.theme.secondaryTextOnBackgroundColor,
+          ),
         ),
       ],
     );

--- a/lib/src/core/widgets/backdrop/step_page_scaffold.dart
+++ b/lib/src/core/widgets/backdrop/step_page_scaffold.dart
@@ -206,7 +206,8 @@ class StepPageScaffoldState extends State<StepPageScaffold> {
                                   color: context
                                       .theme.secondaryTextOnBackgroundColor,
                                 ),
-                                child: widget.discardLabel!)
+                                child: widget.discardLabel!,
+                              )
                             : DefaultTextStyle(
                                 style: context.theme.captionTextStyle.copyWith(
                                   color: context.theme.errorColor,

--- a/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
+++ b/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
@@ -657,13 +657,18 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
     ];
   }
 
+  static const double _minHandleHeight = 20;
   double get _handleHeight {
+    final topPadding = _mediaQueryData.padding.top;
+    if (topPadding > 0) {
+      return math.max(_minHandleHeight, topPadding);
+    }
     if (kIsWeb) {
       return 36.0;
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       return 44.0;
     } else {
-      return math.min(_mediaQueryData.padding.top, 36.0);
+      return 36.0;
     }
   }
 
@@ -676,7 +681,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       animation: _backdropAnimationController,
       builder: (context, child) {
         // rounds _handleHeight up to exactly match
-        final double upRoundedHandleHeight = () {
+        final double scaledAndUpRoundedHandleHeight = () {
           final appScale =
               _appTransformAnimation!.value!.width / _rectAppFillsScreen.width;
           final scaledHandleHeight = _handleHeight * appScale;
@@ -688,6 +693,11 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         }();
 
         final withDesktopHandle = _mediaQueryData.viewPadding.top == 0;
+
+        final fakeAppStatusBar = FakeAppStatusBar(
+          height: _appHandleAnimation.value * scaledAndUpRoundedHandleHeight,
+          color: context.theme.appHandleBackgroundColor,
+        );
 
         return SizedBox(
           height: _mediaQueryData.size.height + _handleHeight,
@@ -728,32 +738,17 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
                           ),
                         ),
                         if (withDesktopHandle)
-                          Positioned(
-                            top: 0,
-                            left: 0,
-                            right: 0,
-                            child: SizedBox(
-                              child: FakeAppStatusBar(
-                                height: _appHandleAnimation.value *
-                                    scaledAndUpRoundedHandleHeight,
-                                color: context.theme.appHandleBackgroundColor,
-                                textColor: context.theme.primaryTextColor,
-                              ),
-                            ),
+                          Align(
+                            alignment: Alignment.topCenter,
+                            child: fakeAppStatusBar,
                           ),
                       ],
                     ),
                   ),
                   if (!withDesktopHandle)
                     FadeTransition(
-                      // TODO show some handle when in screencapture mode?
                       opacity: _appHandleAnimation,
-                      child: FakeAppStatusBar(
-                        height: _appHandleAnimation.value *
-                            scaledAndUpRoundedHandleHeight,
-                        color: context.theme.appHandleBackgroundColor,
-                        textColor: context.theme.primaryTextColor,
-                      ),
+                      child: fakeAppStatusBar,
                     ),
                 ],
               ),

--- a/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
+++ b/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
@@ -657,16 +657,15 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
     ];
   }
 
-  final _handleHeight = () {
+  double get _handleHeight {
     if (kIsWeb) {
       return 36.0;
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       return 44.0;
     } else {
-      // TODO find a good value for windows/linux
-      return 36.0;
+      return math.min(_mediaQueryData.padding.top, 36.0);
     }
-  }();
+  }
 
   /// Clips and adds shadow to the app
   ///
@@ -733,14 +732,12 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
                             top: 0,
                             left: 0,
                             right: 0,
-                            child: ColoredBox(
-                              color: context.theme.primaryColor,
-                              child: SizedBox(
+                            child: SizedBox(
+                              child: FakeAppStatusBar(
                                 height: _appHandleAnimation.value *
-                                    upRoundedHandleHeight,
-                                child: FakeAppStatusBar(
-                                  height: upRoundedHandleHeight,
-                                ),
+                                    scaledAndUpRoundedHandleHeight,
+                                color: context.theme.appHandleBackgroundColor,
+                                textColor: context.theme.primaryTextColor,
                               ),
                             ),
                           ),
@@ -748,20 +745,14 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
                     ),
                   ),
                   if (!withDesktopHandle)
-                    Positioned(
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      height: _mediaQueryData.viewPadding.top,
-                      child: FadeTransition(
-                        // TODO show some handle when in screencapture mode?
-                        opacity: _appHandleAnimation,
-                        child: ColoredBox(
-                          color: context.theme.primaryColor,
-                          child: FakeAppStatusBar(
-                            height: _mediaQueryData.viewPadding.top,
-                          ),
-                        ),
+                    FadeTransition(
+                      // TODO show some handle when in screencapture mode?
+                      opacity: _appHandleAnimation,
+                      child: FakeAppStatusBar(
+                        height: _appHandleAnimation.value *
+                            scaledAndUpRoundedHandleHeight,
+                        color: context.theme.appHandleBackgroundColor,
+                        textColor: context.theme.primaryTextColor,
                       ),
                     ),
                 ],

--- a/lib/src/core/widgets/tron/tron_button.dart
+++ b/lib/src/core/widgets/tron/tron_button.dart
@@ -14,6 +14,7 @@ class TronButton extends StatefulWidget {
     this.child,
     this.onTap,
     this.color,
+    this.textColor,
     this.iconOffset = Offset.zero,
     Key? key,
   })  : assert(
@@ -23,6 +24,7 @@ class TronButton extends StatefulWidget {
         super(key: key);
 
   final Color? color;
+  final Color? textColor;
   final IconData? leadingIcon;
   final IconData? trailingIcon;
   final Offset iconOffset;
@@ -88,6 +90,13 @@ class _TronButtonState extends State<TronButton>
   }
 
   Color get _iconColor {
+    final textColor = widget.textColor;
+    if (textColor != null) {
+      if (!_enabled) {
+        return textColor.withOpacity(0.3);
+      }
+      return textColor;
+    }
     final buttonColor = _buttonColor;
     final luminance = buttonColor.computeLuminance();
     final hsl = HSLColor.fromColor(buttonColor);
@@ -98,7 +107,7 @@ class _TronButtonState extends State<TronButton>
       return blackOrWhite.withOpacity(0.3);
     }
 
-    return blackOrWhite.withOpacity(math.max(hsl.saturation, 0.8));
+    return blackOrWhite.withOpacity(math.max(hsl.saturation, 0.9));
   }
 
   @override

--- a/lib/src/core/widgets/tron/tron_button.dart
+++ b/lib/src/core/widgets/tron/tron_button.dart
@@ -72,16 +72,16 @@ class _TronButtonState extends State<TronButton>
     final buttonColor = widget.color ?? context.theme.primaryColor;
 
     if (!_enabled) {
-      return buttonColor.lighten(0.3);
+      return buttonColor.lighten(0.03);
     }
 
     if (_pressed) {
       // ignore: avoid_redundant_argument_values
-      return buttonColor.darken(0.1);
+      return buttonColor.darken(0.02);
     }
 
     if (_hovered) {
-      return buttonColor.darken(0.05);
+      return buttonColor.lighten(0.02);
     }
 
     return buttonColor;
@@ -212,15 +212,15 @@ class _TronButtonState extends State<TronButton>
     widget.onTap!.call();
     setState(() {
       _pressed = false;
-      _controller.reverse();
     });
+    _controller.forward().then((value) => _controller.reverse());
   }
 
   void _handleTapCancel() {
     setState(() {
       _pressed = false;
-      _controller.reverse();
     });
+    _controller.forward().then((value) => _controller.reverse());
   }
 }
 

--- a/lib/src/core/widgets/tron/tron_progress_indicator.dart
+++ b/lib/src/core/widgets/tron/tron_progress_indicator.dart
@@ -94,7 +94,7 @@ class _TronProgressIndicatorState extends State<TronProgressIndicator>
               context.theme.primaryColor,
               _currentProgress,
               context.theme.primaryColor.darken(0.05),
-              context.theme.primaryContainerColor,
+              context.theme.primaryColor.withOpacity(0.2),
               _nextProgress,
             ),
           ),

--- a/lib/src/core/widgets/tron/tron_progress_indicator.dart
+++ b/lib/src/core/widgets/tron/tron_progress_indicator.dart
@@ -93,7 +93,8 @@ class _TronProgressIndicatorState extends State<TronProgressIndicator>
             painter: _TronProgressPainter(
               context.theme.primaryColor,
               _currentProgress,
-              context.theme.primaryColor.withAlpha(64),
+              context.theme.primaryColor.darken(0.05),
+              context.theme.primaryContainerColor,
               _nextProgress,
             ),
           ),
@@ -107,6 +108,7 @@ class _TronProgressPainter extends CustomPainter {
   const _TronProgressPainter(
     this.colorCurrent,
     this.currentProgress,
+    this.circleColor,
     this.colorNext,
     this.nextProgress,
   );
@@ -115,6 +117,7 @@ class _TronProgressPainter extends CustomPainter {
 
   final Color colorCurrent;
   final Color colorNext;
+  final Color circleColor;
   final double currentProgress;
   final double nextProgress;
 
@@ -123,7 +126,7 @@ class _TronProgressPainter extends CustomPainter {
     final circlePaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = _borderWidth
-      ..color = colorCurrent;
+      ..color = circleColor;
 
     final fillPaint = Paint()
       ..style = PaintingStyle.fill

--- a/lib/src/feedback/steps/step_1_feedback_message.dart
+++ b/lib/src/feedback/steps/step_1_feedback_message.dart
@@ -70,10 +70,15 @@ class _Step1FeedbackMessageState extends State<Step1FeedbackMessage>
               cursorColor: context.theme.primaryColor,
               decoration: InputDecoration(
                 filled: true,
-                fillColor: context.theme.primaryBackgroundColor,
+                // fillColor: context.theme.primaryContainerColor,
+                // focusColor: context.theme.primaryBackgroundColor,
+                // hoverColor: context.theme.primaryBackgroundColor,
+                fillColor: context.theme.surfaceColor,
+                // focusColor: Colors.white70,
+                hoverColor: Colors.transparent,
                 enabledBorder: OutlineInputBorder(
                   borderSide: BorderSide(
-                    color: context.theme.secondaryColor.withOpacity(0.5),
+                    color: context.theme.primaryContainerColor,
                   ),
                 ),
                 focusedBorder: OutlineInputBorder(
@@ -89,8 +94,6 @@ class _Step1FeedbackMessageState extends State<Step1FeedbackMessage>
                     color: context.theme.errorColor.lighten(),
                   ),
                 ),
-                focusColor: context.theme.primaryBackgroundColor,
-                hoverColor: context.theme.primaryBackgroundColor,
                 hintText:
                     'There’s an unknown error when I try to change my avatar...',
                 contentPadding:

--- a/lib/src/feedback/steps/step_2_labels.dart
+++ b/lib/src/feedback/steps/step_2_labels.dart
@@ -124,16 +124,13 @@ class _Label extends StatelessWidget {
           child: Container(
             constraints: const BoxConstraints(maxHeight: 41, minHeight: 41),
             decoration: BoxDecoration(
-                color: Color.lerp(
-                  context.theme.primaryContainerColor,
-                  context.theme.surfaceColor,
-                  anims.pressedAnim.value + anims.selectedAnim.value,
-                ),
+                color: context.theme.primaryContainerColor,
                 borderRadius: BorderRadius.circular(10),
                 border: Border.all(
                   width: 2,
                   // tint
-                  color: context.theme.primaryColor.withOpacity(() {
+                  color:
+                      context.theme.textOnPrimaryContainerColor.withOpacity(() {
                     if (state.pressed || state.selected) {
                       return 1.0;
                     }
@@ -154,7 +151,7 @@ class _Label extends StatelessWidget {
                   fontWeight: FontWeight.w800,
                   color: Color.lerp(
                     context.theme.textOnPrimaryContainerColor,
-                    context.theme.primaryColor,
+                    context.theme.primaryTextOnSurfaceColor,
                     anims.selectedAnim.value,
                   ),
                 ),

--- a/lib/src/feedback/steps/step_2_labels.dart
+++ b/lib/src/feedback/steps/step_2_labels.dart
@@ -119,43 +119,47 @@ class _Label extends StatelessWidget {
       onTap: toggleSelection,
       selected: selected,
       builder: (context, state, anims) {
-        return Container(
-          constraints: const BoxConstraints(maxHeight: 41, minHeight: 41),
-          decoration: BoxDecoration(
-            color: Color.lerp(
-              context.theme.secondaryBackgroundColor,
-              context.theme.secondaryColor,
-              anims.hoveredAnim.value +
-                  anims.pressedAnim.value +
-                  anims.selectedAnim.value,
-            ),
-            borderRadius: BorderRadius.circular(10),
-            border: selected
-                ? Border.all(
-                    width: 2,
-                    // tint
-                    color: context.theme.primaryColor,
-                  )
-                : Border.all(
-                    width: 2,
-                    color: Colors.transparent,
-                  ),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
-          child: Align(
-            widthFactor: 1,
-            child: AnimatedDefaultTextStyle(
-              duration: const Duration(milliseconds: 225),
-              curve: Curves.ease,
-              style: TextStyle(
-                fontWeight: FontWeight.w800,
+        return Opacity(
+          opacity: state.selected ? 1.0 : 0.5,
+          child: Container(
+            constraints: const BoxConstraints(maxHeight: 41, minHeight: 41),
+            decoration: BoxDecoration(
                 color: Color.lerp(
-                  context.theme.primaryColor.withOpacity(0.8),
-                  context.theme.primaryColor,
-                  anims.selectedAnim.value,
+                  context.theme.primaryContainerColor,
+                  context.theme.surfaceColor,
+                  anims.pressedAnim.value + anims.selectedAnim.value,
                 ),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  width: 2,
+                  // tint
+                  color: context.theme.primaryColor.withOpacity(() {
+                    if (state.pressed || state.selected) {
+                      return 1.0;
+                    }
+                    if (state.hovered) {
+                      return 0.25;
+                    }
+
+                    return 0.0;
+                  }()),
+                )),
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
+            child: Align(
+              widthFactor: 1,
+              child: AnimatedDefaultTextStyle(
+                duration: const Duration(milliseconds: 225),
+                curve: Curves.ease,
+                style: TextStyle(
+                  fontWeight: FontWeight.w800,
+                  color: Color.lerp(
+                    context.theme.textOnPrimaryContainerColor,
+                    context.theme.primaryColor,
+                    anims.selectedAnim.value,
+                  ),
+                ),
+                child: Text(label.title),
               ),
-              child: Text(label.title),
             ),
           ),
         );

--- a/lib/src/feedback/steps/step_2_labels.dart
+++ b/lib/src/feedback/steps/step_2_labels.dart
@@ -121,16 +121,21 @@ class _Label extends StatelessWidget {
       builder: (context, state, anims) {
         return Opacity(
           opacity: state.selected ? 1.0 : 0.5,
-          child: Container(
+          child: AnimatedContainer(
             constraints: const BoxConstraints(maxHeight: 41, minHeight: 41),
             decoration: BoxDecoration(
-                color: context.theme.primaryContainerColor,
-                borderRadius: BorderRadius.circular(10),
-                border: Border.all(
-                  width: 2,
-                  // tint
-                  color:
-                      context.theme.textOnPrimaryContainerColor.withOpacity(() {
+              color: () {
+                if (state.selected) {
+                  return context.theme.primaryContainerColor;
+                }
+                return context.theme.secondaryContainerColor;
+              }(),
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                width: 2,
+                // tint
+                color: context.theme.textOnPrimaryContainerColor.withOpacity(
+                  () {
                     if (state.pressed || state.selected) {
                       return 1.0;
                     }
@@ -139,9 +144,12 @@ class _Label extends StatelessWidget {
                     }
 
                     return 0.0;
-                  }()),
-                )),
+                  }(),
+                ),
+              ),
+            ),
             padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
+            duration: const Duration(milliseconds: 225),
             child: Align(
               widthFactor: 1,
               child: AnimatedDefaultTextStyle(
@@ -149,9 +157,10 @@ class _Label extends StatelessWidget {
                 curve: Curves.ease,
                 style: TextStyle(
                   fontWeight: FontWeight.w800,
+                  fontSize: 14,
                   color: Color.lerp(
+                    context.theme.textOnSecondaryContainerColor,
                     context.theme.textOnPrimaryContainerColor,
-                    context.theme.primaryTextOnSurfaceColor,
                     anims.selectedAnim.value,
                   ),
                 ),

--- a/lib/src/feedback/steps/step_3_screenshot_overview.dart
+++ b/lib/src/feedback/steps/step_3_screenshot_overview.dart
@@ -181,14 +181,14 @@ class AttachmentPreview extends StatelessWidget {
       children: [
         Elevation(
           child: ClipRRect(
-            borderRadius: BorderRadius.circular(2),
+            borderRadius: BorderRadius.circular(10),
             child: visual,
           ),
         ),
         Padding(
           padding: const EdgeInsets.all(4),
           child: TronButton(
-            color: context.theme.secondaryBackgroundColor,
+            color: context.theme.primaryContainerColor,
             onTap: () {
               context.feedbackModel.deleteAttachment(attachment);
             },
@@ -196,7 +196,7 @@ class AttachmentPreview extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 4),
               child: TronIcon(
                 Wirecons.trash,
-                color: context.theme.primaryColor,
+                color: context.theme.textOnPrimaryContainerColor,
               ),
             ),
           ),
@@ -237,8 +237,8 @@ class _NewAttachment extends StatelessWidget {
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(10),
                 color: Color.lerp(
-                  context.theme.primaryBackgroundColor,
-                  context.theme.primaryContainerColor,
+                  context.theme.surfaceColor,
+                  context.theme.surfaceColor.darken(0.05),
                   (anims.pressedAnim.value + anims.hoveredAnim.value) * 0.1,
                 ),
               ),
@@ -246,16 +246,16 @@ class _NewAttachment extends StatelessWidget {
               child: AbsorbPointer(
                 child: TronButton(
                   color: state.pressed
-                      ? context.theme.secondaryBackgroundColor
+                      ? context.theme.primaryContainerColor
                           .let(hoverColorAdjustment)
-                      : context.theme.secondaryBackgroundColor
+                      : context.theme.primaryContainerColor
                           .let(hoverColorAdjustment),
                   onTap: () {
                     // nothing but style the button as if it is enabled.
                   },
                   child: TronIcon(
                     Wirecons.plus,
-                    color: context.theme.primaryColor,
+                    color: context.theme.textOnPrimaryContainerColor,
                   ),
                 ),
               ),

--- a/lib/src/feedback/steps/step_6_submit.dart
+++ b/lib/src/feedback/steps/step_6_submit.dart
@@ -79,7 +79,7 @@ class _Step6SubmitState extends State<Step6Submit> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
       child: ListTileTheme(
-        textColor: context.theme.secondaryTextColor,
+        textColor: context.theme.secondaryTextOnBackgroundColor,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/feedback/ui/screenshot_bar.dart
+++ b/lib/src/feedback/ui/screenshot_bar.dart
@@ -36,11 +36,15 @@ class ScreenshotBar extends StatelessWidget {
             context.wiredashModel.services.screenCaptureController.error == null
                 ? 'Save'
                 : 'OK',
-        onTap: feedbackStatus == FeedbackFlowStatus.screenshotDrawing
-            ? () {
-                context.feedbackModel.createMasterpiece();
-              }
-            : null,
+        onTap: () {
+          if (feedbackStatus == FeedbackFlowStatus.screenshotDrawing) {
+            return () => context.feedbackModel.createMasterpiece();
+          }
+          if (feedbackStatus == FeedbackFlowStatus.screenshotSaving) {
+            return () {/* show enabled while closing */};
+          }
+          return null;
+        }(),
       );
     }
 
@@ -114,7 +118,7 @@ class ScreenshotBar extends StatelessWidget {
                   ).normalize(),
                   child: AnimatedFadeWidgetSwitcher(
                     fadeInOnEnter: false,
-                    zoomFactor: 0.5,
+                    zoomFactor: 0.8,
                     alignment: Alignment.centerRight,
                     child: trailing,
                   ),

--- a/lib/src/nps/step_1_nps_rating.dart
+++ b/lib/src/nps/step_1_nps_rating.dart
@@ -242,8 +242,8 @@ class _RatingCardState extends State<_RatingCard>
                       curve: Curves.easeInOut,
                       style: TextStyle(
                         color: widget.checked
-                            ? theme.primaryTextColor
-                            : theme.secondaryTextColor,
+                            ? theme.primaryTextOnBackgroundColor
+                            : theme.secondaryTextOnBackgroundColor,
                       ),
                       duration: _controller.duration!,
                       child: Text(widget.value.toString()),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     sdk: flutter
   http: ">=0.13.0-0 <0.15.0"
   http_parser: ">=4.0.0-0 <5.0.0"
+  material_color_utilities: ">=0.1.4 <1.0.0"
   path_provider: ">=2.0.0 <3.0.0"
   shared_preferences: '>=2.0.0 <3.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   http: ">=0.13.0-0 <0.15.0"
   http_parser: ">=4.0.0-0 <5.0.0"
-  material_color_utilities: ">=0.1.4 <1.0.0"
+  material_color_utilities: ">=0.1.2 <1.0.0"
   path_provider: ">=2.0.0 <3.0.0"
   shared_preferences: '>=2.0.0 <3.0.0'
 


### PR DESCRIPTION
The automatic theming of Wiredash (using `Wiredash.of(context).show(inheritMaterialTheme: true)`) has been reworked. It worked for the most part, but some colors did not generate good secondary colors and colors like the `appHandleBackgroundColor` were not customizable.

The new auto-theme uses the `material_color_utilities` under the hood, which uses an interesting color space to generate matching color tones in different shades, exactly what Wiredash needed. More on this on https://m3.material.io/styles/color/dynamic-color/overview

It also adds new custom colors:
-  `primaryContainerColor`
- `textOnPrimaryContainerColor` (replaces `primaryTextColor`)
- `secondaryContainerColor`
- `textOnSecondaryContainerColor` (replaces `secondaryTextColor`)
- `appBackgroundColor`
- `appHandleBackgroundColor`

To test the whole thing I created a Theme customizer `example/lib/main_customizer.dart` to test out different colors in light and dark mode. That's not the final design, but functional.

 
<img width="953" alt="Screen-Shot-2022-05-09-15-02-20 10" src="https://user-images.githubusercontent.com/1096485/167417290-838cac33-d4c3-4e7e-bb82-e63eb736365b.png">
<img width="949" alt="Screen-Shot-2022-05-09-15-02-24 86" src="https://user-images.githubusercontent.com/1096485/167417299-faaec497-c1c7-4a3f-9a68-7dd714d1052e.png">

