### PR TITLE
Widen lint range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   fake_async: any
   flutter_test:
     sdk: flutter
-  lint: ^1.5.0
+  lint: '>=1.5.0 <3.0.0'
   test: ^1.16.0-nullsafety
   transparent_image: ^2.0.0-nullsafety.0
 


### PR DESCRIPTION
We still support 1.5 for older Flutter SDKs