### PR TITLE
Keeps the SyncEngine alive when the Wiredash widget updates

### DIFF
--- a/lib/src/core/sync/ping_job.dart
+++ b/lib/src/core/sync/ping_job.dart
@@ -4,11 +4,11 @@ import 'package:wiredash/src/core/network/wiredash_api.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 
 class PingJob extends Job {
-  final WiredashApi api;
+  final WiredashApi Function() apiProvider;
   final Future<SharedPreferences> Function() sharedPreferencesProvider;
 
   PingJob({
-    required this.api,
+    required this.apiProvider,
     required this.sharedPreferencesProvider,
   });
 
@@ -45,7 +45,7 @@ class PingJob extends Job {
     }
 
     try {
-      await api.ping();
+      await apiProvider().ping();
       await _saveLastSuccessfulPing(now);
       syncDebugPrint('ping');
     } on KillSwitchException catch (_) {

--- a/lib/src/core/sync/sync_feedback_job.dart
+++ b/lib/src/core/sync/sync_feedback_job.dart
@@ -3,10 +3,10 @@ import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/feedback/_feedback.dart';
 
 class UploadPendingFeedbackJob extends Job {
-  final FeedbackSubmitter feedbackSubmitter;
+  final FeedbackSubmitter Function() feedbackSubmitterProvider;
 
   UploadPendingFeedbackJob({
-    required this.feedbackSubmitter,
+    required this.feedbackSubmitterProvider,
   });
 
   @override
@@ -16,11 +16,11 @@ class UploadPendingFeedbackJob extends Job {
 
   @override
   Future<void> execute() async {
-    if (feedbackSubmitter is! RetryingFeedbackSubmitter) {
+    final submitter = feedbackSubmitterProvider();
+    if (submitter is! RetryingFeedbackSubmitter) {
       return;
     }
 
-    final submitter = feedbackSubmitter as RetryingFeedbackSubmitter;
     await submitter.submitPendingFeedbackItems();
 
     if (kDebugMode) {

--- a/test/sync/ping_job_test.dart
+++ b/test/sync/ping_job_test.dart
@@ -20,7 +20,7 @@ void main() {
     Future<SharedPreferences> prefsProvider() async => prefs;
 
     PingJob createPingJob() => PingJob(
-          api: api,
+          apiProvider: () => api,
           sharedPreferencesProvider: prefsProvider,
         );
 
@@ -92,8 +92,10 @@ void main() {
         api.pingInvocations.interceptor = (invocation) {
           throw const KillSwitchException();
         };
-        final pingJob =
-            PingJob(api: api, sharedPreferencesProvider: prefsProvider);
+        final pingJob = PingJob(
+          apiProvider: () => api,
+          sharedPreferencesProvider: prefsProvider,
+        );
         pingJob.execute();
         async.flushTimers();
         expect(api.pingInvocations.count, 1);
@@ -110,8 +112,10 @@ void main() {
         api.pingInvocations.interceptor = (invocation) {
           throw const SocketException('message');
         };
-        final pingJob =
-            PingJob(api: api, sharedPreferencesProvider: prefsProvider);
+        final pingJob = PingJob(
+          apiProvider: () => api,
+          sharedPreferencesProvider: prefsProvider,
+        );
         pingJob.execute();
         async.flushTimers();
         expect(api.pingInvocations.count, 1);

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -71,7 +71,7 @@ class WiredashTestRobot {
 
     // replace submitter, because for testing we always want to submit directly
     robot.services.inject<FeedbackSubmitter>(
-      (locator) => DirectFeedbackSubmitter(locator.api),
+      (locator) => DirectFeedbackSubmitter(robot.services.api),
     );
 
     return robot;
@@ -328,7 +328,7 @@ class WiredashTestRobot {
 
 WiredashServices createMockServices() {
   final services = WiredashServices();
-  services.inject<WiredashApi>((locator) => MockWiredashApi());
+  services.inject<WiredashApi>((_) => MockWiredashApi());
   return services;
 }
 


### PR DESCRIPTION
The SyncEngine (or better their jobs) depends on the WiredashApi. The WiredashApi depends on the Wiredash widget. When the Wiredash widget changes -because the secret or the projectId have might have changed - the WiredashApi gets recreated and so does the SyncEngine. Unfortunately, this cancels the inital sync where the engine waits 5s before firing the first jobs.

This fix makes sure the SyncEngine does not get recreated. It uses the same instance as long as Wiredash lives.

Why wasn't this caught with tests? Well it was tested. But in tests there is no dependency from the MockWireadshApi to the Wiredash Widget, thus not causing a rebuild. Sigh...