### PR TITLE
Update min SDKs to Flutter 3.0.0 / Dart 2.17

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,7 +10,7 @@ jobs:
   minVersion:
     runs-on: ubuntu-latest
     container:
-      image: cirrusci/flutter:2.8.0
+      image: cirrusci/flutter:3.0.0
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
   pr-min:
     runs-on: ubuntu-latest
     container:
-      image: cirrusci/flutter:2.8.0
+      image: cirrusci/flutter:3.0.0
     steps:
       - uses: actions/checkout@v3
       - name: Flutter version

--- a/examples/localization/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/localization/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
-import shared_preferences_macos
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/examples/localization/pubspec.yaml
+++ b/examples/localization/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.8.0 <4.0.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/examples/localization/pubspec.yaml
+++ b/examples/localization/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     path: ../../
 
 dev_dependencies:
-  lint: ^1.0.0
+  lint: '>=1.0.0 <=3.0.0'
 
 flutter:
   uses-material-design: true

--- a/examples/promoter_score/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/promoter_score/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
-import shared_preferences_macos
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/examples/promoter_score/pubspec.yaml
+++ b/examples/promoter_score/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     path: ../../
 
 dev_dependencies:
-  lint: ^1.0.0
+  lint: '>=1.0.0 <=3.0.0'
 
 flutter:
   uses-material-design: true

--- a/examples/promoter_score/pubspec.yaml
+++ b/examples/promoter_score/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.8.0 <4.0.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/examples/theme_editor/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/theme_editor/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
-import shared_preferences_macos
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/examples/theme_editor/macos/Podfile
+++ b/examples/theme_editor/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.13'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/examples/theme_editor/macos/Runner.xcodeproj/project.pbxproj
+++ b/examples/theme_editor/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -203,7 +203,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -256,6 +256,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -402,7 +403,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -481,7 +482,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -528,7 +529,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/examples/theme_editor/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/theme_editor/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/theme_editor/pubspec.yaml
+++ b/examples/theme_editor/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.8.0 <4.0.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   device_frame: ^1.0.0

--- a/examples/theme_editor/pubspec.yaml
+++ b/examples/theme_editor/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../../
 
 dev_dependencies:
-  lint: ^1.0.0
+  lint: '>=1.0.0 <=3.0.0'
 
 flutter:
   uses-material-design: true

--- a/examples/theming/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/theming/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
-import shared_preferences_macos
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/examples/theming/pubspec.yaml
+++ b/examples/theming/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     path: ../../
 
 dev_dependencies:
-  lint: ^1.0.0
+  lint: '>=1.0.0 <=3.0.0'
 
 flutter:
   uses-material-design: true

