### PR TITLE
Users can remove prefilled email address

### DIFF
--- a/lib/src/feedback/steps/step_5_email.dart
+++ b/lib/src/feedback/steps/step_5_email.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
+import 'package:wiredash/src/core/support/widget_binding_support.dart';
 import 'package:wiredash/src/feedback/_feedback.dart';
 import 'package:wiredash/src/utils/email_validator.dart';
 
@@ -18,13 +19,19 @@ class _Step5EmailState extends State<Step5Email> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _controller = TextEditingController(
-      text: FeedbackModelProvider.of(context, listen: false).userEmail,
+      // read, not watch, because initState
+      text: WiredashModelProvider.of(context, listen: false).metaData.userEmail,
     )..addListener(() {
         final text = _controller.text;
         if (context.feedbackModel.userEmail != text) {
           context.feedbackModel.userEmail = text;
         }
       });
+    widgetsBindingInstance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      FeedbackModelProvider.of(context, listen: false).userEmail =
+          _controller.text;
+    });
   }
 
   @override

--- a/test/android_back_test.dart
+++ b/test/android_back_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/core/network/wiredash_api.dart';
 import 'package:wiredash/src/core/widgets/backdrop/wiredash_backdrop.dart';
 import 'package:wiredash/src/core/widgets/larry_page_view.dart';
 import 'package:wiredash/src/feedback/_feedback.dart';
