### PR TITLE
Make pen colors adjustable

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,20 +81,20 @@ class _WiredashExampleAppState extends State<WiredashExampleApp> {
       theme: WiredashThemeData.fromColor(
         // Customize Brightness and Colors
         // Primary button color, step indicator, focused input border
-        primaryColor: Colors.cyanAccent,
+        primaryColor: Colors.indigo,
         // Secondary button color
-        secondaryColor: Colors.cyan,
+        secondaryColor: Colors.purple,
         brightness: Brightness.light,
       ).copyWith(
         // Customize the Font Family
         fontFamily: 'Monospace',
 
         // i.e. selected labels, buttons on cards, input border
-        primaryContainerColor: Colors.green,
+        primaryContainerColor: Colors.cyan,
         textOnPrimaryContainerColor: Colors.black,
 
         // i.e. labels when not selected
-        secondaryContainerColor: Colors.greenAccent,
+        secondaryContainerColor: Colors.blue,
         textOnSecondaryContainerColor: Colors.white,
 
         // the color behind the application, only visible when your app is
@@ -105,14 +105,14 @@ class _WiredashExampleAppState extends State<WiredashExampleApp> {
 
         // The background gradient, top to bottom
         primaryBackgroundColor: Colors.white,
-        secondaryBackgroundColor: Color(0xFFF4FFF4),
+        secondaryBackgroundColor: Color(0xFFEDD9F6),
 
         errorColor: Colors.deepOrange,
 
-        // firstPenColor: Colors.orange,
-        // secondPenColor: Colors.green,
-        // thirdPenColor: Colors.yellow,
-        // fourthPenColor: Colors.deepPurpleAccent,
+        firstPenColor: Colors.yellow,
+        secondPenColor: Colors.white,
+        thirdPenColor: Color(0xffffebeb),
+        fourthPenColor: Color(0xffced9e3),
       ),
       child: MaterialApp(
         debugShowCheckedModeBanner: false,

--- a/lib/src/core/services/services.dart
+++ b/lib/src/core/services/services.dart
@@ -8,7 +8,6 @@ import 'package:http/http.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/core/network/wiredash_api.dart';
-import 'package:wiredash/src/core/options/wiredash_options_data.dart';
 import 'package:wiredash/src/core/project_credential_validator.dart';
 import 'package:wiredash/src/core/services/streampod.dart';
 import 'package:wiredash/src/core/sync/ping_job.dart';
@@ -16,7 +15,6 @@ import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/sync/sync_feedback_job.dart';
 import 'package:wiredash/src/core/widgets/backdrop/wiredash_backdrop.dart';
 import 'package:wiredash/src/core/wiredash_model.dart';
-import 'package:wiredash/src/core/wiredash_widget.dart';
 import 'package:wiredash/src/feedback/data/direct_feedback_submitter.dart';
 import 'package:wiredash/src/feedback/data/feedback_submitter.dart';
 import 'package:wiredash/src/feedback/data/pending_feedback_item_storage.dart';
@@ -28,6 +26,7 @@ import 'package:wiredash/src/metadata/build_info/device_id_generator.dart';
 import 'package:wiredash/src/metadata/device_info/device_info_generator.dart';
 import 'package:wiredash/src/nps/nps_model.dart';
 import 'package:wiredash/src/utils/uuid.dart';
+import 'package:wiredash/wiredash.dart';
 
 /// Internal service locator
 class WiredashServices extends ChangeNotifier {
@@ -111,7 +110,14 @@ void _setupServices(WiredashServices sl) {
     dispose: (model) => model.dispose(),
   );
   sl.inject<PicassoController>(
-    (_) => PicassoController(),
+    (locator) {
+      final controller = PicassoController();
+      locator.listen<Wiredash>((wiredashWidget) {
+        controller.color ??= wiredashWidget.theme?.firstPenColor;
+      });
+
+      return controller;
+    },
     dispose: (model) => model.dispose(),
   );
   sl.inject<DeviceInfoGenerator>((_) => DeviceInfoGenerator(window));

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -20,6 +20,10 @@ class WiredashThemeData {
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
+    Color? firstPenColor,
+    Color? secondPenColor,
+    Color? thirdPenColor,
+    Color? fourthPenColor,
     String? fontFamily,
     Size? windowSize,
   }) {
@@ -38,6 +42,10 @@ class WiredashThemeData {
       appBackgroundColor: appBackgroundColor,
       appHandleBackgroundColor: appHandleBackgroundColor,
       errorColor: errorColor,
+      firstPenColor: firstPenColor,
+      secondPenColor: secondPenColor,
+      thirdPenColor: thirdPenColor,
+      fourthPenColor: fourthPenColor,
       fontFamily: fontFamily,
     );
   }
@@ -75,6 +83,10 @@ class WiredashThemeData {
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
+    Color? firstPenColor,
+    Color? secondPenColor,
+    Color? thirdPenColor,
+    Color? fourthPenColor,
     String? fontFamily,
     required this.deviceClass,
     required this.windowSize,
@@ -90,6 +102,10 @@ class WiredashThemeData {
         _appBackgroundColor = appBackgroundColor,
         _appHandleBackgroundColor = appHandleBackgroundColor,
         _errorColor = errorColor,
+        _firstPenColor = firstPenColor,
+        _secondPenColor = secondPenColor,
+        _thirdPenColor = thirdPenColor,
+        _fourthPenColor = fourthPenColor,
         _fontFamily = fontFamily;
 
   final Brightness brightness;
@@ -236,6 +252,18 @@ class WiredashThemeData {
   Color get secondaryTextOnSurfaceColor {
     return _primaryTone.onSurface.withOpacity(0.8);
   }
+
+  final Color? _firstPenColor;
+  Color get firstPenColor => _firstPenColor ?? const Color(0xffff0c67);
+
+  final Color? _secondPenColor;
+  Color get secondPenColor => _secondPenColor ?? const Color(0xff00081e);
+
+  final Color? _thirdPenColor;
+  Color get thirdPenColor => _thirdPenColor ?? const Color(0xff9cdcdc);
+
+  final Color? _fourthPenColor;
+  Color get fourthPenColor => _fourthPenColor ?? const Color(0xffe96115);
 
   // --- Error --- //
   final Color? _errorColor;
@@ -385,6 +413,10 @@ class WiredashThemeData {
           appBackgroundColor == other.appBackgroundColor &&
           appHandleBackgroundColor == other.appHandleBackgroundColor &&
           errorColor == other.errorColor &&
+          firstPenColor == other.firstPenColor &&
+          secondPenColor == other.secondPenColor &&
+          thirdPenColor == other.thirdPenColor &&
+          fourthPenColor == other.fourthPenColor &&
           deviceClass == other.deviceClass &&
           windowSize == other.windowSize &&
           fontFamily == other.fontFamily;
@@ -405,6 +437,10 @@ class WiredashThemeData {
       appBackgroundColor.hashCode ^
       appHandleBackgroundColor.hashCode ^
       errorColor.hashCode ^
+      firstPenColor.hashCode ^
+      secondPenColor.hashCode ^
+      thirdPenColor.hashCode ^
+      fourthPenColor.hashCode ^
       deviceClass.hashCode ^
       windowSize.hashCode ^
       fontFamily.hashCode;
@@ -426,6 +462,10 @@ class WiredashThemeData {
         'appBackgroundColor: $appBackgroundColor, '
         'appHandleBackgroundColor: $appHandleBackgroundColor, '
         'errorColor: $errorColor, '
+        'firstPenColor: $firstPenColor'
+        'secondPenColor: $secondPenColor'
+        'thirdPenColor: $thirdPenColor'
+        'fourthPenColor: $fourthPenColor'
         'deviceClass: $deviceClass, '
         'fontFamily: $fontFamily, '
         'windowSize: $windowSize, '
@@ -445,6 +485,10 @@ class WiredashThemeData {
     Color? appBackgroundColor,
     Color? appHandleBackgroundColor,
     Color? errorColor,
+    Color? firstPenColor,
+    Color? secondPenColor,
+    Color? thirdPenColor,
+    Color? fourthPenColor,
     DeviceClass? deviceClass,
     String? fontFamily,
     Size? windowSize,
@@ -469,6 +513,10 @@ class WiredashThemeData {
       appHandleBackgroundColor:
           appHandleBackgroundColor ?? this.appHandleBackgroundColor,
       errorColor: errorColor ?? this.errorColor,
+      firstPenColor: firstPenColor ?? this.firstPenColor,
+      secondPenColor: secondPenColor ?? this.secondPenColor,
+      thirdPenColor: thirdPenColor ?? this.thirdPenColor,
+      fourthPenColor: fourthPenColor ?? this.fourthPenColor,
       deviceClass: deviceClass ?? this.deviceClass,
       fontFamily: fontFamily ?? this.fontFamily,
       windowSize: windowSize ?? this.windowSize,

--- a/lib/src/core/widgets/animated_shape.dart
+++ b/lib/src/core/widgets/animated_shape.dart
@@ -27,6 +27,7 @@ class _AnimatedShapeState extends AnimatedWidgetBaseState<AnimatedShape> {
   @override
   Widget build(BuildContext context) {
     return PhysicalShape(
+      shadowColor: _colorTween!.evaluate(animation)!,
       color: _colorTween!.evaluate(animation)!,
       clipper: ShapeBorderClipper(
         shape: _borderTween!.evaluate(animation)!,

--- a/lib/src/feedback/feedback_backdrop.dart
+++ b/lib/src/feedback/feedback_backdrop.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
 import 'package:wiredash/src/core/support/back_button_interceptor.dart';
@@ -114,14 +114,23 @@ Widget? _buildForegroundLayer(
               ? 0
               : 1,
         ),
-        child: ColorPalette(
-          initialColor: services.picassoController.color,
-          initialStrokeWidth: services.picassoController.strokeWidth,
-          onNewColorSelected: (color) =>
-              services.picassoController.color = color,
-          onNewStrokeWidthSelected: (width) =>
-              services.picassoController.strokeWidth = width,
-          onUndo: services.picassoController.undo,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 8, right: 8),
+          child: ColorPalette(
+            colors: [
+              context.theme.firstPenColor,
+              context.theme.secondPenColor,
+              context.theme.thirdPenColor,
+              context.theme.fourthPenColor,
+            ],
+            initialSelection: services.picassoController.color ?? Colors.black,
+            initialStrokeWidth: services.picassoController.strokeWidth,
+            onNewColorSelected: (color) =>
+                services.picassoController.color = color,
+            onNewStrokeWidthSelected: (width) =>
+                services.picassoController.strokeWidth = width,
+            onUndo: services.picassoController.undo,
+          ),
         ),
       ),
     );

--- a/lib/src/feedback/picasso/picasso.dart
+++ b/lib/src/feedback/picasso/picasso.dart
@@ -111,7 +111,7 @@ class _PicassoState extends State<Picasso> {
     _currentStroke = Stroke(
       StrokeType.dot,
       [point],
-      widget.controller.color,
+      widget.controller.color ?? Colors.black,
       widget.controller.strokeWidth,
     );
   }
@@ -124,7 +124,7 @@ class _PicassoState extends State<Picasso> {
     _currentStroke = Stroke(
       StrokeType.line,
       path,
-      widget.controller.color,
+      widget.controller.color ?? Colors.black,
       widget.controller.strokeWidth,
     );
     _currentStrokeStreamController.add(_currentStroke);
@@ -206,7 +206,6 @@ class PicassoController extends ChangeNotifier {
   _PicassoState? _state;
 
   bool _isActive = false;
-  Color _color = const Color(0xff6B46C1);
   double _strokeWidth = 8.0;
 
   bool get isActive => _isActive;
@@ -216,9 +215,9 @@ class PicassoController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Color get color => _color;
-
-  set color(Color value) {
+  Color? _color;
+  Color? get color => _color;
+  set color(Color? value) {
     _color = value;
     notifyListeners();
   }

--- a/lib/src/feedback/ui/color_palette.dart
+++ b/lib/src/feedback/ui/color_palette.dart
@@ -202,24 +202,20 @@ class HorizontalColorPicker extends StatelessWidget {
       ),
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
-        child: Scrollbar(
-          thumbVisibility: false,
-          thickness: 0,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ...colors.map((color) {
-                return Padding(
-                  padding: const EdgeInsets.only(left: 2),
-                  child: AnimatedColorDot(
-                    color: color,
-                    isSelected: color == selectedColor,
-                    onTap: () => onNewColorSelected?.call(color),
-                  ),
-                );
-              }),
-            ],
-          ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ...colors.map((color) {
+              return Padding(
+                padding: const EdgeInsets.only(left: 2),
+                child: AnimatedColorDot(
+                  color: color,
+                  isSelected: color == selectedColor,
+                  onTap: () => onNewColorSelected?.call(color),
+                ),
+              );
+            }),
+          ],
         ),
       ),
     );

--- a/lib/src/feedback/ui/slider/stroke_width_slider_widget.dart
+++ b/lib/src/feedback/ui/slider/stroke_width_slider_widget.dart
@@ -10,13 +10,15 @@ class StrokeWidthSlider extends StatefulWidget {
     required this.maxWidth,
     required this.currentWidth,
     this.onNewWidthSelected,
+    this.onInteract,
   }) : super(key: key);
 
   final Color color;
   final double minWidth;
   final double maxWidth;
   final double currentWidth;
-  final Function(double)? onNewWidthSelected;
+  final void Function(double)? onNewWidthSelected;
+  final void Function()? onInteract;
 
   @override
   State<StrokeWidthSlider> createState() => _StrokeWidthSliderState();
@@ -41,6 +43,7 @@ class _StrokeWidthSliderState extends State<StrokeWidthSlider> {
     } else {
       _dragPosition = position;
     }
+    widget.onInteract?.call();
 
     setState(() {});
   }


### PR DESCRIPTION
<img width="414" alt="Screen-Shot-2022-07-04-22-09-45 93" src="https://user-images.githubusercontent.com/1096485/177212193-51b9d943-a021-4ba1-a086-f7fe96abb026.png">

The colors can now be adjusted via `theme`

```dart
return Wiredash(
  theme: WiredashThemeData.fromColor(
    primaryColor: Colors.indigo,
    secondaryColor: Colors.purple,
    brightness: Brightness.light,
  ).copyWith(
    firstPenColor: Colors.yellow,
    secondPenColor: Colors.white,
    thirdPenColor: Color(0xffffebeb),
    fourthPenColor: Color(0xffced9e3),
  ),
  child: MyApp(),
);
```

Also the stroke width slider now closes automatically