### PR TITLE
Test setup - fix nightly build for min-version and beta

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,12 +58,15 @@ jobs:
           ref: beta
       - name: Flutter version
         run: flutter doctor -v
-      - name: Download dependencies
-        run: ./wiresdk deps
-      - name: Test
-        run: ./wiresdk test
       - name: Build
         run: cd examples/theming && ./../../wiresdk flutter build web
+      - name: Download dependencies
+        run: |
+          # Override dependencies as long as we depend on checks 0.2.2
+          ./wiresdk flutter pub add 'override:test_api:^0.7.0'
+          ./wiresdk deps
+      - name: Test
+        run: ./wiresdk test
 
   latest:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,9 +21,12 @@ jobs:
         run: cd examples/theming && ./../../wiresdk flutter build web
       - name: Download dependencies
         run: |
-          ./wiresdk flutter pub add 'override:checks:0.2.2'       
-          ./wiresdk flutter pub add 'override:meta:1.9.0'       
-          ./wiresdk flutter pub add 'override:test_api:0.4.9'       
+          # Override dependencies
+          printf "dependency_overrides:\n  checks: 0.2.2\n  meta: 1.9.0\n  test_api: 0.4.9" >> pubspec.yaml
+          
+          # The override syntax does not work with Flutter 3.0
+          #./wiresdk flutter pub add 'override:checks:0.2.2'  
+          
           ./wiresdk deps
       - name: Test
         run: ./wiresdk test

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,12 +17,16 @@ jobs:
           ref: stable
       - name: Flutter version
         run: flutter doctor -v
-      - name: Download dependencies
-        run: ./wiresdk deps
-      - name: Test
-        run: ./wiresdk test
       - name: Build
         run: cd examples/theming && ./../../wiresdk flutter build web
+      - name: Download dependencies
+        run: |
+          ./wiresdk flutter pub add 'override:checks:0.2.2'       
+          ./wiresdk flutter pub add 'override:meta:1.9.0'       
+          ./wiresdk flutter pub add 'override:test_api:0.4.9'       
+          ./wiresdk deps
+      - name: Test
+        run: ./wiresdk test
 
   stable:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -71,9 +71,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Flutter version
         run: flutter doctor -v
-      - name: Download dependencies
-        run: ./wiresdk deps
-      - name: Test
-        run: ./wiresdk test
       - name: Build
         run: cd examples/theming && ./../../wiresdk flutter build web
+      - name: Download dependencies
+        run: |
+          # Override dependencies as long as we depend on checks 0.2.2
+          ./wiresdk flutter pub add 'override:test_api:^0.7.0'
+          ./wiresdk deps
+      - name: Test
+        run: ./wiresdk test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,12 +32,16 @@ jobs:
       - uses: actions/checkout@v3
       - name: Flutter version
         run: flutter doctor -v
-      - name: Download dependencies
-        run: ./wiresdk deps
-      - name: Test
-        run: ./wiresdk test
       - name: Build
         run: cd examples/theming && ./../../wiresdk flutter build web
+      - name: Download dependencies
+        run: |
+          ./wiresdk flutter pub add 'override:checks:0.2.2'       
+          ./wiresdk flutter pub add 'override:meta:1.9.0'       
+          ./wiresdk flutter pub add 'override:test_api:0.4.9'       
+          ./wiresdk deps
+      - name: Test
+        run: ./wiresdk test
 
   pr-stable:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,9 +36,12 @@ jobs:
         run: cd examples/theming && ./../../wiresdk flutter build web
       - name: Download dependencies
         run: |
-          ./wiresdk flutter pub add 'override:checks:0.2.2'       
-          ./wiresdk flutter pub add 'override:meta:1.9.0'       
-          ./wiresdk flutter pub add 'override:test_api:0.4.9'       
+          # Override dependencies
+          printf "dependency_overrides:\n  checks: 0.2.2\n  meta: 1.9.0\n  test_api: 0.4.9" >> pubspec.yaml
+          
+          # The override syntax does not work with Flutter 3.0
+          #./wiresdk flutter pub add 'override:checks:0.2.2'  
+          
           ./wiresdk deps
       - name: Test
         run: ./wiresdk test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,10 +44,6 @@ dev_dependencies:
   test: ^1.21.0
   transparent_image: ^2.0.0
 
-dependency_overrides:
-  # checks 0.2.2 requires test_api 0.7.0. Upgrade when upgrading to Dart 3.0+
-  test_api: ^0.6.0
-
 flutter:
   assets:
     - packages/wiredash/assets/images/logo_white.png


### PR DESCRIPTION
The build step should always work without changes.
Testing dependencies might need overrides for specific versions (checks is problematic here https://github.com/dart-lang/test/issues/2189)