### PR TITLE
Mute Wiredash in widget tests

### DIFF
--- a/lib/src/core/services/error_report.dart
+++ b/lib/src/core/services/error_report.dart
@@ -13,10 +13,6 @@ FlutterErrorDetails reportWiredashError(
   StackTrace stack,
   String message,
 ) {
-  if (isInFlutterTest()) {
-    // never fail tests
-    return reportWiredashInfo(e, stack, message);
-  }
   final details = FlutterErrorDetails(
     exception: e,
     stack: stack,
@@ -39,9 +35,8 @@ FlutterErrorDetails reportWiredashError(
 FlutterErrorDetails reportWiredashInfo(
   Object e,
   StackTrace stack,
-  String message, {
-  bool ignoreInTests = false,
-}) {
+  String message,
+) {
   final details = FlutterErrorDetails(
     exception: e,
     stack: stack,
@@ -50,14 +45,7 @@ FlutterErrorDetails reportWiredashInfo(
       DiagnosticsNode.message(message),
     ],
   );
-  if (ignoreInTests && isInFlutterTest()) {
-    return details;
-  }
   final reporter = FlutterError.presentError;
   reporter.call(details);
   return details;
-}
-
-bool isInFlutterTest() {
-  return Platform.environment.containsKey('FLUTTER_TEST');
 }

--- a/lib/src/core/services/error_report.dart
+++ b/lib/src/core/services/error_report.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 
 /// Reports an user errors, that can be resolved by the developer.

--- a/lib/src/core/services/services.dart
+++ b/lib/src/core/services/services.dart
@@ -26,6 +26,7 @@ import 'package:wiredash/src/feedback/feedback_model.dart';
 import 'package:wiredash/src/feedback/picasso/picasso.dart';
 import 'package:wiredash/src/feedback/ui/screencapture.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
+import 'package:wiredash/src/utils/test_detector.dart';
 import 'package:wiredash/wiredash.dart';
 
 /// Internal service locator
@@ -75,6 +76,8 @@ class WiredashServices extends ChangeNotifier {
   AppTelemetry get appTelemetry => _locator.watch();
 
   MetaDataCollector get metaDataCollector => _locator.watch();
+
+  TestDetector get testDetector => _locator.watch();
 
   void updateWidget(Wiredash wiredashWidget) {
     inject<Wiredash>((_) => wiredashWidget);
@@ -247,6 +250,7 @@ void _setupServices(WiredashServices sl) {
 
   sl.inject<DiscardFeedbackUseCase>((_) => DiscardFeedbackUseCase(sl));
   sl.inject<DiscardPsUseCase>((_) => DiscardPsUseCase(sl));
+  sl.inject<TestDetector>((_) => TestDetector());
 }
 
 /// Discards the current feedback

--- a/lib/src/core/wiredash_model.dart
+++ b/lib/src/core/wiredash_model.dart
@@ -165,7 +165,7 @@ class WiredashModel with ChangeNotifier {
         final after = await collector(before);
         return customizableMetaData = after.copyWith();
       } catch (e, stack) {
-        reportWiredashError(
+        reportWiredashInfo(
           e,
           stack,
           'Failed to collect custom metadata',

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:collection/collection.dart';
@@ -184,26 +183,6 @@ class WiredashState extends State<Wiredash> {
     return _services;
   }
 
-  @visibleForTesting
-  static bool? isInsideTestsOverride;
-
-  bool get _isInsideTests {
-    bool? override;
-    assert(() {
-      override = isInsideTestsOverride;
-      return true;
-    }());
-    if (override != null) {
-      return override!;
-    }
-    if (kIsWeb) {
-      // Platform not available
-      return false;
-    }
-
-    return Platform.environment.containsKey('FLUTTER_TEST');
-  }
-
   @override
   void initState() {
     super.initState();
@@ -216,9 +195,8 @@ class WiredashState extends State<Wiredash> {
     _services.wiredashModel.addListener(_markNeedsBuild);
     _services.backdropController.addListener(_markNeedsBuild);
 
-    final insideTests = _isInsideTests;
-
-    if (!insideTests) {
+    final inFakeAsync = _services.testDetector.inFakeAsync();
+    if (!inFakeAsync) {
       // start the sync engine
       unawaited(_services.syncEngine.onWiredashInit());
     }

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -219,11 +219,8 @@ class WiredashState extends State<Wiredash> {
     final insideTests = _isInsideTests;
 
     if (!insideTests) {
-      print('production');
       // start the sync engine
       unawaited(_services.syncEngine.onWiredashInit());
-    } else {
-      print('inside tests');
     }
 
     _backButtonDispatcher = WiredashBackButtonDispatcher()..initialize();

--- a/lib/src/core/wuid_generator.dart
+++ b/lib/src/core/wuid_generator.dart
@@ -75,7 +75,7 @@ class SharedPrefsWuidGenerator implements WuidGenerator {
     } catch (e, stack) {
       // might fail when users manipulate shared prefs. Creating a new id in
       // that case
-      reportWiredashError(e, stack, 'Could not read $key from shared prefs');
+      reportWiredashInfo(e, stack, 'Could not read $key from shared prefs');
     }
 
     // first time generation or fallback in case of sharedPrefs error
@@ -84,7 +84,7 @@ class SharedPrefsWuidGenerator implements WuidGenerator {
       final prefs = await sharedPrefsProvider().timeout(_sharedPrefsTimeout);
       await prefs.setString(key, deviceId).timeout(_sharedPrefsTimeout);
     } catch (e, stack) {
-      reportWiredashError(e, stack, 'Could not write $key to shared prefs');
+      reportWiredashInfo(e, stack, 'Could not write $key to shared prefs');
     }
     return deviceId;
   }

--- a/lib/src/feedback/data/direct_feedback_submitter.dart
+++ b/lib/src/feedback/data/direct_feedback_submitter.dart
@@ -46,14 +46,14 @@ class DirectFeedbackSubmitter implements FeedbackSubmitter {
           e.message!.contains('is required')) {
         // some required property is missing. The item will never be delivered
         // to the server, therefore discard it.
-        reportWiredashError(
+        reportWiredashInfo(
           e,
           stack,
           'Feedback has missing properties and can not be submitted to server',
         );
         rethrow;
       }
-      reportWiredashError(
+      reportWiredashInfo(
         e,
         stack,
         'Wiredash server error. Will retry after app restart',

--- a/lib/src/feedback/data/pending_feedback_item_storage.dart
+++ b/lib/src/feedback/data/pending_feedback_item_storage.dart
@@ -42,7 +42,7 @@ class PendingFeedbackItemStorage {
 
         // The next time addPendingItem is called, the invalid feedbacks get
         // removed automatically
-        reportWiredashError(e, stack, 'Could not parse item from disk $item');
+        reportWiredashInfo(e, stack, 'Could not parse item from disk $item');
         try {
           // Remove the associated screenshot right now.
           // This here is custom parsing and fails when the serialization
@@ -53,7 +53,7 @@ class PendingFeedbackItemStorage {
             await screenshot.delete();
           }
         } catch (e) {
-          reportWiredashError(
+          reportWiredashInfo(
             e,
             stack,
             'Could not delete screenshot for invalid item $item',

--- a/lib/src/feedback/data/retrying_feedback_submitter.dart
+++ b/lib/src/feedback/data/retrying_feedback_submitter.dart
@@ -208,7 +208,7 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
         if (e.response?.statusCode == 400) {
           // The request is invalid. The feedback will never be delivered
           // to the server, therefore discard it.
-          reportWiredashError(
+          reportWiredashInfo(
             e,
             stack,
             'Feedback has missing properties and can not be submitted to '

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -376,7 +376,7 @@ class FeedbackModel extends ChangeNotifier2 {
           _feedbackProcessed = true;
           notifyListeners();
         } catch (e, stack) {
-          reportWiredashError(e, stack, 'Feedback submission failed');
+          reportWiredashInfo(e, stack, 'Feedback submission failed');
           _submissionError = e;
         }
       }

--- a/lib/src/feedback/ui/screencapture.dart
+++ b/lib/src/feedback/ui/screencapture.dart
@@ -215,7 +215,7 @@ class ScreenCaptureController extends ChangeNotifier {
     try {
       _screenshot = await _state!.captureScreen();
     } catch (e, stack) {
-      _error = reportWiredashError(e, stack, _screenshotTakenErrorMessage);
+      _error = reportWiredashInfo(e, stack, _screenshotTakenErrorMessage);
     }
     notifyListeners();
     return _screenshot;

--- a/lib/src/metadata/meta_data_collector.dart
+++ b/lib/src/metadata/meta_data_collector.dart
@@ -41,22 +41,25 @@ class MetaDataCollector {
     }
 
     final results = await Future.wait(
-      <Future<Object?>>[
+      [
         _collectAppInfo(),
         _collectDeviceInfo(),
         Future(buildInfoProvider),
-      ].map(
-        (e) => e.timeout(const Duration(seconds: 1)).catchError(
+      ].map((Future<Object> future) {
+        return future.then<Object?>((value) => value);
+      }).map((e) {
+        return e.timeout(const Duration(seconds: 1)).catchError(
           (Object e, StackTrace stack) {
-            reportWiredashError(
+            reportWiredashInfo(
               e,
               stack,
               'Could not collect metadata',
             );
-            return null;
+            // ignore: avoid_redundant_argument_values
+            return Future.value(null);
           },
-        ),
-      ),
+        );
+      }),
     );
     final appInfo = results[0] as AppInfo?;
     final deviceInfo = results[1] as DeviceInfo?;
@@ -84,7 +87,7 @@ class MetaDataCollector {
         buildNumber: packageInfo.buildNumber,
       );
     } catch (e, stack) {
-      reportWiredashError(e, stack, 'Failed to collect package info');
+      reportWiredashInfo(e, stack, 'Failed to collect package info');
     }
 
     return appInfo;
@@ -164,7 +167,7 @@ class MetaDataCollector {
         return const DeviceInfo();
       }
 
-      reportWiredashError(
+      reportWiredashInfo(
         e,
         stack,
         'Failed to collect deviceInfo.model with device_info_plus',

--- a/lib/src/promoterscore/ps_model.dart
+++ b/lib/src/promoterscore/ps_model.dart
@@ -93,7 +93,7 @@ class PsModel extends ChangeNotifier2 {
       await _services.api.sendPromoterScore(body);
     } catch (e, stack) {
       if (kDevMode) {
-        reportWiredashError(e, stack, 'Promoter score start request failed');
+        reportWiredashInfo(e, stack, 'Promoter score start request failed');
       } else {
         if (silentFail) {
           // fail silently
@@ -115,7 +115,7 @@ class PsModel extends ChangeNotifier2 {
       unawaited(_services.syncEngine.onSubmitPromoterScore());
     } catch (e, stack) {
       _submissionError = e;
-      reportWiredashError(e, stack, 'Promoter Score submission failed');
+      reportWiredashInfo(e, stack, 'Promoter Score submission failed');
     } finally {
       _closeDelay?.dispose();
       _closeDelay = Delay(const Duration(seconds: 2));

--- a/lib/src/utils/test_detector.dart
+++ b/lib/src/utils/test_detector.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Detects if the code is currently running in a test environment
+///
+/// Being fully aware that test detection in production code is an anti-pattern
+/// it is very useful to prevent Wiredash from scheduling background jobs,
+/// that would exchange data with the backend. Those requests will fail in a
+/// test environment, but the scheduled jobs could unnecessarily interfere with
+/// the app under test by creating Timers, use timeouts or call method channels.
+class TestDetector {
+  /// Returns true if the code is executed inside testWidgets()
+  bool inFakeAsync() {
+    try {
+      if (kReleaseMode) {
+        // release mode never executes tests
+        return false;
+      }
+
+      // Check the timer implementation. Wiredash should only ignore job scheduling in testWidgets()
+      final timer = Zone.current.createTimer(Duration.zero, () {});
+      timer.cancel();
+
+      // Attempt #1 detect FakeTimer by its toString() method
+      // timer.toString(); returns => Instance of 'FakeTimer'
+      final isFakeTimer = timer.toString().contains('FakeTimer');
+      if (isFakeTimer) {
+        // Wiredash schedules jobs with timers.
+        // If FakeTimers are used, we are inside a widget test.
+        // Do not schedule jobs with fakeTimers because application test code is
+        // most likely not about the Wiredash jobs, but about the application itself.
+        // Scheduling jobs would interfere with the test.
+        return true;
+      }
+
+      // Attempt #2 detect FakeTimer by its creationStackTrace getter
+      // in case FakeTimer.toString() changes.
+      try {
+        // identify FakeTimer by its creationStackTrace getter
+        final dynamic dynamicTimer = timer;
+        // ignore: avoid_dynamic_calls
+        final stack = dynamicTimer.creationStackTrace;
+        if (stack is StackTrace) {
+          return true;
+        }
+      } catch (e) {
+        // ignore
+      }
+
+      return false;
+    } catch (e) {
+      // being paranoid, but never ever crash this function
+      return false;
+    }
+  }
+}

--- a/test/common/network/wiredash_api_test.dart
+++ b/test/common/network/wiredash_api_test.dart
@@ -112,7 +112,7 @@ void main() {
         },
       );
       expect(
-        errors.presentError.toString(),
+        errors.onError.toString(),
         stringContainsInOrder([
           'customMetaData',
           'property function',

--- a/test/common/network/wiredash_api_test.dart
+++ b/test/common/network/wiredash_api_test.dart
@@ -3,25 +3,18 @@
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
 import 'package:test/test.dart';
 import 'package:wiredash/src/_feedback.dart';
 import 'package:wiredash/src/_ps.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 
+import '../../util/flutter_error.dart';
+
 void main() {
   group('Serialize feedback item', () {
     test('FeedbackBody.toJson()', () {
-      final oldOnErrorHandler = FlutterError.onError;
-      late FlutterErrorDetails caught;
-      FlutterError.onError = (FlutterErrorDetails details) {
-        caught = details;
-      };
-      addTearDown(() {
-        FlutterError.onError = oldOnErrorHandler;
-      });
-
+      final errors = captureFlutterErrors();
       final body = FeedbackItem(
         feedbackId: '1234',
         attachments: [
@@ -119,7 +112,7 @@ void main() {
         },
       );
       expect(
-        caught.toString(),
+        errors.presentError.toString(),
         stringContainsInOrder([
           'customMetaData',
           'property function',

--- a/test/promoterscore_flow_test.dart
+++ b/test/promoterscore_flow_test.dart
@@ -6,7 +6,6 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 
 import 'util/flutter_error.dart';
 import 'util/robot.dart';
-import 'util/wiredash_tester.dart';
 
 void main() {
   group('promoter score', () {

--- a/test/promoterscore_flow_test.dart
+++ b/test/promoterscore_flow_test.dart
@@ -1,19 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:spot/spot.dart';
 import 'package:wiredash/src/_ps.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 
+import 'util/flutter_error.dart';
 import 'util/robot.dart';
+import 'util/wiredash_tester.dart';
 
 void main() {
   group('promoter score', () {
-    setUp(() {
-      SharedPreferences.setMockInitialValues({});
-    });
-
-    testWidgets('Send promoter score', (tester) async {
+    testWidgets('Send promoter score - happy path', (tester) async {
       final robot = await WiredashTestRobot(tester).launchApp();
       await robot.openPromoterScore();
       await robot.ratePromoterScore(7);
@@ -149,14 +146,7 @@ void main() {
           (invocation) async {
         throw Exception('No internet');
       };
-      final oldOnErrorHandler = FlutterError.onError;
-      late FlutterErrorDetails caught;
-      FlutterError.onError = (FlutterErrorDetails details) {
-        caught = details;
-      };
-      addTearDown(() {
-        FlutterError.onError = oldOnErrorHandler;
-      });
+      final errors = captureFlutterErrors();
 
       await robot.openPromoterScore();
       await robot.ratePromoterScore(7);
@@ -167,7 +157,11 @@ void main() {
       await robot.showsPromoterScoreThanksMessage();
 
       await robot.waitUntilWiredashIsClosed();
-      expect(caught.exception.toString(), contains('No internet'));
+      expect(
+        errors.presentError[0].exception.toString(),
+        contains('No internet'),
+      );
+      expect(errors.onError, isEmpty);
     });
 
     testWidgets('Hold app while submitting ps resets form', (tester) async {

--- a/test/util/flutter_error.dart
+++ b/test/util/flutter_error.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// Consumes all [FlutterError.onError] and [FlutterError.presentError] calls
+/// during this test and makes them accessible as list for assertions.
 FlutterErrors captureFlutterErrors() {
   final errors = FlutterErrors();
   final oldPresentHandler = FlutterError.presentError;
   FlutterError.presentError = (details) {
-    errors.presentError.add(details);
+    errors._presentError.add(details);
   };
   addTearDown(() {
     FlutterError.presentError = oldPresentHandler;
@@ -13,7 +15,7 @@ FlutterErrors captureFlutterErrors() {
 
   final oldOnErrorHandler = FlutterError.onError;
   FlutterError.onError = (FlutterErrorDetails details) {
-    errors.onError.add(details);
+    errors._onError.add(details);
   };
   addTearDown(() {
     FlutterError.onError = oldOnErrorHandler;
@@ -22,7 +24,12 @@ FlutterErrors captureFlutterErrors() {
   return errors;
 }
 
+/// A summary of [FlutterError.onError] and [FlutterError.presentError] calls
 class FlutterErrors {
-  final List<FlutterErrorDetails> onError = [];
-  final List<FlutterErrorDetails> presentError = [];
+  List<FlutterErrorDetails> get onError => List.unmodifiable(_onError);
+  final List<FlutterErrorDetails> _onError = [];
+
+  List<FlutterErrorDetails> get presentError =>
+      List.unmodifiable(_presentError);
+  final List<FlutterErrorDetails> _presentError = [];
 }

--- a/test/util/flutter_error.dart
+++ b/test/util/flutter_error.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+FlutterErrors captureFlutterErrors() {
+  final errors = FlutterErrors();
+  final oldPresentHandler = FlutterError.presentError;
+  FlutterError.presentError = (details) {
+    errors.presentError.add(details);
+  };
+  addTearDown(() {
+    FlutterError.presentError = oldPresentHandler;
+  });
+
+  final oldOnErrorHandler = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    errors.onError.add(details);
+  };
+  addTearDown(() {
+    FlutterError.onError = oldOnErrorHandler;
+  });
+
+  return errors;
+}
+
+class FlutterErrors {
+  final List<FlutterErrorDetails> onError = [];
+  final List<FlutterErrorDetails> presentError = [];
+}

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -122,6 +122,9 @@ class WiredashTestRobot {
       }
       return null;
     });
+
+    WiredashState.isInsideTestsOverride = false;
+    addTearDown(() => WiredashState.isInsideTestsOverride = null);
   }
 
   Future<WiredashTestRobot> launchApp({

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -19,6 +19,7 @@ import 'package:wiredash/src/core/wiredash_widget.dart';
 
 // ignore: unused_import
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
+import 'package:wiredash/src/utils/test_detector.dart';
 import 'package:wiredash/wiredash.dart';
 
 import 'mock_api.dart';
@@ -122,9 +123,6 @@ class WiredashTestRobot {
       }
       return null;
     });
-
-    WiredashState.isInsideTestsOverride = false;
-    addTearDown(() => WiredashState.isInsideTestsOverride = null);
   }
 
   Future<WiredashTestRobot> launchApp({
@@ -638,6 +636,9 @@ WiredashServices createMockServices({bool useDirectFeedbackSubmitter = false}) {
     return MockWiredashApi.fake();
   });
 
+  // Let the widget behave as in production
+  services.inject<TestDetector>((_) => _OverlookFakeAsync());
+
   if (useDirectFeedbackSubmitter) {
     // replace submitter, because for testing we always want to submit directly
     services.inject<FeedbackSubmitter>(
@@ -647,6 +648,17 @@ WiredashServices createMockServices({bool useDirectFeedbackSubmitter = false}) {
     assert(services.feedbackSubmitter is RetryingFeedbackSubmitter);
   }
   return services;
+}
+
+/// Fake the test detector to not detect the fake async environment
+///
+/// Wiredash should behave differently in user tests. But wiredash tests should
+/// be able schedule jobs in a fake async environment.
+class _OverlookFakeAsync implements TestDetector {
+  @override
+  bool inFakeAsync() {
+    return false;
+  }
 }
 
 class WiredashTestLocalizationDelegate

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: avoid_print
 
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -365,7 +365,6 @@ void main() {
 
       await tester.pump(const Duration(minutes: 10));
 
-      // TODO verify with Http
       // No http calls
       expect(api.pingInvocations.count, 0);
       expect(api.sendFeedbackInvocations.count, 0);

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -22,6 +22,9 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       debugServicesCreator = createMockServices;
       addTearDown(() => debugServicesCreator = null);
+
+      WiredashState.isInsideTestsOverride = false;
+      addTearDown(() => WiredashState.isInsideTestsOverride = null);
     });
 
     testWidgets('widget can be created', (tester) async {


### PR DESCRIPTION
Don't call `FlutterError.onError` unless it is an error that can be resolved by the developer.

This came up in a 3rd party app testing setup. Test failed because the `ping` after 5s after app start tried to read the device information, but no mock was setup. Wiredash then called `onError` with the `MissingPluginException`.

Technically it could be fixed by mocking the plugin, but that is completely out of scope of the test. Wiredash can print the error, but should not fail the test.

- [x] Check if pings and other jobs can be prevented altogether in 3rd party tests
- [x] Check if not calling `onWiredashInit()` has negative consequences
  - Does not write `firstAppStart` and increment `appStartCount` (required for PromoterScore)
  - Does not send `ping`
  - Does not send pending `feedbacks`