### PR TITLE
[test] Remove tap warnings

### DIFF
--- a/lib/src/feedback/steps/step_3_screenshot_overview.dart
+++ b/lib/src/feedback/steps/step_3_screenshot_overview.dart
@@ -230,7 +230,7 @@ class AttachmentPreview extends StatelessWidget {
 }
 
 class NewAttachment extends StatelessWidget {
-  const NewAttachment();
+  const NewAttachment({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/feedback/steps/step_3_screenshot_overview.dart
+++ b/lib/src/feedback/steps/step_3_screenshot_overview.dart
@@ -149,7 +149,7 @@ class Step3WithGallery extends StatelessWidget {
                             ),
                           ),
                         if (context.feedbackModel.attachments.length < 3)
-                          const _NewAttachment(),
+                          const NewAttachment(),
                       ],
                     ),
                   ),
@@ -229,8 +229,8 @@ class AttachmentPreview extends StatelessWidget {
   }
 }
 
-class _NewAttachment extends StatelessWidget {
-  const _NewAttachment();
+class NewAttachment extends StatelessWidget {
+  const NewAttachment();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/promoterscore/step_1_rating.dart
+++ b/lib/src/promoterscore/step_1_rating.dart
@@ -128,7 +128,7 @@ class _PsRaterState extends State<_PsRater> {
             for (final i in [0, 1, 2, 3, 4, 5])
               ConstrainedBox(
                 constraints: BoxConstraints(maxWidth: maxItemWidth),
-                child: _RatingCard(
+                child: RatingCard(
                   value: i,
                   checked: i == selectedScore,
                   onTap: () => _onTap(i),
@@ -142,7 +142,7 @@ class _PsRaterState extends State<_PsRater> {
             for (final i in [6, 7, 8, 9, 10])
               ConstrainedBox(
                 constraints: BoxConstraints(maxWidth: maxItemWidth),
-                child: _RatingCard(
+                child: RatingCard(
                   value: i,
                   checked: i == selectedScore,
                   onTap: () => _onTap(i),
@@ -176,8 +176,9 @@ class _PsRaterState extends State<_PsRater> {
   }
 }
 
-class _RatingCard extends StatefulWidget {
-  const _RatingCard({
+class RatingCard extends StatefulWidget {
+  const RatingCard({
+    super.key,
     required this.value,
     required this.checked,
     required this.onTap,
@@ -188,10 +189,10 @@ class _RatingCard extends StatefulWidget {
   final void Function() onTap;
 
   @override
-  _RatingCardState createState() => _RatingCardState();
+  State<RatingCard> createState() => _RatingCardState();
 }
 
-class _RatingCardState extends State<_RatingCard>
+class _RatingCardState extends State<RatingCard>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 
@@ -215,7 +216,7 @@ class _RatingCardState extends State<_RatingCard>
   }
 
   @override
-  void didUpdateWidget(_RatingCard oldWidget) {
+  void didUpdateWidget(RatingCard oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.checked != oldWidget.checked) {
       if (widget.checked) {

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -414,7 +414,16 @@ class WiredashTestRobot {
   Future<void> ratePromoterScore(int rating) async {
     assert(rating >= 0 && rating <= 10);
     final step = _spotPageView.spotSingle<PsStep1Rating>()..existsOnce();
-    await _tap(step.spotSingleText(rating.toString()));
+
+    SingleWidgetSelector<RatingCard> spotRatingCard(int rating) => step
+        .spot<RatingCard>()
+        .whereWidget(
+          (widget) => widget.value == rating,
+          description: 'RatingCard $rating',
+        )
+        .first();
+
+    await _tap(spotRatingCard(rating));
     await tester.pumpAndSettle();
 
     /// automatically goes to next step
@@ -429,16 +438,16 @@ class WiredashTestRobot {
       children: [spotSingleText('l10n.promoterScoreSubmitButton')],
     ).last()
       ..existsOnce();
+    final scrollable = spotSingle<LarryPageView>()
+        .spotSingle<StepPageScaffold>()
+        .spotSingle<ScrollBox>()
+        .spotSingle<SingleChildScrollView>()
+        .spot<Scrollable>()
+        .first();
     await tester.scrollUntilVisible(
       submitButton.finder,
       -100,
-      scrollable: spotSingle<LarryPageView>()
-          .spotSingle<StepPageScaffold>()
-          .spotSingle<ScrollBox>()
-          .spotSingle<SingleChildScrollView>()
-          .spot<Scrollable>()
-          .first()
-          .finder,
+      scrollable: scrollable.finder,
     );
     await _tap(submitButton);
     await tester.pumpAndSettle();

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -308,12 +308,9 @@ class WiredashTestRobot {
       await _tap(addScreenshotBtn);
     } else {
       final gallery = step.spotSingle<Step3WithGallery>()..existsOnce();
-      final addAttachmentItem = gallery.spotSingleIcon(Wirecons.plus)
+      final addAttachmentItem = gallery.spotSingle<NewAttachment>()
         ..existsOnce();
-      // TODO
-      await _tap(
-        addAttachmentItem, /* warnIfMissed: false*/
-      );
+      await _tap(addAttachmentItem);
     }
 
     await tester.waitUntil(find.byType(ScreenshotBar), findsOneWidget);


### PR DESCRIPTION
spot reported correctly that the target is actually wrapped in an `AbsorbPointer`.

Now the `RatingCard` and `NewAttachment` widgets are exposed and tapped instead.

Easier to debug, less warnings in log. Win Win.