### PR TITLE
Ignore '' from environment variables

### DIFF
--- a/lib/src/core/services/services.dart
+++ b/lib/src/core/services/services.dart
@@ -148,6 +148,7 @@ void _setupServices(WiredashServices sl) {
   // Replace with FlutterView when we drop support for Flutter v3.7.0-32.0.pre.
   // ignore: deprecated_member_use
   sl.inject<FlutterInfoCollector>((_) => FlutterInfoCollector(window));
+  sl.inject<BuildInfo>((_) => getBuildInformation());
   sl.inject<WiredashOptionsData>(
     (_) => sl.wiredashWidget.options ?? const WiredashOptionsData(),
   );
@@ -206,6 +207,7 @@ void _setupServices(WiredashServices sl) {
       wiredashModel: sl.get(),
       deviceInfoCollector: sl.get,
       wiredashWidget: sl.get,
+      buildInfoProvider: sl.get,
     );
   });
 

--- a/lib/src/core/sync/ping_job.dart
+++ b/lib/src/core/sync/ping_job.dart
@@ -50,20 +50,18 @@ class PingJob extends Job {
       return;
     }
 
-    final fixedData = await metaDataCollector().collectFixedMetaData();
+    final fixedMetadata = await metaDataCollector().collectFixedMetaData();
     final flutterInfo = metaDataCollector().collectFlutterInfo();
 
     final body = PingRequestBody(
       analyticsId: await wuidGenerator().appUsageId(),
-      buildCommit: fixedData.buildInfo.buildCommit,
-      buildVersion:
-          fixedData.buildInfo.buildVersion ?? fixedData.appInfo.version,
-      buildNumber:
-          fixedData.buildInfo.buildNumber ?? fixedData.appInfo.buildNumber,
-      bundleId: fixedData.appInfo.bundleId,
+      buildCommit: fixedMetadata.resolvedBuildCommit,
+      buildNumber: fixedMetadata.resolvedBuildNumber,
+      buildVersion: fixedMetadata.resolvedBuildVersion,
+      bundleId: fixedMetadata.appInfo.bundleId,
       platformLocale: flutterInfo.platformLocale,
       platformOS: flutterInfo.platformOS,
-      platformOSVersion: fixedData.deviceInfo.osVersion,
+      platformOSVersion: fixedMetadata.deviceInfo.osVersion,
       sdkVersion: wiredashSdkVersion,
     );
     try {

--- a/lib/src/metadata/all_meta_data.dart
+++ b/lib/src/metadata/all_meta_data.dart
@@ -92,11 +92,9 @@ class AllMetaData {
       appBrightness: sessionMetadata?.appBrightness,
       appLocale: sessionMetadata?.appLocale?.toLanguageTag(),
       appName: fixedMetadata.appInfo.appName,
-      buildCommit: fixedMetadata.buildInfo.buildCommit,
-      buildNumber: fixedMetadata.buildInfo.buildNumber ??
-          fixedMetadata.appInfo.buildNumber,
-      buildVersion:
-          fixedMetadata.buildInfo.buildVersion ?? fixedMetadata.appInfo.version,
+      buildCommit: fixedMetadata.resolvedBuildCommit,
+      buildNumber: fixedMetadata.resolvedBuildNumber,
+      buildVersion: fixedMetadata.resolvedBuildVersion,
       bundleId: fixedMetadata.appInfo.bundleId,
       compilationMode: fixedMetadata.buildInfo.compilationMode,
       custom: customizableMetadata.custom,

--- a/lib/src/metadata/build_info/build_info.dart
+++ b/lib/src/metadata/build_info/build_info.dart
@@ -93,16 +93,20 @@ class BuildInfo {
   }
 }
 
-final buildInfo = BuildInfo(
-  compilationMode: () {
-    if (kDebugMode) return CompilationMode.debug;
-    if (kProfileMode) return CompilationMode.profile;
-    return CompilationMode.release;
-  }(),
-  buildVersion: EnvBuildInfo.buildVersion,
-  buildNumber: EnvBuildInfo.buildNumber,
-  buildCommit: EnvBuildInfo.buildCommit,
-);
+BuildInfo getBuildInformation() {
+  return BuildInfo(
+    compilationMode: getCompilationMode(),
+    buildVersion: EnvBuildInfo.buildVersion,
+    buildNumber: EnvBuildInfo.buildNumber,
+    buildCommit: EnvBuildInfo.buildCommit,
+  );
+}
+
+CompilationMode getCompilationMode() {
+  if (kDebugMode) return CompilationMode.debug;
+  if (kProfileMode) return CompilationMode.profile;
+  return CompilationMode.release;
+}
 
 /// The compile mode the Flutter app was built with
 enum CompilationMode {

--- a/lib/src/metadata/meta_data_collector.dart
+++ b/lib/src/metadata/meta_data_collector.dart
@@ -22,11 +22,13 @@ class MetaDataCollector {
     required this.wiredashModel,
     required this.deviceInfoCollector,
     required this.wiredashWidget,
+    required this.buildInfoProvider,
   });
 
   final WiredashModel wiredashModel;
   final FlutterInfoCollector Function() deviceInfoCollector;
   final Wiredash Function() wiredashWidget;
+  final BuildInfo Function() buildInfoProvider;
 
   /// In-memory cache for fixed metadata
   FixedMetaData? fixedMetaData;
@@ -42,6 +44,7 @@ class MetaDataCollector {
       <Future<Object?>>[
         _collectAppInfo(),
         _collectDeviceInfo(),
+        Future(buildInfoProvider),
       ].map(
         (e) => e.timeout(const Duration(seconds: 1)).catchError(
           (Object e, StackTrace stack) {
@@ -57,11 +60,13 @@ class MetaDataCollector {
     );
     final appInfo = results[0] as AppInfo?;
     final deviceInfo = results[1] as DeviceInfo?;
+    final buildInfo = results[2] as BuildInfo?;
 
     final combined = FixedMetaData(
       appInfo: appInfo ?? const AppInfo(),
       deviceInfo: deviceInfo ?? const DeviceInfo(),
-      buildInfo: buildInfo,
+      buildInfo: buildInfo ??
+          const BuildInfo(compilationMode: CompilationMode.profile),
     );
 
     fixedMetaData = combined;

--- a/lib/src/metadata/meta_data_collector.dart
+++ b/lib/src/metadata/meta_data_collector.dart
@@ -196,6 +196,43 @@ class FixedMetaData {
     required this.buildInfo,
     required this.appInfo,
   });
+
+  String? get resolvedBuildVersion {
+    final fromBuildInfo = buildInfo.buildVersion;
+    if (fromBuildInfo != null && fromBuildInfo.isNotEmpty) {
+      return fromBuildInfo;
+    }
+    return appInfo.version;
+  }
+
+  String? get resolvedBuildNumber {
+    final fromBuildInfo = buildInfo.buildNumber;
+    if (fromBuildInfo != null && fromBuildInfo.isNotEmpty) {
+      return fromBuildInfo;
+    }
+    return appInfo.buildNumber;
+  }
+
+  String? get resolvedBuildCommit {
+    final commit = buildInfo.buildCommit;
+    if (commit != null && commit.isNotEmpty) {
+      return commit;
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FixedMetaData &&
+          runtimeType == other.runtimeType &&
+          deviceInfo == other.deviceInfo &&
+          buildInfo == other.buildInfo &&
+          appInfo == other.appInfo;
+
+  @override
+  int get hashCode =>
+      deviceInfo.hashCode ^ buildInfo.hashCode ^ appInfo.hashCode;
 }
 
 /// Information about the device the user is using

--- a/test/metadata_test.dart
+++ b/test/metadata_test.dart
@@ -81,6 +81,29 @@ void main() {
     expect(ping.buildCommit, 'abc');
   });
 
+  testWidgets('empty strings from build information ENVs are ignored',
+      (tester) async {
+    final robot = WiredashTestRobot(tester);
+    await robot.launchApp();
+    robot.services.inject<BuildInfo>((_) {
+      return const BuildInfo(
+        compilationMode: CompilationMode.profile,
+        // fake from ENV
+        buildCommit: '',
+        buildNumber: '',
+        buildVersion: '',
+      );
+    });
+    // send ping
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpHardAndSettle();
+    final latestPing = robot.mockServices.mockApi.pingInvocations.latest;
+    final ping = latestPing[0] as PingRequestBody?;
+    expect(ping!.buildVersion, '0.1.0'); // from appInfo
+    expect(ping.buildNumber, '1'); // from appInfo
+    expect(ping.buildCommit, isNull);
+  });
+
   testWidgets('set metadata before opening wiredash', (tester) async {
     final robot = WiredashTestRobot(tester);
 


### PR DESCRIPTION
`buildNumber`, `buildVersion` and `buildCommit` can be overwritten with environment variables (https://docs.wiredash.io/sdk/custom-properties/#set-build-properties)

Unfortunately, the override also worked when the env variable returned an empty string `""`. This is now resolved. Empty strings will not override the true version information anymore 