### PR TITLE
Improve opening animation performance

### DIFF
--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -201,9 +201,12 @@ class WiredashThemeData {
 
   final WiredashTextTheme? _textTheme;
 
+  /// Caching is possible because [_defaultWiredashTextTheme] and [_textTheme] are immutable
+  WiredashTextTheme? _mergedTextTheme;
+
   WiredashTextThemeWithDefaults get textTheme {
-    final merged = _defaultWiredashTextTheme.merge(_textTheme);
-    return WiredashTextThemeWithDefaults(this, merged);
+    _mergedTextTheme ??= _defaultWiredashTextTheme.merge(_textTheme);
+    return WiredashTextThemeWithDefaults(this, _mergedTextTheme!);
   }
 
   SurfaceBasedTextStyle get text {
@@ -889,7 +892,7 @@ class SurfaceBasedTextStyle {
   }
 }
 
-final _defaultWiredashTextTheme = WiredashTextTheme(
+final WiredashTextTheme _defaultWiredashTextTheme = WiredashTextTheme(
   headlineMedium: const TextStyle(
     fontSize: 32,
     fontWeight: FontWeight.bold,

--- a/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
+++ b/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
@@ -80,7 +80,8 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
   Animation<Rect?>? _appTransformAnimation;
 
   /// Used for animating the corner radius of the app
-  late Animation<BorderRadius?> _cornerRadiusAnimation;
+  Animation<BorderRadius?> _cornerRadiusAnimation =
+      AlwaysStoppedAnimation(_appBorderRadiusClosed);
 
   /// How much the app handle is visible
   late Animation<double> _appHandleAnimation;
@@ -166,8 +167,9 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
     }
   }
 
-  final BorderRadius _appBorderRadiusClosed = BorderRadius.zero;
-  final BorderRadius _appBorderRadiusOpen = BorderRadius.circular(20);
+  static const BorderRadius _appBorderRadiusClosed = BorderRadius.zero;
+  static const BorderRadius _appBorderRadiusOpen =
+      BorderRadius.all(Radius.circular(20));
 
   @override
   void didChangeDependencies() {
@@ -226,7 +228,6 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
       if (_backdropStatus == WiredashBackdropStatus.closed) {
         _appHandleAnimation = const AlwaysStoppedAnimation(0.0);
       }
-      _cornerRadiusAnimation = AlwaysStoppedAnimation(_appBorderRadiusOpen);
       _backdropAnimationController.forward(
         from: animateSizeChange == true ? 0 : 1,
       );
@@ -985,9 +986,14 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
             RectTween(begin: oldRectAppFillsScreen, end: _rectAppOutOfFocus)
                 .animate(_driverAnimation);
         _cornerRadiusAnimation = BorderRadiusTween(
-          begin: _appBorderRadiusClosed,
+          begin: _cornerRadiusAnimation.value,
           end: _appBorderRadiusOpen,
-        ).animate(_driverAnimation);
+        ).animate(
+          CurvedAnimation(
+            parent: _driverAnimation,
+            curve: const Interval(0.3, 0.7),
+          ),
+        );
         _appHandleAnimation = Tween(begin: 0.0, end: 1.0).animate(
           CurvedAnimation(parent: _driverAnimation, curve: Curves.easeInOut),
         );
@@ -999,9 +1005,14 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
                 .animate(_driverAnimation);
         _backdropAnimationController.value = 0.0;
         _cornerRadiusAnimation = BorderRadiusTween(
-          begin: _appBorderRadiusOpen,
+          begin: _cornerRadiusAnimation.value,
           end: _appBorderRadiusClosed,
-        ).animate(_driverAnimation);
+        ).animate(
+          CurvedAnimation(
+            parent: _driverAnimation,
+            curve: const Interval(0.3, 0.7),
+          ),
+        );
         _appHandleAnimation = Tween(begin: 1.0, end: 0.0).animate(
           CurvedAnimation(parent: _driverAnimation, curve: Curves.easeInOut),
         );
@@ -1056,6 +1067,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         _backdropStatus = WiredashBackdropStatus.closed;
       });
     }
+    _swapAnimation();
   }
 
   void _markAsDirty() {

--- a/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
+++ b/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
@@ -81,7 +81,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
 
   /// Used for animating the corner radius of the app
   Animation<BorderRadius?> _cornerRadiusAnimation =
-      AlwaysStoppedAnimation(_appBorderRadiusClosed);
+      const AlwaysStoppedAnimation(_appBorderRadiusClosed);
 
   /// How much the app handle is visible
   late Animation<double> _appHandleAnimation;
@@ -201,6 +201,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
   }
 
   Size? _injectedContentSize;
