### PR TITLE
Add issue_tracker link for pub.dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,7 @@ description: Wiredash is an interactive user feedback tool for Flutter apps incl
 version: 1.5.0
 homepage: https://wiredash.io
 repository: https://github.com/wiredashio/wiredash-sdk
+issue_tracker: https://github.com/wiredashio/wiredash-sdk/issues
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).