@@ -20,7 +21,7 @@ void main() {
         (tester) async {
       final robot = await WiredashTestRobot.launchApp(tester);
       final mockApi = MockWiredashApi();
-      robot.mockWiredashApi(mockApi);
+      robot.services.inject<WiredashApi>((_) => mockApi);
 
       await robot.openWiredash();
       await robot.enterFeedbackMessage('test message');

--- a/test/email_validation_test.dart
+++ b/test/email_validation_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: avoid_print
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wiredash/src/core/options/feedback_options.dart';
 import 'package:wiredash/src/core/widgets/larry_page_view.dart';
@@ -12,14 +14,14 @@ import 'util/wiredash_tester.dart';
 void main() {
   group('Email validation errors', () {
     testWidgets('Submit works with valid email', (tester) async {
-      final WiredashTestRobot robot = await goToEmailStep(tester);
+      final WiredashTestRobot robot = await tester.goToEmailStep();
       await robot.enterEmail('dash@flutter.io');
       await robot.submitEmailViaButton();
       selectByType(LarryPageView).childByType(Step6Submit).existsOnce();
     });
 
     testWidgets('Submit works without email', (tester) async {
-      final WiredashTestRobot robot = await goToEmailStep(tester);
+      final WiredashTestRobot robot = await tester.goToEmailStep();
       await robot.enterEmail('');
       await robot.submitEmailViaButton();
       selectByType(LarryPageView).childByType(Step6Submit).existsOnce();
@@ -27,7 +29,7 @@ void main() {
 
     testWidgets('Submit via button - Shows error for invalid email',
         (tester) async {
-      final WiredashTestRobot robot = await goToEmailStep(tester);
+      final WiredashTestRobot robot = await tester.goToEmailStep();
       await robot.enterEmail('invalid');
       await robot.submitEmailViaButton();
       await tester.waitUntil(
@@ -38,7 +40,7 @@ void main() {
 
     testWidgets('Submit via enter - Shows error for invalid email',
         (tester) async {
-      final WiredashTestRobot robot = await goToEmailStep(tester);
+      final WiredashTestRobot robot = await tester.goToEmailStep();
       await robot.enterEmail('invalid');
       await robot.submitEmailViaKeyboard();
       await tester.waitUntil(
@@ -64,23 +66,85 @@ void main() {
       );
     });
   });
+
+  group('email input', () {
+    testWidgets(
+        'Deleting the prefilled email address does not submit it in feedback',
+        (tester) async {
+      final robot = await tester.goToEmailStep(
+        beforeOpen: (robot) {
+          robot.wiredashController.modifyMetaData(
+            (metaData) => metaData..userEmail = 'dash@flutter.io',
+          );
+        },
+      );
+
+      // shows prefilled email
+      expect(find.text('dash@flutter.io'), findsOneWidget);
+      // user clear the email address
+      await robot.enterEmail('');
+
+      await robot.goToNextStep();
+      await robot.submitFeedback();
+
+      await tester.waitUntil(
+        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
+        findsOneWidget,
+      );
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+
+      // email is not submitted because the user actively deleted it
+      expect(submittedFeedback!.email, isNull);
+    });
+
+    testWidgets('Submit prefilled email address', (tester) async {
+      final robot = await tester.goToEmailStep(
+        beforeOpen: (robot) {
+          robot.wiredashController.modifyMetaData(
+            (metaData) => metaData..userEmail = 'dash@flutter.io',
+          );
+        },
+      );
+
+      // shows prefilled email / user leaves it as it
+      expect(find.text('dash@flutter.io'), findsOneWidget);
+      await robot.goToNextStep();
+      await robot.submitFeedback();
+
+      await tester.waitUntil(
+        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
+        findsOneWidget,
+      );
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
+      expect(submittedFeedback!.email, 'dash@flutter.io');
+    });
+  });
 }
 
-Future<WiredashTestRobot> goToEmailStep(WidgetTester tester) async {
-  final robot = await WiredashTestRobot.launchApp(
-    tester,
-    feedbackOptions: const WiredashFeedbackOptions(
-      askForUserEmail: true,
-    ),
-  );
+extension on WidgetTester {
+  Future<WiredashTestRobot> goToEmailStep({
+    FutureOr<void> Function(WiredashTestRobot robot)? beforeOpen,
+  }) async {
+    final robot = await WiredashTestRobot.launchApp(
+      this,
+      feedbackOptions: const WiredashFeedbackOptions(
+        askForUserEmail: true,
+      ),
+    );
 
-  await robot.openWiredash();
-  await robot.enterFeedbackMessage('test message');
-  await robot.goToNextStep();
-  await robot.skipScreenshot();
-  expect(
-    robot.services.feedbackModel.feedbackFlowStatus,
-    FeedbackFlowStatus.email,
-  );
-  return robot;
+    await beforeOpen?.call(robot);
+    await robot.openWiredash();
+    await robot.enterFeedbackMessage('test message');
+    await robot.goToNextStep();
+    await robot.skipScreenshot();
+    expect(
+      robot.services.feedbackModel.feedbackFlowStatus,
+      FeedbackFlowStatus.email,
+    );
+    return robot;
+  }
 }

--- a/test/email_validation_test.dart
+++ b/test/email_validation_test.dart
@@ -86,11 +86,7 @@ void main() {
 
       await robot.goToNextStep();
       await robot.submitFeedback();
-
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
@@ -112,11 +108,7 @@ void main() {
       expect(find.text('dash@flutter.io'), findsOneWidget);
       await robot.goToNextStep();
       await robot.submitFeedback();
-
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -7,7 +7,6 @@ import 'package:wiredash/src/feedback/_feedback.dart';
 import 'package:wiredash/wiredash.dart';
 
 import 'util/assert_widget.dart';
-import 'util/mock_api.dart';
 import 'util/robot.dart';
 import 'util/wiredash_tester.dart';
 
@@ -19,8 +18,6 @@ void main() {
 
     testWidgets('Send text only feedback', (tester) async {
       final robot = await WiredashTestRobot.launchApp(tester);
-      final mockApi = MockWiredashApi();
-      robot.mockWiredashApi(mockApi);
 
       await robot.openWiredash();
       await robot.enterFeedbackMessage('test message');
@@ -31,7 +28,8 @@ void main() {
         find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
         findsOneWidget,
       );
-      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback!.message, 'test message');
     });
@@ -39,8 +37,6 @@ void main() {
     testWidgets('No message shows error, entering one allows continue',
         (tester) async {
       final robot = await WiredashTestRobot.launchApp(tester);
-      final mockApi = MockWiredashApi();
-      robot.mockWiredashApi(mockApi);
       await robot.openWiredash();
 
       // Pressing next shows error
@@ -60,8 +56,6 @@ void main() {
 
     testWidgets('Send feedback with screenshot', (tester) async {
       final robot = await WiredashTestRobot.launchApp(tester);
-      final mockApi = MockWiredashApi.fake();
-      robot.mockWiredashApi(mockApi);
 
       await robot.openWiredash();
       await robot.enterFeedbackMessage('test message');
@@ -75,7 +69,8 @@ void main() {
         find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
         findsOneWidget,
       );
-      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback, isNotNull);
       expect(submittedFeedback!.message, 'test message');
@@ -84,8 +79,6 @@ void main() {
 
     testWidgets('Send feedback with multiple screenshots', (tester) async {
       final robot = await WiredashTestRobot.launchApp(tester);
-      final mockApi = MockWiredashApi.fake();
-      robot.mockWiredashApi(mockApi);
 
       await robot.openWiredash();
       await robot.enterFeedbackMessage('test message');
@@ -103,7 +96,8 @@ void main() {
         find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
         findsOneWidget,
       );
-      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback, isNotNull);
       expect(submittedFeedback!.message, 'test message');
@@ -120,8 +114,6 @@ void main() {
           ],
         ),
       );
-      final mockApi = MockWiredashApi.fake();
-      robot.mockWiredashApi(mockApi);
 
       await robot.openWiredash();
       await robot.enterFeedbackMessage('feedback with labels');
@@ -139,7 +131,8 @@ void main() {
         find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
         findsOneWidget,
       );
-      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback, isNotNull);
       expect(submittedFeedback!.labels, ['lbl-2']);
@@ -153,8 +146,6 @@ void main() {
           askForUserEmail: true,
         ),
       );
-      final mockApi = MockWiredashApi.fake();
-      robot.mockWiredashApi(mockApi);
 
       await robot.openWiredash();
       await robot.enterFeedbackMessage('test message');
@@ -167,7 +158,8 @@ void main() {
         find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
         findsOneWidget,
       );
-      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback, isNotNull);
       expect(submittedFeedback!.message, 'test message');
@@ -186,9 +178,6 @@ void main() {
           ],
         ),
       );
-      final mockApi = MockWiredashApi.fake();
-      robot.mockWiredashApi(mockApi);
-
       await robot.openWiredash();
 
       await robot.enterFeedbackMessage('test message');
@@ -210,15 +199,14 @@ void main() {
         find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
         findsOneWidget,
       );
-      final latestCall = mockApi.sendFeedbackInvocations.latest;
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
       expect(submittedFeedback!.message, 'test message');
     });
 
     testWidgets('Restore flow state when reopening', (tester) async {
       final robot = await WiredashTestRobot.launchApp(tester);
-      final mockApi = MockWiredashApi();
-      robot.mockWiredashApi(mockApi);
 
       await robot.openWiredash();
       await robot.enterFeedbackMessage('test message');

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -24,10 +24,7 @@ void main() {
       await robot.goToNextStep();
       await robot.skipScreenshot();
       await robot.submitFeedback();
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
@@ -65,10 +62,7 @@ void main() {
       await robot.confirmDrawing();
       await robot.goToNextStep();
       await robot.submitFeedback();
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
@@ -92,10 +86,7 @@ void main() {
       expect(find.byType(AttachmentPreview), findsNWidgets(2));
       await robot.goToNextStep();
       await robot.submitFeedback();
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
@@ -127,10 +118,7 @@ void main() {
 
       await robot.skipScreenshot();
       await robot.submitFeedback();
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
@@ -154,10 +142,7 @@ void main() {
       await robot.enterEmail('dash@flutter.io');
       await robot.goToNextStep();
       await robot.submitFeedback();
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;
@@ -194,11 +179,7 @@ void main() {
       await robot.enterEmail('dash@flutter.io');
       await robot.goToNextStep();
       await robot.submitFeedback();
-
-      await tester.waitUntil(
-        find.text('l10n.feedbackStep7SubmissionSuccessMessage'),
-        findsOneWidget,
-      );
+      await robot.waitUntilWiredashIsClosed();
       final latestCall =
           robot.mockServices.mockApi.sendFeedbackInvocations.latest;
       final submittedFeedback = latestCall[0] as PersistedFeedbackItem?;

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -8,7 +8,6 @@ import 'package:wiredash/wiredash.dart';
 
 import 'util/assert_widget.dart';
 import 'util/robot.dart';
-import 'util/wiredash_tester.dart';
 
 void main() {
   group('Wiredash', () {

--- a/test/util/mock_api.dart
+++ b/test/util/mock_api.dart
@@ -11,11 +11,16 @@ import 'invocation_catcher.dart';
 class MockWiredashApi implements WiredashApi {
   MockWiredashApi();
 
+  /// Returns "success" responses
   factory MockWiredashApi.fake() {
     final api = MockWiredashApi();
     api.uploadAttachmentInvocations.interceptor = (iv) {
       final randomFloat = Random().nextDouble().toString();
       return AttachmentId(randomFloat.replaceFirst('0.', ''));
+    };
+
+    api.pingInvocations.interceptor = (iv) {
+      return PingResponse();
     };
     return api;
   }

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -171,6 +171,7 @@ class WiredashTestRobot {
     print('Skipped label selection');
   }
 
+  /// Actually calling [FeedbackModel.submitFeedback]
   Future<void> submitFeedback() async {
     final step = _pageView.childByType(Step6Submit).existsOnce();
     await tester.tap(
@@ -328,6 +329,13 @@ class WiredashTestRobot {
     // ignore: invalid_use_of_protected_member
     await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
+  }
+
+  Future<void> waitUntilWiredashIsClosed() async {
+    await tester.waitUntil(
+      () => services.wiredashModel.isWiredashActive,
+      isFalse,
+    );
   }
 }
 

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -67,7 +67,7 @@ class WiredashTestRobot {
     final robot = WiredashTestRobot(tester);
 
     // Don't do actual http calls
-    robot.services.inject<WiredashApi>((_) => MockWiredashApi());
+    robot.services.inject<WiredashApi>((_) => MockWiredashApi.fake());
 
     // replace submitter, because for testing we always want to submit directly
     robot.services.inject<FeedbackSubmitter>(
@@ -92,8 +92,13 @@ class WiredashTestRobot {
     return (element.state as WiredashState).debugServices;
   }
 
-  void mockWiredashApi(WiredashApi api) {
-    services.inject<WiredashApi>((_) => api);
+  /// Equivalent to `Wiredash.of(context)`
+  WiredashController get wiredashController {
+    return WiredashController(services.wiredashModel);
+  }
+
+  WiredashMockServices get mockServices {
+    return WiredashMockServices(services);
   }
 
   Future<void> openWiredash() async {
@@ -326,9 +331,17 @@ class WiredashTestRobot {
   }
 }
 
+class WiredashMockServices {
+  final WiredashServices services;
+
+  WiredashMockServices(this.services);
+
+  MockWiredashApi get mockApi => services.api as MockWiredashApi;
+}
+
 WiredashServices createMockServices() {
   final services = WiredashServices();
-  services.inject<WiredashApi>((_) => MockWiredashApi());
+  services.inject<WiredashApi>((_) => MockWiredashApi.fake());
   return services;
 }
 

--- a/test/util/wiredash_tester.dart
+++ b/test/util/wiredash_tester.dart
@@ -25,7 +25,7 @@ extension WiredashTester on WidgetTester {
   }
 
   Future<void> waitUntil(
-    dynamic actual,
+    final dynamic actual,
     Matcher matcher, {
     Duration timeout = const Duration(seconds: 5),
   }) async {
@@ -34,17 +34,21 @@ extension WiredashTester on WidgetTester {
     var attempt = 0;
     while (true) {
       attempt++;
-      if (matcher.matches(actual, {})) {
+      dynamic actualValue = actual;
+      if (actual is Function()) {
+        actualValue = actual.call();
+      }
+      if (matcher.matches(actualValue, {})) {
         break;
       }
 
       final now = DateTime.now();
       final executingTime = start.difference(now).abs();
-      if (actual.runtimeType.toString().contains('_TextFinder') &&
+      if (actualValue.runtimeType.toString().contains('_TextFinder') &&
           attempt > 1) {
         print(
           'Text on screen (@ $executingTime) should '
-          'match $actual but got "${matcher.describe(StringDescription()).toString()}":',
+          'match $actualValue but got "${matcher.describe(StringDescription()).toString()}":',
         );
         print(
           "Text on screen: ${allWidgets.whereType<Text>().map((e) => e.data).toList()}",
@@ -54,11 +58,11 @@ extension WiredashTester on WidgetTester {
       if (now.isAfter(start.add(timeout))) {
         // Exit with error
         print(stack);
-        if (actual.runtimeType.toString().contains('_TextFinder')) {
+        if (actualValue.runtimeType.toString().contains('_TextFinder')) {
           print('Text on screen:');
           print(allWidgets.whereType<Text>().map((e) => e.data).toList());
         }
-        throw 'Did not find $actual after $timeout (attempt: $attempt)';
+        throw 'Did not find $actualValue after $timeout (attempt: $attempt)';
       }
 
       final duration =
@@ -68,7 +72,7 @@ extension WiredashTester on WidgetTester {
         // show continuous updates
         print(
           'Waiting for match (attempt: $attempt, @ $executingTime)\n'
-          '\tFinder: $actual to match\n'
+          '\tFinder: $actualValue to match\n'
           '\tMatcher: ${matcher.describe(StringDescription()).toString()}',
         );
       }

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -4,11 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/core/project_credential_validator.dart';
-import 'package:wiredash/src/core/services/services.dart';
 import 'package:wiredash/src/core/wiredash_widget.dart';
 
 import 'util/invocation_catcher.dart';
-import 'util/mock_api.dart';
 import 'util/robot.dart';
 
 void main() {
@@ -40,7 +38,8 @@ void main() {
           child: CircularProgressIndicator(),
         ),
       );
-      final api1 = findWireadshServices.api as MockWiredashApi;
+      final robot = WiredashTestRobot(tester);
+      final api1 = robot.mockServices.mockApi;
       await tester.pump();
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
@@ -76,10 +75,15 @@ void main() {
       );
       await tester.pump(const Duration(seconds: 1));
 
-      final api1 = findWireadshServices.api as MockWiredashApi;
+      final robot = WiredashTestRobot(tester);
+      final api1 = robot.mockServices.mockApi;
       expect(api1.pingInvocations.count, 0);
       await tester.pump(const Duration(seconds: 5));
       expect(api1.pingInvocations.count, 1);
+
+      // wait a bit, so we don't run in cases where the ping is not sent because
+      // it was triggered too recently
+      await tester.pump(const Duration(days: 1));
 
       // remove wiredash
       expect(find.byType(Wiredash), findsOneWidget);
@@ -97,7 +101,7 @@ void main() {
       );
       await tester.pump(const Duration(seconds: 1));
 
-      final api2 = findWireadshServices.api as MockWiredashApi;
+      final api2 = robot.mockServices.mockApi;
       expect(api2.pingInvocations.count, 0);
       await tester.pump(const Duration(seconds: 5));
       expect(api2.pingInvocations.count, 1);
@@ -159,12 +163,6 @@ class _MockProjectCredentialValidator extends Fake
       },
     )?.future;
   }
-}
-
-WiredashServices get findWireadshServices {
-  final found = find.byType(Wiredash).evaluate().first as StatefulElement;
-  final wiredashState = found.state as WiredashState;
-  return wiredashState.debugServices;
 }
 
 class _FakeApp extends StatefulWidget {


### PR DESCRIPTION
When a prefilled email address was set, it was sent to be backend regardless if the user deleted it in the input field or not. This is now fixed and transparent. The email is now submitted as the user sees it in the email step. It might be prefilled or not. When the field is empty nothing is sent