+
   void _onContentSizeChanged(Size? size, {bool? animateSizeChange}) {
     if (_injectedContentSize?.height != size?.height) {
       _injectedContentSize = size;
@@ -659,6 +660,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
   }
 
   static const double _minHandleHeight = 20;
+
   double get _handleHeight {
     final topPadding = _mediaQueryData.padding.top;
     if (topPadding > 0) {
@@ -962,7 +964,8 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         _appTransformAnimation =
             RectTween(begin: oldAppOutOfFocusRect, end: _rectAppOutOfFocus)
                 .animate(_driverAnimation);
-        _cornerRadiusAnimation = AlwaysStoppedAnimation(_appBorderRadiusOpen);
+        _cornerRadiusAnimation =
+            const AlwaysStoppedAnimation(_appBorderRadiusOpen);
         _appHandleAnimation = const AlwaysStoppedAnimation(1.0);
         break;
 
@@ -970,7 +973,8 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         _appTransformAnimation =
             RectTween(begin: oldRectAppFillsScreen, end: _rectAppFillsScreen)
                 .animate(_driverAnimation);
-        _cornerRadiusAnimation = AlwaysStoppedAnimation(_appBorderRadiusClosed);
+        _cornerRadiusAnimation =
+            const AlwaysStoppedAnimation(_appBorderRadiusClosed);
         _appHandleAnimation = const AlwaysStoppedAnimation(0.0);
         break;
 
@@ -978,7 +982,8 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         _appTransformAnimation =
             RectTween(begin: oldRectAppCentered, end: _rectAppCentered)
                 .animate(_driverAnimation);
-        _cornerRadiusAnimation = AlwaysStoppedAnimation(_appBorderRadiusOpen);
+        _cornerRadiusAnimation =
+            const AlwaysStoppedAnimation(_appBorderRadiusOpen);
         _appHandleAnimation = const AlwaysStoppedAnimation(0.0);
         break;
 
@@ -1023,7 +1028,8 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         _appTransformAnimation =
             RectTween(begin: oldAppOutOfFocusRect, end: _rectAppCentered)
                 .animate(_driverAnimation);
-        _cornerRadiusAnimation = AlwaysStoppedAnimation(_appBorderRadiusOpen);
+        _cornerRadiusAnimation =
+            const AlwaysStoppedAnimation(_appBorderRadiusOpen);
         _appHandleAnimation = Tween(begin: 1.0, end: 0.0).animate(
           CurvedAnimation(parent: _driverAnimation, curve: Curves.easeInOut),
         );
@@ -1033,7 +1039,8 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         _appTransformAnimation =
             RectTween(begin: oldRectAppCentered, end: _rectAppOutOfFocus)
                 .animate(_driverAnimation);
-        _cornerRadiusAnimation = AlwaysStoppedAnimation(_appBorderRadiusOpen);
+        _cornerRadiusAnimation =
+            const AlwaysStoppedAnimation(_appBorderRadiusOpen);
         _appHandleAnimation = Tween(begin: 0.0, end: 1.0).animate(
           CurvedAnimation(parent: _driverAnimation, curve: Curves.easeInOut),
         );
@@ -1083,10 +1090,13 @@ class BackdropController extends ChangeNotifier {
   }
 
   _WiredashBackdropState? _stateField;
+
   _WiredashBackdropState? get _state => _stateField;
 
   Size? _contentSize;
+
   Size? get contentSize => _contentSize;
+
   set contentSize(Size? value) {
     if (_contentSize != value) {
       _contentSize = value;


### PR DESCRIPTION
Opening Wiredash has been a bit laggy, most noticeably on iOS and macOS due to the [shader jank](https://docs.flutter.dev/perf/shader).

While experimenting with different clipping behaviors `Clip.antiAliasWithSaveLayer` vs. `Clip.antiAlias` vs. `Clip.hardEdge` as recommended in #225 I found several points of improvement.

- `setState` was called way too often
- delay corner animation
- theme merging wasn't cached

Together, I saw a significant reduction of jank. 

---

### Results

> Test setup:
> iPhone SE, iOS 15.1
> Flutter version 3.3.0-0.1.pre on channel beta
> I always completely restarted the app, cleared the timeline and only measured close and open (two taps).

Before improvements (debug build)
<img width="1653" alt="Screen-Shot-2022-07-31-00-15-25 67" src="https://user-images.githubusercontent.com/1096485/182002572-41f5d94f-c5d1-459f-8cbc-053b65343e9f.png">

After improvements (debug build)
<img width="1656" alt="Screen-Shot-2022-07-31-00-16-02 15" src="https://user-images.githubusercontent.com/1096485/182002573-69ebcbc6-34b4-40d3-93fa-b9136958702b.png">


### Save or not to save Layer
I did not notice a significant performance improvement when switching from `Clip.antiAliasWithSaveLayer` to `Clip.hardEdge`

`Clip.antiAliasWithSaveLayer` profile build
<img width="1659" alt="Screen-Shot-2022-07-31-00-31-30 96" src="https://user-images.githubusercontent.com/1096485/182002617-311abfd1-e9f3-40ce-a099-f179e52c0dca.png">
`Clip.hardEdge` profile build
<img width="1657" alt="Screen-Shot-2022-07-31-00-33-07 63" src="https://user-images.githubusercontent.com/1096485/182002619-59b35170-0925-410e-822d-c0e593bdf034.png">

Instead, `Clip.antiAlias` and `Clip.hardEdge` produce very noticeable artifacts (see below 👇), thus not changing this.
 
`Clip.hardEdge` vs. `Clip.antiAlias` vs. `Clip.antiAliasWithSaveLayer`
<img width="655" alt="Screen-Shot-2022-07-31-00-50-57 30" src="https://user-images.githubusercontent.com/1096485/182002686-531b1de8-cae2-4b24-8ba8-e4ce99170e47.png">

