### PR TITLE
Wipe pending events in debug mode (similar to feedbacks)

### DIFF
--- a/lib/src/analytics/event_store.dart
+++ b/lib/src/analytics/event_store.dart
@@ -23,6 +23,9 @@ abstract class AnalyticsEventStore {
 
   /// Removes outdated events
   Future<void> deleteOutdatedEvents();
+
+  /// Deletes all events from the store
+  Future<void> wipe();
 }
 
 /// Event to be saved in the [AnalyticsEventStore]
@@ -194,6 +197,16 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
     // remove remaining events that exceed the maximum size
     for (final event in oldestLast) {
       await prefs.remove(event);
+    }
+  }
+
+  @override
+  Future<void> wipe() async {
+    final prefs = await sharedPreferences();
+    final eventKeys =
+        prefs.getKeys().where((key) => eventKeyRegex.hasMatch(key)).toList();
+    for (final key in eventKeys) {
+      await prefs.remove(key);
     }
   }
 }

--- a/lib/src/analytics/event_submitter.dart
+++ b/lib/src/analytics/event_submitter.dart
@@ -20,6 +20,9 @@ abstract class EventSubmitter {
 
   /// Disposes the [EventSubmitter], cancels all scheduled tasks and timers
   void dispose();
+
+  /// Deletes all pending events from the [AnalyticsEventStore]
+  Future<void> deletePendingEvents();
 }
 
 /// Sends events directly to the backend without batching.
@@ -34,6 +37,11 @@ class DirectEventSubmitter extends DebounceEventSubmitter {
           throttleDuration: Duration.zero,
           initialThrottleDuration: Duration.zero,
         );
+
+  @override
+  Future<void> deletePendingEvents() async {
+    // noop
+  }
 }
 
 /// Denounces event submission to the backend, minimizing network traffic by batching events.
@@ -188,5 +196,10 @@ class DebounceEventSubmitter implements EventSubmitter {
   @override
   void dispose() {
     _delay?.dispose();
+  }
+
+  @override
+  Future<void> deletePendingEvents() async {
+    await eventStore.wipe();
   }
 }

--- a/lib/src/core/sync/event_upload_job.dart
+++ b/lib/src/core/sync/event_upload_job.dart
@@ -1,4 +1,5 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/analytics/event_submitter.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 
@@ -28,5 +29,9 @@ class EventUploadJob extends Job {
     }
     final submitter = eventSubmitter();
     await submitter.submitEvents();
+
+    if (kDevMode) {
+      await submitter.deletePendingEvents();
+    }
   }
 }

--- a/test/analytics/event_submitter_test.dart
+++ b/test/analytics/event_submitter_test.dart
@@ -131,4 +131,9 @@ class InMemoryEventStore implements AnalyticsEventStore {
   Future<void> trimToDiskLimit() async {
     // noop
   }
+
+  @override
+  Future<void> wipe() async {
+    _events.clear();
+  }
 }


### PR DESCRIPTION
Less errors when developing without a valid backend/credentials