--- a/examples/theming/pubspec.yaml
+++ b/examples/theming/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.8.0 <4.0.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/lib/src/core/network/wiredash_api.dart
+++ b/lib/src/core/network/wiredash_api.dart
@@ -557,7 +557,7 @@ class PingResponse {
 
 /// Backend returns an error which silences the SDK for one week
 class KillSwitchException extends WiredashApiException {
-  const KillSwitchException({Response? response}) : super(response: response);
+  const KillSwitchException({super.response});
   @override
   String toString() {
     return 'KillSwitchException{${response?.statusCode}, body: ${response?.body}}';

--- a/lib/src/core/support/back_button_interceptor.dart
+++ b/lib/src/core/support/back_button_interceptor.dart
@@ -6,10 +6,10 @@ import 'package:wiredash/src/core/support/widget_binding_support.dart';
 /// Allows intercepting of the Android back button
 class BackButtonInterceptor extends StatefulWidget {
   const BackButtonInterceptor({
-    Key? key,
+    super.key,
     required this.onBackPressed,
     required this.child,
-  }) : super(key: key);
+  });
 
   /// Return [BackButtonAction.consumed] when a back action was handles and return
   /// [BackButtonAction.ignored] to give other [BackButtonInterceptor]s the chance
@@ -121,10 +121,9 @@ class WiredashBackButtonDispatcher extends WidgetsBindingObserver {
 
 class _BackButtonDispatcherInheritedWidget extends InheritedWidget {
   const _BackButtonDispatcherInheritedWidget({
-    Key? key,
     required this.dispatcher,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   final WiredashBackButtonDispatcher dispatcher;
 

--- a/lib/src/core/support/material_support_layer.dart
+++ b/lib/src/core/support/material_support_layer.dart
@@ -13,9 +13,9 @@ import 'package:wiredash/src/utils/semver.dart';
 /// not wrapped into an [MaterialApp]
 class MaterialSupportLayer extends StatefulWidget {
   const MaterialSupportLayer({
-    Key? key,
+    super.key,
     required this.child,
-  }) : super(key: key);
+  });
 
   final Widget child;
 

--- a/lib/src/core/support/not_a_widgets_app.dart
+++ b/lib/src/core/support/not_a_widgets_app.dart
@@ -9,8 +9,8 @@ class NotAWidgetsApp extends StatefulWidget {
   const NotAWidgetsApp({
     required this.child,
     this.textDirection,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final Widget child;
 

--- a/lib/src/core/theme/wiredash_theme.dart
+++ b/lib/src/core/theme/wiredash_theme.dart
@@ -3,10 +3,10 @@ import 'package:wiredash/src/core/theme/wiredash_theme_data.dart';
 
 class WiredashTheme extends StatelessWidget {
   const WiredashTheme({
-    Key? key,
+    super.key,
     required this.data,
     required this.child,
-  }) : super(key: key);
+  });
 
   final WiredashThemeData data;
   final Widget child;
@@ -58,10 +58,9 @@ class WiredashTheme extends StatelessWidget {
 
 class _InheritedWiredashTheme extends InheritedWidget {
   const _InheritedWiredashTheme({
-    Key? key,
     required this.themeData,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   final WiredashThemeData themeData;
 

--- a/lib/src/core/widgets/animated_shape.dart
+++ b/lib/src/core/widgets/animated_shape.dart
@@ -5,9 +5,8 @@ class AnimatedShape extends ImplicitlyAnimatedWidget {
     required this.color,
     required this.shape,
     required this.child,
-    Key? key,
+    super.key,
   }) : super(
-          key: key,
           curve: Curves.easeInOutCubic,
           duration: const Duration(milliseconds: 150),
         );

--- a/lib/src/core/widgets/backdrop/backdrop_controller_provider.dart
+++ b/lib/src/core/widgets/backdrop/backdrop_controller_provider.dart
@@ -3,10 +3,10 @@ import 'package:wiredash/src/core/widgets/backdrop/wiredash_backdrop.dart';
 
 class BackdropControllerProvider extends InheritedNotifier<BackdropController> {
   const BackdropControllerProvider({
-    Key? key,
+    super.key,
     required BackdropController backdropController,
-    required Widget child,
-  }) : super(key: key, notifier: backdropController, child: child);
+    required super.child,
+  }) : super(notifier: backdropController);
 
   static BackdropController of(BuildContext context, {bool listen = true}) {
     if (listen) {

--- a/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
+++ b/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
@@ -8,10 +8,10 @@ import 'package:wiredash/src/core/theme/wirecons.dart';
 /// Fakes the system statusbar when the app is floating in [WiredashBackdrop]
 class FakeAppStatusBar extends StatelessWidget {
   const FakeAppStatusBar({
-    Key? key,
+    super.key,
     required this.height,
     required this.color,
-  }) : super(key: key);
+  });
 
   final double height;
   final Color color;

--- a/lib/src/core/widgets/backdrop/pull_to_close_detector.dart
+++ b/lib/src/core/widgets/backdrop/pull_to_close_detector.dart
@@ -11,7 +11,7 @@ enum CloseDirection {
 /// [WiredashBackdrop] is open
 class PullToCloseDetector extends StatefulWidget {
   const PullToCloseDetector({
-    Key? key,
+    super.key,
     required this.child,
     // required this.distanceToEdge,
     // required this.openedPosition,
@@ -20,7 +20,7 @@ class PullToCloseDetector extends StatefulWidget {
     required this.startCloseSimulation,
     required this.startReopenSimulation,
     this.closeDirection = CloseDirection.downwards,
-  }) : super(key: key);
+  });
 
   final Widget child;
 

--- a/lib/src/core/widgets/backdrop/step_page_scaffold.dart
+++ b/lib/src/core/widgets/backdrop/step_page_scaffold.dart
@@ -19,11 +19,11 @@ class StepPageScaffold extends StatefulWidget {
     this.indicator,
     this.discardLabel,
     this.discardConfirmLabel,
-    Key? key,
+    super.key,
     this.onClose,
     this.alignemnt,
     this.minHeight,
-  }) : super(key: key);
+  });
 
   final int? currentStep;
   final int? totalSteps;
@@ -297,10 +297,10 @@ enum StepPageAlignemnt {
 /// Scrollable area with scrollbar
 class ScrollBox extends StatefulWidget {
   const ScrollBox({
-    Key? key,
+    super.key,
     required this.child,
     this.padding,
-  }) : super(key: key);
+  });
 
   final Widget child;
 
@@ -339,11 +339,11 @@ class _ScrollBoxState extends State<ScrollBox> {
 
 class StepIndicator extends StatelessWidget {
   const StepIndicator({
-    Key? key,
+    super.key,
     required this.completed,
     required this.total,
     required this.currentStep,
-  }) : super(key: key);
+  });
 
   final bool completed;
   final int total;

--- a/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
+++ b/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
@@ -18,14 +18,14 @@ import 'package:wiredash/wiredash.dart';
 /// The Wiredash UI behind the app
 class WiredashBackdrop extends StatefulWidget {
   const WiredashBackdrop({
-    Key? key,
+    super.key,
     required this.contentBuilder,
     required this.app,
     required this.controller,
     this.padding,
     this.backgroundLayerBuilder,
     this.foregroundLayerBuilder,
-  }) : super(key: key);
+  });
 
   /// The wrapped app
   final Widget app;
@@ -1244,7 +1244,7 @@ enum WiredashBackdropStatus {
 
 /// Keeps the app alive, even when not in viewport
 class _KeepAppAlive extends StatefulWidget {
-  const _KeepAppAlive({Key? key, required this.child}) : super(key: key);
+  const _KeepAppAlive({required this.child});
 
   final Widget child;
 

--- a/lib/src/core/widgets/confidential.dart
+++ b/lib/src/core/widgets/confidential.dart
@@ -5,11 +5,11 @@ import 'package:wiredash/wiredash.dart';
 /// from being captured inside a feedback screenshot.
 class Confidential extends StatelessWidget {
   const Confidential({
-    Key? key,
+    super.key,
     this.mode = ConfidentialMode.black,
     this.enabled = true,
     required this.child,
-  }) : super(key: key);
+  });
 
   /// How the confidential widget will be hidden when Wiredash is active.
   ///

--- a/lib/src/core/widgets/larry_page_view.dart
+++ b/lib/src/core/widgets/larry_page_view.dart
@@ -10,12 +10,12 @@ import 'package:flutter/rendering.dart';
 /// Use [viewInsets] to move the page into a fully visible area
 class LarryPageView extends StatefulWidget {
   const LarryPageView({
-    Key? key,
+    super.key,
     required this.stepCount,
     required this.builder,
     this.onPageChanged,
     this.pageIndex = 0,
-  }) : super(key: key);
+  });
 
   final Widget Function(BuildContext context) builder;
 
@@ -457,10 +457,10 @@ class LarryPageViewState extends State<LarryPageView>
 
 class StepInheritedWidget extends InheritedWidget {
   const StepInheritedWidget({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   final StepInformation data;
 

--- a/lib/src/core/widgets/measure_size.dart
+++ b/lib/src/core/widgets/measure_size.dart
@@ -7,10 +7,10 @@ class MeasureSize extends SingleChildRenderObjectWidget {
   final void Function(Size size, Rect bounds) onChange;
 
   const MeasureSize({
-    Key? key,
+    super.key,
     required this.onChange,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required Widget super.child,
+  });
 
   @override
   RenderObject createRenderObject(BuildContext context) {

--- a/lib/src/core/widgets/tron/animated_fade_widget_switcher.dart
+++ b/lib/src/core/widgets/tron/animated_fade_widget_switcher.dart
@@ -8,7 +8,7 @@ import 'package:wiredash/src/core/support/widget_binding_support.dart';
 /// out before showing the new one
 class AnimatedFadeWidgetSwitcher extends StatefulWidget {
   const AnimatedFadeWidgetSwitcher({
-    Key? key,
+    super.key,
     this.child,
     this.duration,
     this.alignment,
@@ -17,7 +17,7 @@ class AnimatedFadeWidgetSwitcher extends StatefulWidget {
     this.zoomFactor,
     this.onSwitch,
     this.clipBehavior,
-  }) : super(key: key);
+  });
 
   final Widget? child;
   final Duration? duration;
@@ -112,12 +112,12 @@ class _AnimatedFadeWidgetSwitcherState
 
 class FadeSwapTransition extends StatelessWidget {
   const FadeSwapTransition({
-    Key? key,
+    super.key,
     required this.animation,
     required this.secondaryAnimation,
     this.zoomFactor,
     this.child,
-  }) : super(key: key);
+  });
 
   /// The animation that drives the [child]'s entrance and exit.
   ///
@@ -160,11 +160,10 @@ class FadeSwapTransition extends StatelessWidget {
 
 class _ZoomedFadeInFadeOut extends StatelessWidget {
   const _ZoomedFadeInFadeOut({
-    Key? key,
     required this.animation,
     this.zoomFactor,
     this.child,
-  }) : super(key: key);
+  });
 
   final Animation<double> animation;
   final Widget? child;

--- a/lib/src/core/widgets/tron/animations_lib.dart
+++ b/lib/src/core/widgets/tron/animations_lib.dart
@@ -171,13 +171,13 @@ class PageTransitionSwitcher extends StatefulWidget {
   /// The [duration], [reverse], and [transitionBuilder] parameters
   /// must not be null.
   const PageTransitionSwitcher({
-    Key? key,
+    super.key,
     this.duration = const Duration(milliseconds: 300),
     this.reverse = false,
     required this.transitionBuilder,
     this.layoutBuilder = defaultLayoutBuilder,
     this.child,
-  }) : super(key: key);
+  });
 
   /// The current child widget to display.
   ///

--- a/lib/src/core/widgets/tron/tron_button.dart
+++ b/lib/src/core/widgets/tron/tron_button.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -17,12 +16,11 @@ class TronButton extends StatefulWidget {
     this.textColor,
     this.iconOffset = Offset.zero,
     this.maxWidth,
-    Key? key,
-  })  : assert(
+    super.key,
+  }) : assert(
           label != null || child != null,
           'Set label or child, one is required',
-        ),
-        super(key: key);
+        );
 
   final Color? color;
   final Color? textColor;
@@ -237,71 +235,5 @@ class _TronButtonState extends State<TronButton>
       _pressed = false;
     });
     _controller.forward().then((value) => _controller.reverse());
-  }
-}
-
-/// Backport of [AnimatedSlide], which was added in Flutter 2.5
-class _AnimatedSlideBackport extends ImplicitlyAnimatedWidget {
-  /// Creates a widget that animates its offset translation implicitly.
-  ///
-  /// The [offset] and [duration] arguments must not be null.
-  const _AnimatedSlideBackport({
-    Key? key,
-    // ignore: unused_element
-    this.child,
-    required this.offset,
-    Curve curve = Curves.linear,
-    required Duration duration,
-    VoidCallback? onEnd,
-  }) : super(key: key, curve: curve, duration: duration, onEnd: onEnd);
-
-  /// The widget below this widget in the tree.
-  ///
-  /// {@macro flutter.widgets.ProxyWidget.child}
-  final Widget? child;
-
-  /// The target offset.
-  /// The child will be translated horizontally by `width * dx` and vertically
-  /// by `height * dy`
-  ///
-  /// The offset must not be null.
-  final Offset offset;
-
-  @override
-  ImplicitlyAnimatedWidgetState<_AnimatedSlideBackport> createState() =>
-      _AnimatedSlideBackportState();
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Offset>('offset', offset));
-  }
-}
-
-class _AnimatedSlideBackportState
-    extends ImplicitlyAnimatedWidgetState<_AnimatedSlideBackport> {
-  Tween<Offset>? _offset;
-  late Animation<Offset> _offsetAnimation;
-
-  @override
-  void forEachTween(TweenVisitor<dynamic> visitor) {
-    _offset = visitor(
-      _offset,
-      widget.offset,
-      (dynamic value) => Tween<Offset>(begin: value as Offset),
-    ) as Tween<Offset>?;
-  }
-
-  @override
-  void didUpdateTweens() {
-    _offsetAnimation = animation.drive(_offset!);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SlideTransition(
-      position: _offsetAnimation,
-      child: widget.child,
-    );
   }
 }

--- a/lib/src/core/widgets/tron/tron_icon.dart
+++ b/lib/src/core/widgets/tron/tron_icon.dart
@@ -4,10 +4,10 @@ class TronIcon extends StatefulWidget {
   const TronIcon(
     this.icon, {
     this.color,
-    Key? key,
+    super.key,
     this.size,
     this.duration = const Duration(milliseconds: 250),
-  }) : super(key: key);
+  });
 
   final Color? color;
   final Duration duration;

