### PR TITLE
Show logging only in dev mode

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 - Bump version in `pubspec.yaml`
 - Increment `wiredashSdkVersion` in `lib/src/version.dart` by `1` for patch releases, by `10` for minor releases
 - Make sure `prod` backend is used, not `dev` in `lib/src/core/network/wiredash_api.dart` (ending with `.io`, not `.dev`)
+- Set `kDevMode` in `lib/src/_wiredash_internal.dart` to `false`
 - Write release notes in `CHANGELOG.md`
 - Commit changes
 - Tag release `vX.Y.Z` and push it

--- a/lib/src/_wiredash_internal.dart
+++ b/lib/src/_wiredash_internal.dart
@@ -9,3 +9,6 @@ export 'package:wiredash/src/core/wiredash_controller.dart';
 export 'package:wiredash/src/core/wiredash_model.dart';
 export 'package:wiredash/src/core/wiredash_model_provider.dart';
 export 'package:wiredash/src/utils/standard_kt.dart';
+
+/// `true` when Wiredash is in development mode, enables enhanced logging
+const bool kDevMode = false;

--- a/lib/src/core/sync/sync_engine.dart
+++ b/lib/src/core/sync/sync_engine.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
+import 'package:wiredash/src/_wiredash_internal.dart';
 
-const _kSyncDebugPrint = false;
+const _kSyncDebugPrint = kDevMode;
 
 void syncDebugPrint(Object? message) {
   if (_kSyncDebugPrint) {

--- a/lib/src/core/sync/sync_feedback_job.dart
+++ b/lib/src/core/sync/sync_feedback_job.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/feedback/_feedback.dart';
 
@@ -23,7 +23,7 @@ class UploadPendingFeedbackJob extends Job {
 
     await submitter.submitPendingFeedbackItems();
 
-    if (kDebugMode) {
+    if (kDevMode) {
       await submitter.deletePendingFeedbacks();
     }
   }

--- a/lib/src/feedback/data/persisted_feedback_item.dart
+++ b/lib/src/feedback/data/persisted_feedback_item.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:collection/collection.dart';
 import 'package:file/file.dart';
 import 'package:flutter/cupertino.dart';

--- a/lib/src/feedback/data/persisted_feedback_item.dart
+++ b/lib/src/feedback/data/persisted_feedback_item.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:collection/collection.dart';
 import 'package:file/file.dart';
 import 'package:flutter/cupertino.dart';

--- a/lib/src/feedback/data/retrying_feedback_submitter.dart
+++ b/lib/src/feedback/data/retrying_feedback_submitter.dart
@@ -252,6 +252,7 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
     final items = await _pendingFeedbackItemStorage.retrieveAllPendingItems();
     if (items.isEmpty) {
       debugPrint('No pending feedbacks');
+      return;
     }
     for (final item in items) {
       await _pendingFeedbackItemStorage.clearPendingItem(item.id);

--- a/lib/src/metadata/device_info/device_info.dart
+++ b/lib/src/metadata/device_info/device_info.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' show Brightness;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/feedback/data/pending_feedback_item.dart';

--- a/lib/src/metadata/device_info/device_info.dart
+++ b/lib/src/metadata/device_info/device_info.dart
@@ -1,8 +1,8 @@
+import 'dart:ui' show Brightness;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/feedback/data/pending_feedback_item.dart';
-
-export 'dart:ui' show Brightness;
 
 /// All information we can gather from the Flutter Framework about the
 /// device/window/canvas


### PR DESCRIPTION
The `No pending feedbacks` accidentally made it into the production build.

Introducing `kDevMode` for development logging  