### PR TITLE
Remove Wiredash branding

### DIFF
--- a/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
+++ b/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
@@ -49,25 +49,8 @@ class FakeAppStatusBar extends StatelessWidget {
           ),
           child: Stack(
             children: [
-              Positioned.fill(
-                child: Opacity(
-                  opacity: 0.5,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      Image.asset(
-                        'assets/images/logo_white.png',
-                        package: 'wiredash',
-                        height: barContentHeight + 5,
-                        color: blackOrWhite,
-                      ),
-                      SizedBox(width: 0.5 * barContentHeight),
-                      const Text('Wiredash'),
-                    ],
-                  ),
-                ),
-              ),
-              Center(
+              Align(
+                alignment: Alignment.centerLeft,
                 child: Text(context.l10n.backdropReturnToApp),
               ),
             ],


### PR DESCRIPTION
Customers did not like it, we will find a better branding strategy

Before
<img width="742" alt="Screen-Shot-2022-07-04-13-18-18 78" src="https://user-images.githubusercontent.com/1096485/177144240-3aa16f85-1cc4-49a4-afb6-c9f17a5f718e.png">


After
<img width="735" alt="Screen-Shot-2022-07-04-13-18-02 39" src="https://user-images.githubusercontent.com/1096485/177144258-1902d22c-3ab7-4dfe-bdfd-c55d12004b38.png">