--- a/lib/src/core/widgets/tron/tron_labeled_button.dart
+++ b/lib/src/core/widgets/tron/tron_labeled_button.dart
@@ -4,12 +4,11 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 /// Clickable text
 class TronLabeledButton extends ImplicitlyAnimatedWidget {
   const TronLabeledButton({
-    Key? key,
+    super.key,
     required this.child,
     this.onTap,
     this.padding,
   }) : super(
-          key: key,
           curve: Curves.easeInOutCirc,
           duration: const Duration(milliseconds: 150),
         );

--- a/lib/src/core/widgets/tron/tron_progress_indicator.dart
+++ b/lib/src/core/widgets/tron/tron_progress_indicator.dart
@@ -5,10 +5,10 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 
 class TronProgressIndicator extends StatefulWidget {
   const TronProgressIndicator({
-    Key? key,
+    super.key,
     required this.totalSteps,
     required this.currentStep,
-  }) : super(key: key);
+  });
 
   final int totalSteps;
   final int currentStep;

--- a/lib/src/core/wiredash_model.dart
+++ b/lib/src/core/wiredash_model.dart
@@ -164,7 +164,7 @@ extension ChangeNotifierAsValueNotifier<C extends ChangeNotifier> on C {
 }
 
 class _DisposableValueNotifier<T> extends ValueNotifier<T> {
-  _DisposableValueNotifier(T value, {required this.onDispose}) : super(value);
+  _DisposableValueNotifier(super.value, {required this.onDispose});
   void Function() onDispose;
 
   @override

--- a/lib/src/core/wiredash_model_provider.dart
+++ b/lib/src/core/wiredash_model_provider.dart
@@ -3,10 +3,10 @@ import 'package:wiredash/src/core/wiredash_model.dart';
 
 class WiredashModelProvider extends InheritedNotifier<WiredashModel> {
   const WiredashModelProvider({
-    Key? key,
+    super.key,
     required WiredashModel wiredashModel,
-    required Widget child,
-  }) : super(key: key, notifier: wiredashModel, child: child);
+    required super.child,
+  }) : super(notifier: wiredashModel);
 
   static WiredashModel of(BuildContext context, {bool listen = true}) {
     if (listen) {

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -42,7 +42,7 @@ class Wiredash extends StatefulWidget {
   /// Creates a new [Wiredash] Widget which allows users to send feedback,
   /// wishes, ratings and much more
   const Wiredash({
-    Key? key,
+    super.key,
     required this.projectId,
     required this.secret,
     @Deprecated('Since 1.0.0 the navigatorKey is not required anymore')
@@ -53,7 +53,7 @@ class Wiredash extends StatefulWidget {
     this.psOptions,
     this.padding,
     required this.child,
-  }) : super(key: key);
+  });
 
   /// Reference to the app [Navigator] to show the Wiredash bottom sheet
   @Deprecated('Since 1.0.0 the navigatorKey is not required anymore')

--- a/lib/src/feedback/feedback_backdrop.dart
+++ b/lib/src/feedback/feedback_backdrop.dart
@@ -9,9 +9,9 @@ import 'package:wiredash/src/core/support/back_button_interceptor.dart';
 /// The backdrop for [WiredashFlow.feedback]
 class FeedbackBackdrop extends StatelessWidget {
   const FeedbackBackdrop({
-    Key? key,
+    super.key,
     required this.child,
-  }) : super(key: key);
+  });
 
   final Widget child;
 

--- a/lib/src/feedback/feedback_flow.dart
+++ b/lib/src/feedback/feedback_flow.dart
@@ -7,7 +7,7 @@ import 'package:wiredash/src/core/support/widget_binding_support.dart';
 import 'package:wiredash/src/feedback/ui/grey_scale_filter.dart';
 
 class WiredashFeedbackFlow extends StatefulWidget {
-  const WiredashFeedbackFlow({Key? key}) : super(key: key);
+  const WiredashFeedbackFlow({super.key});
 
   @override
   State<WiredashFeedbackFlow> createState() => _WiredashFeedbackFlowState();
@@ -140,9 +140,9 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
 /// Inherits the step information from [FeedbackModel]
 class FeedbackProgressIndicator extends StatefulWidget {
   const FeedbackProgressIndicator({
-    Key? key,
+    super.key,
     required this.flowStatus,
-  }) : super(key: key);
+  });
 
   final FeedbackFlowStatus flowStatus;
 

--- a/lib/src/feedback/feedback_model_provider.dart
+++ b/lib/src/feedback/feedback_model_provider.dart
@@ -3,10 +3,10 @@ import 'package:wiredash/src/feedback/feedback_model.dart';
 
 class FeedbackModelProvider extends InheritedNotifier<FeedbackModel> {
   const FeedbackModelProvider({
-    Key? key,
+    super.key,
     required FeedbackModel feedbackModel,
-    required Widget child,
-  }) : super(key: key, notifier: feedbackModel, child: child);
+    required super.child,
+  }) : super(notifier: feedbackModel);
 
   static FeedbackModel of(BuildContext context, {bool listen = true}) {
     if (listen) {

--- a/lib/src/feedback/picasso/picasso.dart
+++ b/lib/src/feedback/picasso/picasso.dart
@@ -8,10 +8,10 @@ import 'package:wiredash/src/feedback/picasso/stroke.dart';
 
 class Picasso extends StatefulWidget {
   const Picasso({
-    Key? key,
+    super.key,
     required this.controller,
     required this.child,
-  }) : super(key: key);
+  });
 
   final PicassoController controller;
   final Widget child;

--- a/lib/src/feedback/picasso/picasso_provider.dart
+++ b/lib/src/feedback/picasso/picasso_provider.dart
@@ -3,10 +3,10 @@ import 'package:wiredash/src/feedback/picasso/picasso.dart';
 
 class PicassoControllerProvider extends InheritedNotifier<PicassoController> {
   const PicassoControllerProvider({
-    Key? key,
+    super.key,
     required PicassoController picassoController,
-    required Widget child,
-  }) : super(key: key, notifier: picassoController, child: child);
+    required super.child,
+  }) : super(notifier: picassoController);
 
   static PicassoController of(BuildContext context, {bool listen = true}) {
     if (listen) {

--- a/lib/src/feedback/steps/step_1_feedback_message.dart
+++ b/lib/src/feedback/steps/step_1_feedback_message.dart
@@ -4,7 +4,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
 
 class Step1FeedbackMessage extends StatefulWidget {
-  const Step1FeedbackMessage({Key? key}) : super(key: key);
+  const Step1FeedbackMessage({super.key});
 
   @override
   State<Step1FeedbackMessage> createState() => _Step1FeedbackMessageState();

--- a/lib/src/feedback/steps/step_2_labels.dart
+++ b/lib/src/feedback/steps/step_2_labels.dart
@@ -4,7 +4,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
 
 class Step2Labels extends StatefulWidget {
-  const Step2Labels({Key? key}) : super(key: key);
+  const Step2Labels({super.key});
 
   @override
   State<Step2Labels> createState() => _Step2LabelsState();
@@ -74,8 +74,7 @@ class _LabelRecommendations extends StatelessWidget {
     required this.labels,
     required this.isLabelSelected,
     required this.toggleSelection,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final List<Label> labels;
   final bool Function(Label) isLabelSelected;
@@ -105,8 +104,7 @@ class _Label extends StatelessWidget {
     required this.label,
     required this.selected,
     required this.toggleSelection,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Label label;
   final bool selected;

--- a/lib/src/feedback/steps/step_3_screenshot_overview.dart
+++ b/lib/src/feedback/steps/step_3_screenshot_overview.dart
@@ -4,7 +4,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
 
 class Step3ScreenshotOverview extends StatefulWidget {
-  const Step3ScreenshotOverview({Key? key}) : super(key: key);
+  const Step3ScreenshotOverview({super.key});
 
   @override
   State<Step3ScreenshotOverview> createState() =>
@@ -33,8 +33,8 @@ class _Step3ScreenshotOverviewState extends State<Step3ScreenshotOverview> {
 
 class Step3NotAttachments extends StatelessWidget {
   const Step3NotAttachments({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -101,8 +101,8 @@ class Step3NotAttachments extends StatelessWidget {
 
 class Step3WithGallery extends StatelessWidget {
   const Step3WithGallery({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -174,9 +174,9 @@ class Step3WithGallery extends StatelessWidget {
 
 class AttachmentPreview extends StatelessWidget {
   const AttachmentPreview({
-    Key? key,
+    super.key,
     required this.attachment,
-  }) : super(key: key);
+  });
 
   final PersistedAttachment attachment;
 
@@ -222,9 +222,7 @@ class AttachmentPreview extends StatelessWidget {
 }
 
 class _NewAttachment extends StatelessWidget {
-  const _NewAttachment({
-    Key? key,
-  }) : super(key: key);
+  const _NewAttachment();
 
   @override
   Widget build(BuildContext context) {
@@ -283,7 +281,7 @@ class _NewAttachment extends StatelessWidget {
 }
 
 class Elevation extends StatelessWidget {
-  const Elevation({Key? key, this.child, this.elevation = 2}) : super(key: key);
+  const Elevation({super.key, this.child, this.elevation = 2});
 
   final Widget? child;
   final double elevation;

--- a/lib/src/feedback/steps/step_5_email.dart
+++ b/lib/src/feedback/steps/step_5_email.dart
@@ -6,7 +6,7 @@ import 'package:wiredash/src/core/support/widget_binding_support.dart';
 import 'package:wiredash/src/utils/email_validator.dart';
 
 class Step5Email extends StatefulWidget {
-  const Step5Email({Key? key}) : super(key: key);
+  const Step5Email({super.key});
 
   @override
   State<Step5Email> createState() => _Step5EmailState();

--- a/lib/src/feedback/steps/step_6_submit.dart
+++ b/lib/src/feedback/steps/step_6_submit.dart
@@ -5,7 +5,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
 
 class Step6Submit extends StatefulWidget {
-  const Step6Submit({Key? key}) : super(key: key);
+  const Step6Submit({super.key});
 
   @override
   State<Step6Submit> createState() => _Step6SubmitState();

--- a/lib/src/feedback/steps/step_7_submitting.dart
+++ b/lib/src/feedback/steps/step_7_submitting.dart
@@ -4,7 +4,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
 
 class Step7SubmittingAndError extends StatefulWidget {
-  const Step7SubmittingAndError({Key? key}) : super(key: key);
+  const Step7SubmittingAndError({super.key});
 
   @override
   State<Step7SubmittingAndError> createState() =>
@@ -37,9 +37,7 @@ class _Step7SubmittingAndErrorState extends State<Step7SubmittingAndError> {
 }
 
 class _Submitted extends StatelessWidget {
-  const _Submitted({
-    Key? key,
-  }) : super(key: key);
+  const _Submitted();
 
   @override
   Widget build(BuildContext context) {
@@ -73,9 +71,7 @@ class _Submitted extends StatelessWidget {
 }
 
 class _Submitting extends StatelessWidget {
-  const _Submitting({
-    Key? key,
-  }) : super(key: key);
+  const _Submitting();
 
   @override
   Widget build(BuildContext context) {
@@ -107,8 +103,7 @@ class _Submitting extends StatelessWidget {
 class _Error extends StatelessWidget {
   const _Error({
     required this.error,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Object error;
 

--- a/lib/src/feedback/ui/base_click_target.dart
+++ b/lib/src/feedback/ui/base_click_target.dart
@@ -5,13 +5,13 @@ const buttonBlue = Color(0xFF1A56DB);
 
 class BaseClickTarget extends StatefulWidget {
   const BaseClickTarget({
-    Key? key,
+    super.key,
     this.onTap,
     required this.builder,
     this.child,
     this.selected,
     this.onStateChanged,
-  }) : super(key: key);
+  });
 
   final void Function()? onTap;
   final void Function(TargetState state)? onStateChanged;
@@ -159,7 +159,7 @@ class TargetStateAnimations {
 
 class AnimatedClickTarget extends StatefulWidget {
   const AnimatedClickTarget({
-    Key? key,
+    super.key,
     this.focusNode,
     this.onTap,
     required this.builder,
@@ -168,7 +168,7 @@ class AnimatedClickTarget extends StatefulWidget {
     this.selected,
     this.curve = Curves.easeInOutCubic,
     this.reverseCurve,
-  }) : super(key: key);
+  });
 
   final FocusNode? focusNode;
   final void Function()? onTap;

--- a/lib/src/feedback/ui/color_palette.dart
+++ b/lib/src/feedback/ui/color_palette.dart
@@ -8,14 +8,14 @@ import 'package:wiredash/src/feedback/ui/slider/stroke_width_slider_widget.dart'
 
 class ColorPalette extends StatefulWidget {
   const ColorPalette({
-    Key? key,
+    super.key,
     required this.colors,
     this.initialSelection = const Color(0xff6B46C1),
     this.initialStrokeWidth = 8.0,
     this.onNewColorSelected,
     this.onNewStrokeWidthSelected,
     this.onUndo,
-  }) : super(key: key);
+  });
 
   static const _borderRadius = 20.0;
 
@@ -181,11 +181,11 @@ class _ColorPaletteState extends State<ColorPalette>
 
 class HorizontalColorPicker extends StatelessWidget {
   const HorizontalColorPicker({
-    Key? key,
+    super.key,
     required this.colors,
     this.selectedColor,
     this.onNewColorSelected,
-  }) : super(key: key);
+  });
 
   final List<Color> colors;
   final Color? selectedColor;
@@ -223,7 +223,7 @@ class HorizontalColorPicker extends StatelessWidget {
 }
 
 class StrokeWidthDot extends StatefulWidget {
-  const StrokeWidthDot({Key? key, this.onTap}) : super(key: key);
+  const StrokeWidthDot({super.key, this.onTap});
 
   final VoidCallback? onTap;
 
@@ -305,11 +305,11 @@ class _StrokeWidthDotState extends State<StrokeWidthDot> {
 
 class AnimatedColorDot extends StatefulWidget {
   const AnimatedColorDot({
-    Key? key,
+    super.key,
     required this.color,
     required this.isSelected,
     required this.onTap,
-  }) : super(key: key);
+  });
 
   final Color color;
   final bool isSelected;

--- a/lib/src/feedback/ui/grey_scale_filter.dart
+++ b/lib/src/feedback/ui/grey_scale_filter.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 class GreyScaleFilter extends StatelessWidget {
-  const GreyScaleFilter({required this.greyScale, Key? key, this.child})
-      : super(key: key);
+  const GreyScaleFilter({required this.greyScale, super.key, this.child});
 
   final Widget? child;
   final double greyScale;

--- a/lib/src/feedback/ui/screencapture.dart
+++ b/lib/src/feedback/ui/screencapture.dart
@@ -11,10 +11,10 @@ import 'package:wiredash/src/feedback/ui/grey_scale_filter.dart';
 
 class ScreenCapture extends StatefulWidget {
   const ScreenCapture({
-    Key? key,
+    super.key,
     required this.controller,
     required this.child,
-  }) : super(key: key);
+  });
 
   final ScreenCaptureController controller;
   final Widget child;

--- a/lib/src/feedback/ui/screenshot_bar.dart
+++ b/lib/src/feedback/ui/screenshot_bar.dart
@@ -5,8 +5,8 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 
 class ScreenshotBar extends StatelessWidget {
   const ScreenshotBar({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/feedback/ui/semi_transparent_statusbar.dart
+++ b/lib/src/feedback/ui/semi_transparent_statusbar.dart
@@ -11,9 +11,9 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 /// Wiredash.
 class SemiTransparentStatusBar extends StatelessWidget {
   const SemiTransparentStatusBar({
-    Key? key,
+    super.key,
     required this.child,
-  }) : super(key: key);
+  });
 
   final Widget child;
 

--- a/lib/src/feedback/ui/slider/stroke_width_slider_widget.dart
+++ b/lib/src/feedback/ui/slider/stroke_width_slider_widget.dart
@@ -4,14 +4,14 @@ import 'package:wiredash/src/feedback/ui/slider/stroke_width_slider_painter.dart
 
 class StrokeWidthSlider extends StatefulWidget {
   const StrokeWidthSlider({
-    Key? key,
+    super.key,
     required this.color,
     required this.minWidth,
     required this.maxWidth,
     required this.currentWidth,
     this.onNewWidthSelected,
     this.onInteract,
-  }) : super(key: key);
+  });
 
   final Color color;
   final double minWidth;

--- a/lib/src/promoterscore/ps_backdrop.dart
+++ b/lib/src/promoterscore/ps_backdrop.dart
@@ -6,9 +6,9 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 /// The backdrop for [WiredashFlow.promoterScore]
 class PsBackdrop extends StatelessWidget {
   const PsBackdrop({
-    Key? key,
+    super.key,
     required this.child,
-  }) : super(key: key);
+  });
 
   final Widget child;
 

--- a/lib/src/promoterscore/ps_flow.dart
+++ b/lib/src/promoterscore/ps_flow.dart
@@ -5,7 +5,7 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 import 'package:wiredash/src/core/support/material_support_layer.dart';
 
 class PromoterScoreFlow extends StatefulWidget {
-  const PromoterScoreFlow({Key? key}) : super(key: key);
+  const PromoterScoreFlow({super.key});
 
   @override
   State<PromoterScoreFlow> createState() => _PromoterScoreFlowState();

--- a/lib/src/promoterscore/ps_model_provider.dart
+++ b/lib/src/promoterscore/ps_model_provider.dart
@@ -3,10 +3,10 @@ import 'package:wiredash/src/promoterscore/ps_model.dart';
 
 class PsModelProvider extends InheritedNotifier<PsModel> {
   const PsModelProvider({
-    Key? key,
+    super.key,
     required PsModel psModel,
-    required Widget child,
-  }) : super(key: key, notifier: psModel, child: child);
+    required super.child,
+  }) : super(notifier: psModel);
 
   static PsModel of(BuildContext context, {bool listen = true}) {
     if (listen) {

--- a/lib/src/promoterscore/step_1_rating.dart
+++ b/lib/src/promoterscore/step_1_rating.dart
@@ -8,8 +8,8 @@ import 'package:wiredash/src/utils/delay.dart';
 
 class PsStep1Rating extends StatefulWidget {
   const PsStep1Rating({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<PsStep1Rating> createState() => _PsStep1RatingState();
@@ -58,10 +58,9 @@ class _PsStep1RatingState extends State<PsStep1Rating> {
 
 class _PsRater extends StatefulWidget {
   const _PsRater({
-    Key? key,
     required this.score,
     required this.onSelected,
-  }) : super(key: key);
+  });
 
   final void Function(int? score) onSelected;
   final int? score;
@@ -178,11 +177,10 @@ class _PsRaterState extends State<_PsRater> {
 
 class _RatingCard extends StatefulWidget {
   const _RatingCard({
-    Key? key,
     required this.value,
     required this.checked,
     required this.onTap,
-  }) : super(key: key);
+  });
 
   final int value;
   final bool checked;

--- a/lib/src/promoterscore/step_2_message.dart
+++ b/lib/src/promoterscore/step_2_message.dart
@@ -5,8 +5,8 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 
 class PsStep2Message extends StatefulWidget {
   const PsStep2Message({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<PsStep2Message> createState() => _PsStep2MessageState();

--- a/lib/src/promoterscore/step_3_thanks.dart
+++ b/lib/src/promoterscore/step_3_thanks.dart
@@ -4,7 +4,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/_wiredash_ui.dart';
 
 class PsStep3Thanks extends StatelessWidget {
-  const PsStep3Thanks({Key? key}) : super(key: key);
+  const PsStep3Thanks({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/wiredashio/wiredash-sdk
 issue_tracker: https://github.com/wiredashio/wiredash-sdk/issues
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.8.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   clock: ^1.1.0
@@ -28,9 +28,9 @@ dev_dependencies:
   fake_async: any
   flutter_test:
     sdk: flutter
-  lint: '>=1.5.0 <3.0.0'
-  test: ^1.16.0-nullsafety
-  transparent_image: ^2.0.0-nullsafety.0
+  lint: '>=1.10.0 <3.0.0'
+  test: ^1.21.0
+  transparent_image: ^2.0.0
 
 flutter:
   assets:

--- a/test/util/assert_widget.dart
+++ b/test/util/assert_widget.dart
@@ -405,7 +405,8 @@ extension on List<WidgetSelector> {
 class _MultiAncestorDescendantFinder extends Finder {
   _MultiAncestorDescendantFinder(
     this.ancestors,
-    this.finder,);
+    this.finder,
+  );
 
   final List<Finder> ancestors;
   final Finder finder;

--- a/test/util/assert_widget.dart
+++ b/test/util/assert_widget.dart
@@ -405,9 +405,7 @@ extension on List<WidgetSelector> {
 class _MultiAncestorDescendantFinder extends Finder {
   _MultiAncestorDescendantFinder(
     this.ancestors,
-    this.finder, {
-    bool skipOffstage = true,
-  }) : super(skipOffstage: skipOffstage);
+    this.finder,);
 
   final List<Finder> ancestors;
   final Finder finder;

--- a/test/util/assert_widget_test.dart
+++ b/test/util/assert_widget_test.dart
@@ -116,7 +116,7 @@ void main() {
 }
 
 class _UnknownWidget extends StatelessWidget {
-  const _UnknownWidget({Key? key}) : super(key: key);
+  const _UnknownWidget();
 
   @override
   Widget build(BuildContext context) {

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -272,7 +272,7 @@ class _MockProjectCredentialValidator extends Fake
 }
 
 class _FakeApp extends StatefulWidget {
-  const _FakeApp({Key? key}) : super(key: key);
+  const _FakeApp();
 
   @override
   State<_FakeApp> createState() => _FakeAppState();


### PR DESCRIPTION
Flutter 3.0 was released one year ago `11/05/2022`, it's time to drop support for older versions

Former min SDK Flutter 2.8 was released `09/12/2021`
