### PR TITLE
Fix go_router focus bug

### DIFF
--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -152,6 +152,8 @@ class WiredashState extends State<Wiredash> {
 
   Timer? _submitTimer;
 
+  final FocusScopeNode _appFocusScopeNode = FocusScopeNode();
+
   WiredashServices get debugServices {
     WiredashServices? services;
     assert(
@@ -195,6 +197,7 @@ class WiredashState extends State<Wiredash> {
     _submitTimer = null;
     _services.dispose();
     _backButtonDispatcher.dispose();
+    _appFocusScopeNode.dispose();
     super.dispose();
   }
 
@@ -215,9 +218,16 @@ class WiredashState extends State<Wiredash> {
   Widget build(BuildContext context) {
     // Assign app an key so it doesn't lose state when wrapped, unwrapped
     // with widgets
-    final Widget app = KeyedSubtree(
+    Widget app = KeyedSubtree(
       key: _appKey,
       child: widget.child,
+    );
+
+    // Fix focus bug for apps that use go_router
+    // https://github.com/flutter/flutter/issues/119849
+    app = FocusScope(
+      node: _appFocusScopeNode,
+      child: app,
     );
 
     if (!_services.wiredashModel.isWiredashActive) {


### PR DESCRIPTION
Fixes https://github.com/wiredashio/wiredash-sdk/issues/262

Related https://github.com/flutter/flutter/issues/119849

This is a hotfix and guarantees that Wiredash works. 

It breaks that the feedback TextField is focused when opening Wiredash. This has to be restored in a followup. 