### PR TITLE
Allow setting a environment (default dev/prod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then create a project with a descriptive name.
 ### 2. Add Wiredash to your pubspec.yaml
 
 ```bash
-$ flutter pub add wiredash:^2.2.0
+$ flutter pub add wiredash:^2.3.0
 ```
 
 ```yaml
@@ -44,7 +44,7 @@ dependencies:
   flutter:
     sdk: flutter
   ...
-  wiredash: ^2.2.0
+  wiredash: ^2.3.0
 ```
 
 ### 3. Wrap your root widget with Wiredash

--- a/lib/src/analytics/analytics.dart
+++ b/lib/src/analytics/analytics.dart
@@ -98,9 +98,11 @@ class WiredashAnalytics {
     final fixedMetadata =
         await _services.metaDataCollector.collectFixedMetaData();
     final flutterInfo = _services.metaDataCollector.collectFlutterInfo();
+    final environment = await _services.environmentLoader.getEnvironment();
+    final analyticsId = await _services.wuidGenerator.appUsageId();
 
     final event = AnalyticsEvent(
-      analyticsId: await _services.wuidGenerator.appUsageId(),
+      analyticsId: analyticsId,
       buildCommit: fixedMetadata.resolvedBuildCommit,
       buildNumber: fixedMetadata.resolvedBuildNumber,
       buildVersion: fixedMetadata.resolvedBuildVersion,
@@ -108,6 +110,7 @@ class WiredashAnalytics {
       createdAt: clock.now(),
       eventData: eventData,
       eventName: eventName,
+      environment: environment,
       platformOS: flutterInfo.platformOS,
       platformOSVersion: fixedMetadata.deviceInfo.osVersion,
       platformLocale: flutterInfo.platformLocale,

--- a/lib/src/analytics/analytics.dart
+++ b/lib/src/analytics/analytics.dart
@@ -132,7 +132,7 @@ class WiredashAnalytics {
     _services.updateWidget(wiredash?.widget);
 
     final String environment =
-        _environment ?? await _services.environmentLoader.getEnvironment();
+        _environment ?? await _services.environmentDetector.getEnvironment();
 
     final fixedMetadata =
         await _services.metaDataCollector.collectFixedMetaData();

--- a/lib/src/analytics/analytics.dart
+++ b/lib/src/analytics/analytics.dart
@@ -36,12 +36,7 @@ class WiredashAnalytics {
   /// White-label apps can use this to differentiate between different clients,
   /// when they share the same Wiredash project.
   ///
-  /// The environment needs to be
-  /// - at least 2 characters long, max 32 characters
-  /// - only use lowercase a-z, - and _
-  /// - start with a letter (a-z)
-  ///
-  /// Experimental, because this feature is not yet fully rolled out in the console
+  /// {@macro environmentNameConstraints}
   final String? _environment;
 
   /// Creates a new instance of [WiredashAnalytics], creating multiple is totally fine.

--- a/lib/src/analytics/analytics.dart
+++ b/lib/src/analytics/analytics.dart
@@ -6,7 +6,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/analytics/event_store.dart';
-import 'package:wiredash/src/core/options/environment_loader.dart';
 import 'package:wiredash/src/core/version.dart';
 import 'package:wiredash/src/core/wiredash_widget.dart';
 
@@ -41,6 +40,8 @@ class WiredashAnalytics {
   /// - at least 2 characters long, max 32 characters
   /// - only use lowercase a-z, - and _
   /// - start with a letter (a-z)
+  ///
+  /// Experimental, because this feature is not yet fully rolled out in the console
   final String? _environment;
 
   /// Creates a new instance of [WiredashAnalytics], creating multiple is totally fine.
@@ -48,6 +49,13 @@ class WiredashAnalytics {
   ///
   /// Set the [projectId] in case you have multiple [Wiredash] widgets with different
   /// projectIds in your app. If you only have one [Wiredash] widget, you can omit the [projectId].
+  ///
+  /// Set the [environment] of your app, like 'prod', 'dev', 'staging'
+  /// Defaults to the environment of the [Wiredash] widget, which itself
+  /// defaults to 'dev' for debug builds and 'prod' for release builds.
+  ///
+  /// It is necessary to set the [environment] in cases when there is no [Wiredash]
+  /// widget mounted, like in a background isolate.
   WiredashAnalytics({
     String? projectId,
     String? environment,

--- a/lib/src/analytics/event_store.dart
+++ b/lib/src/analytics/event_store.dart
@@ -37,6 +37,7 @@ class AnalyticsEvent {
   final String? bundleId;
   final DateTime? createdAt;
   final Map<String, Object?>? eventData;
+  final String? environment;
   final String eventName;
   final String? platformOS;
   final String? platformOSVersion;
@@ -51,6 +52,7 @@ class AnalyticsEvent {
     this.bundleId,
     this.createdAt,
     this.eventData,
+    this.environment,
     required this.eventName,
     this.platformOS,
     this.platformOSVersion,
@@ -67,6 +69,7 @@ class AnalyticsEvent {
         'buildVersion: $buildVersion, '
         'bundleId: $bundleId, '
         'createdAt: $createdAt, '
+        'environment: $environment, '
         'eventData: $eventData, '
         'eventName: $eventName, '
         'platformOS: $platformOS, '
@@ -75,6 +78,41 @@ class AnalyticsEvent {
         'sdkVersion: $sdkVersion'
         '}';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AnalyticsEvent &&
+          runtimeType == other.runtimeType &&
+          analyticsId == other.analyticsId &&
+          buildCommit == other.buildCommit &&
+          buildNumber == other.buildNumber &&
+          buildVersion == other.buildVersion &&
+          bundleId == other.bundleId &&
+          createdAt == other.createdAt &&
+          eventData == other.eventData &&
+          environment == other.environment &&
+          eventName == other.eventName &&
+          platformOS == other.platformOS &&
+          platformOSVersion == other.platformOSVersion &&
+          platformLocale == other.platformLocale &&
+          sdkVersion == other.sdkVersion;
+
+  @override
+  int get hashCode =>
+      analyticsId.hashCode ^
+      buildCommit.hashCode ^
+      buildNumber.hashCode ^
+      buildVersion.hashCode ^
+      bundleId.hashCode ^
+      createdAt.hashCode ^
+      eventData.hashCode ^
+      environment.hashCode ^
+      eventName.hashCode ^
+      platformOS.hashCode ^
+      platformOSVersion.hashCode ^
+      platformLocale.hashCode ^
+      sdkVersion.hashCode;
 }
 
 /// Saves [AnalyticsEvent] on disk
@@ -220,6 +258,7 @@ Map<String, Object?> serializeEventV1(AnalyticsEvent event) {
     if (event.bundleId != null) "bundleId": event.bundleId,
     if (event.createdAt != null)
       "createdAt": event.createdAt!.toIso8601String(),
+    if (event.environment != null) "environment": event.environment,
     "eventName": event.eventName,
     if (event.platformOS != null) "platformOS": event.platformOS,
     if (event.platformOSVersion != null)
@@ -266,6 +305,7 @@ AnalyticsEvent deserializeEventV1(Map<String, Object?> map) {
     final buildVersion = map['buildVersion'] as String?;
     final bundleId = map['bundleId'] as String?;
     final createdAtRaw = map['createdAt'] as String?;
+    final environment = map['environment'] as String?;
     final eventData = map['eventData'] as Map<String, Object?>?;
     final eventName = map['eventName']! as String;
     final platformOS = map['platformOS'] as String?;
@@ -279,6 +319,7 @@ AnalyticsEvent deserializeEventV1(Map<String, Object?> map) {
       buildVersion: buildVersion,
       bundleId: bundleId,
       createdAt: createdAtRaw != null ? DateTime.parse(createdAtRaw) : null,
+      environment: environment,
       eventData: eventData,
       eventName: eventName,
       platformOS: platformOS,

--- a/lib/src/analytics/event_submitter.dart
+++ b/lib/src/analytics/event_submitter.dart
@@ -152,6 +152,7 @@ class DebounceEventSubmitter implements EventSubmitter {
         createdAt: event.createdAt,
         eventData: event.eventData,
         eventName: event.eventName,
+        environment: event.environment,
         platformOS: event.platformOS,
         platformOSVersion: event.platformOSVersion,
         platformLocale: event.platformLocale,

--- a/lib/src/core/network/ping_request.dart
+++ b/lib/src/core/network/ping_request.dart
@@ -34,6 +34,7 @@ class PingRequestBody {
   final String? buildNumber;
   final String? buildVersion;
   final String? bundleId;
+  final String? environment;
   final String? platformOS;
   final String? platformOSVersion;
   final String? platformLocale;
@@ -45,6 +46,7 @@ class PingRequestBody {
     this.buildNumber,
     this.buildVersion,
     this.bundleId,
+    this.environment,
     this.platformOS,
     this.platformOSVersion,
     this.platformLocale,
@@ -74,6 +76,11 @@ class PingRequestBody {
     final _bundleId = bundleId;
     if (_bundleId != null) {
       body['bundleId'] = _bundleId;
+    }
+
+    final _environment = environment;
+    if (_environment != null) {
+      body['environment'] = _environment;
     }
 
     final _platformOS = platformOS;

--- a/lib/src/core/network/send_events_request.dart
+++ b/lib/src/core/network/send_events_request.dart
@@ -107,6 +107,7 @@ class RequestEvent {
   final String? buildVersion;
   final String? bundleId;
   final DateTime? createdAt;
+  final String? environment;
   final Map<String, Object?>? eventData;
   final String eventName;
   final String? platformOS;
@@ -121,6 +122,7 @@ class RequestEvent {
     this.buildVersion,
     this.bundleId,
     this.createdAt,
+    this.environment,
     this.eventData,
     required this.eventName,
     this.platformOS,
@@ -158,6 +160,11 @@ class RequestEvent {
     if (_createdAt != null) {
       final unixTimestamp = _createdAt.millisecondsSinceEpoch;
       body['createdAt'] = unixTimestamp;
+    }
+
+    final _environment = environment;
+    if (_environment != null) {
+      body['environment'] = _environment;
     }
 
     final _eventData = eventData;

--- a/lib/src/core/network/send_feedback_request.dart
+++ b/lib/src/core/network/send_feedback_request.dart
@@ -142,6 +142,11 @@ extension AllMetaDataRequestJson on AllMetaData {
       values.addAll({'deviceModel': _deviceModel});
     }
 
+    final _environment = environment;
+    if (_environment != null) {
+      values.addAll({'environment': _environment});
+    }
+
     assert(installId.length >= 16);
     // for backwards compatability we convert the old uuid to a nanoId
     final _installNanoId = uuidToNanoId(installId, maxLength: 32);

--- a/lib/src/core/options/environment_detector.dart
+++ b/lib/src/core/options/environment_detector.dart
@@ -1,18 +1,20 @@
-import 'package:flutter/foundation.dart';
 import 'package:wiredash/src/core/wiredash_widget.dart';
+import 'package:wiredash/src/metadata/build_info/build_info.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
 
-/// Load the environment from the Wiredash widget and either uses it or falls
-/// back to 'dev' or 'prod'
-class EnvironmentLoader {
-  EnvironmentLoader({
+/// Evaluates the environment from the [Wiredash] widget or falls back to 'dev' or 'prod'
+class EnvironmentDetector {
+  EnvironmentDetector({
     required Wiredash? Function() wiredashWidget,
     required MetaDataCollector Function() metaDataCollector,
+    required BuildInfo Function() buildInfoProvider,
   })  : _wiredashWidget = wiredashWidget,
-        _metaDataCollector = metaDataCollector;
+        _metaDataCollector = metaDataCollector,
+        _buildInfoProvider = buildInfoProvider;
 
   final Wiredash? Function() _wiredashWidget;
   final MetaDataCollector Function() _metaDataCollector;
+  final BuildInfo Function() _buildInfoProvider;
 
   /// Returns the environment from the Wiredash widget or falls back to 'dev' or 'prod'
   Future<String> getEnvironment() async {
@@ -21,13 +23,15 @@ class EnvironmentLoader {
       return widgetEnv;
     }
 
-    if (!kReleaseMode) {
+    final buildInfo = _buildInfoProvider();
+    if (buildInfo.compilationMode != CompilationMode.release) {
+      // dev and profile modes are non-production environments
       return 'dev';
     }
 
     final fixedMetaData = await _metaDataCollector().collectFixedMetaData();
     if (fixedMetaData.deviceInfo.isPhysicalDevice == false) {
-      // running on an emulator or simulator is considered dev
+      // running on an emulator or simulator is considered a non-production environment
       return 'dev';
     }
 

--- a/lib/src/core/options/environment_loader.dart
+++ b/lib/src/core/options/environment_loader.dart
@@ -6,46 +6,31 @@ import 'package:wiredash/src/metadata/meta_data_collector.dart';
 /// back to 'dev' or 'prod'
 class EnvironmentLoader {
   EnvironmentLoader({
-    required Wiredash Function() wiredashWidget,
+    required Wiredash? Function() wiredashWidget,
     required MetaDataCollector Function() metaDataCollector,
   })  : _wiredashWidget = wiredashWidget,
         _metaDataCollector = metaDataCollector;
 
-  final Wiredash Function() _wiredashWidget;
+  final Wiredash? Function() _wiredashWidget;
   final MetaDataCollector Function() _metaDataCollector;
 
-  /// Returns [Wiredash.environment] if set, otherwise 'dev' or 'prod' depending on [kReleaseMode]
+  /// Returns the environment from the Wiredash widget or falls back to 'dev' or 'prod'
   Future<String> getEnvironment() async {
-    final widgetEnv = _wiredashWidget().environment;
-
+    final widgetEnv = _wiredashWidget()?.environment;
     if (widgetEnv != null) {
-      assert(() {
-        validateEnvironment(widgetEnv);
-        return true;
-      }());
       return widgetEnv;
     }
 
-    if (await isDevEnvironment()) {
-      return 'dev';
-    }
-
-    return 'prod';
-  }
-
-  /// Returns true when a non-production environment is detected
-  Future<bool> isDevEnvironment() async {
     if (!kReleaseMode) {
-      // debug and profile builds are always considered dev
-      return true;
+      return 'dev';
     }
 
     final fixedMetaData = await _metaDataCollector().collectFixedMetaData();
     if (fixedMetaData.deviceInfo.isPhysicalDevice == false) {
       // running on an emulator or simulator is considered dev
-      return true;
+      return 'dev';
     }
 
-    return false;
+    return 'prod';
   }
 }

--- a/lib/src/core/options/environment_loader.dart
+++ b/lib/src/core/options/environment_loader.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+import 'package:wiredash/src/core/wiredash_widget.dart';
+import 'package:wiredash/src/metadata/meta_data_collector.dart';
+
+/// Load the environment from the Wiredash widget and either uses it or falls
+/// back to 'dev' or 'prod'
+class EnvironmentLoader {
+  EnvironmentLoader({
+    required Wiredash Function() wiredashWidget,
+    required MetaDataCollector Function() metaDataCollector,
+  })  : _wiredashWidget = wiredashWidget,
+        _metaDataCollector = metaDataCollector;
+
+  final Wiredash Function() _wiredashWidget;
+  final MetaDataCollector Function() _metaDataCollector;
+
+  /// Returns [Wiredash.environment] if set, otherwise 'dev' or 'prod' depending on [kReleaseMode]
+  Future<String> getEnvironment() async {
+    final widgetEnv = _wiredashWidget().environment;
+
+    if (widgetEnv != null) {
+      assert(() {
+        validateEnvironment(widgetEnv);
+        return true;
+      }());
+      return widgetEnv;
+    }
+
+    if (await isDevEnvironment()) {
+      return 'dev';
+    }
+
+    return 'prod';
+  }
+
+  /// Returns true when a non-production environment is detected
+  Future<bool> isDevEnvironment() async {
+    if (!kReleaseMode) {
+      // debug and profile builds are always considered dev
+      return true;
+    }
+
+    final fixedMetaData = await _metaDataCollector().collectFixedMetaData();
+    if (fixedMetaData.deviceInfo.isPhysicalDevice == false) {
+      // running on an emulator or simulator is considered dev
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/lib/src/core/services/services.dart
+++ b/lib/src/core/services/services.dart
@@ -12,6 +12,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/analytics/event_store.dart';
 import 'package:wiredash/src/analytics/event_submitter.dart';
 import 'package:wiredash/src/core/lifecycle/lifecycle_notifier.dart';
+import 'package:wiredash/src/core/options/environment_loader.dart';
 import 'package:wiredash/src/core/project_credential_validator.dart';
 import 'package:wiredash/src/core/services/streampod.dart';
 import 'package:wiredash/src/core/sync/app_telemetry_job.dart';
@@ -111,6 +112,8 @@ class WiredashServices extends ChangeNotifier {
 
   FlutterAppLifecycleNotifier get appLifecycleNotifier => _locator.watch();
 
+  EnvironmentLoader get environmentLoader => _locator.watch();
+
   Future<SharedPreferences> Function() get sharedPreferencesProvider {
     // explicitly using get instead of watch, because it is a factory not an
     // object that returns the correct object for every call
@@ -154,6 +157,12 @@ void registerProdWiredashServices(WiredashServices sl) {
       child: SizedBox(),
     ),
   );
+  sl.inject<EnvironmentLoader>((_) {
+    return EnvironmentLoader(
+      wiredashWidget: () => sl.wiredashWidget,
+      metaDataCollector: () => sl.metaDataCollector,
+    );
+  });
   sl.inject<WuidGenerator>(
     (_) {
       final generator = SharedPrefsWuidGenerator(
@@ -294,6 +303,7 @@ void registerProdWiredashServices(WiredashServices sl) {
           wuidGenerator: () => sl.wuidGenerator,
           metaDataCollector: () => sl.metaDataCollector,
           sharedPreferencesProvider: sl.sharedPreferencesProvider,
+          environmentLoader: () => sl.environmentLoader,
         ),
       );
       engine.addJob(

--- a/lib/src/core/services/services.dart
+++ b/lib/src/core/services/services.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:file/local.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:http/http.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -11,7 +10,7 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/analytics/event_store.dart';
 import 'package:wiredash/src/analytics/event_submitter.dart';
 import 'package:wiredash/src/core/lifecycle/lifecycle_notifier.dart';
-import 'package:wiredash/src/core/options/environment_loader.dart';
+import 'package:wiredash/src/core/options/environment_detector.dart';
 import 'package:wiredash/src/core/project_credential_validator.dart';
 import 'package:wiredash/src/core/services/streampod.dart';
 import 'package:wiredash/src/core/sync/app_telemetry_job.dart';
@@ -103,6 +102,8 @@ class WiredashServices extends ChangeNotifier {
 
   MetaDataCollector get metaDataCollector => _locator.watch();
 
+  BuildInfo get buildInfo => _locator.get();
+
   TestDetector get testDetector => _locator.watch();
 
   AnalyticsEventStore get eventStore => _locator.watch();
@@ -111,7 +112,7 @@ class WiredashServices extends ChangeNotifier {
 
   FlutterAppLifecycleNotifier get appLifecycleNotifier => _locator.watch();
 
-  EnvironmentLoader get environmentLoader => _locator.watch();
+  EnvironmentDetector get environmentDetector => _locator.watch();
 
   Future<SharedPreferences> Function() get sharedPreferencesProvider {
     // explicitly using get instead of watch, because it is a factory not an
@@ -152,10 +153,11 @@ void registerProdWiredashServices(WiredashServices sl) {
   sl.inject<Wiredash?>((_) {
     return null;
   });
-  sl.inject<EnvironmentLoader>((_) {
-    return EnvironmentLoader(
+  sl.inject<EnvironmentDetector>((_) {
+    return EnvironmentDetector(
       wiredashWidget: () => sl.wiredashWidget,
       metaDataCollector: () => sl.metaDataCollector,
+      buildInfoProvider: () => sl.buildInfo,
     );
   });
   sl.inject<WuidGenerator>(
@@ -298,7 +300,7 @@ void registerProdWiredashServices(WiredashServices sl) {
           wuidGenerator: () => sl.wuidGenerator,
           metaDataCollector: () => sl.metaDataCollector,
           sharedPreferencesProvider: sl.sharedPreferencesProvider,
-          environmentLoader: () => sl.environmentLoader,
+          environmentDetector: () => sl.environmentDetector,
         ),
       );
       engine.addJob(

--- a/lib/src/core/services/services.dart
+++ b/lib/src/core/services/services.dart
@@ -345,21 +345,3 @@ class DiscardPsUseCase {
     services.inject<PsModel>((locator) => PsModel(services));
   }
 }
-
-class UnmountedWiredashWidget extends Wiredash {
-  const UnmountedWiredashWidget({super.key})
-      : super(
-          projectId: 'unmounted',
-          secret: 'unmounted',
-          child: const SizedBox(),
-        );
-
-  @override
-  String get projectId => throw UnsupportedError('No widget is unmounted');
-
-  @override
-  String get secret => throw UnsupportedError('No widget is unmounted');
-
-  @override
-  String get environment => throw UnsupportedError('No widget is unmounted');
-}

--- a/lib/src/core/services/streampod.dart
+++ b/lib/src/core/services/streampod.dart
@@ -210,19 +210,28 @@ class InstanceFactory<T> {
       _tracker.create();
       _log(() => '${DependencyTracker._levelIndent}Creating $factoryType');
       late final T i;
-      i = create(locator);
-      _log(() {
-        final deps = dependencies.map((e) {
-          final i = e._instance as Object?;
-          if (i == null) return e.factoryType;
-          if (i is Function) return i.objectId;
-          return '${e.factoryType}=>${i.objectId}';
-        }).join(', ');
-        final depsText = deps.isEmpty ? '' : ', watching $deps';
-        return '${DependencyTracker._levelIndent}Created $factoryType=>${(i as Object?).objectId}$depsText';
-      });
-      _tracker.created();
-      _instance = i;
+      try {
+        i = create(locator);
+        _log(() {
+          final deps = dependencies.map((e) {
+            final i = e._instance as Object?;
+            if (i == null) return e.factoryType;
+            if (i is Function) return i.objectId;
+            return '${e.factoryType}=>${i.objectId}';
+          }).join(', ');
+          final depsText = deps.isEmpty ? '' : ', watching $deps';
+          return '${DependencyTracker._levelIndent}Created $factoryType=>${(i as Object?).objectId}$depsText';
+        });
+        _instance = i;
+      } catch (e, stack) {
+        _log(
+          () =>
+              '${DependencyTracker._levelIndent}Error creating $factoryType: $e\n$stack',
+        );
+        rethrow;
+      } finally {
+        _tracker.created();
+      }
     } else {
       _tracker.create();
       _tracker.created();

--- a/lib/src/core/sync/ping_job.dart
+++ b/lib/src/core/sync/ping_job.dart
@@ -1,6 +1,7 @@
 import 'package:clock/clock.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
+import 'package:wiredash/src/core/options/environment_loader.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/version.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
@@ -10,12 +11,14 @@ class PingJob extends Job {
   final Future<SharedPreferences> Function() sharedPreferencesProvider;
   final WuidGenerator Function() wuidGenerator;
   final MetaDataCollector Function() metaDataCollector;
+  final EnvironmentLoader Function() environmentLoader;
 
   PingJob({
     required this.apiProvider,
     required this.sharedPreferencesProvider,
     required this.wuidGenerator,
     required this.metaDataCollector,
+    required this.environmentLoader,
   });
 
   static const lastSuccessfulPingKey = 'io.wiredash.last_successful_ping';
@@ -52,6 +55,7 @@ class PingJob extends Job {
 
     final fixedMetadata = await metaDataCollector().collectFixedMetaData();
     final flutterInfo = metaDataCollector().collectFlutterInfo();
+    final environment = await environmentLoader().getEnvironment();
 
     final body = PingRequestBody(
       analyticsId: await wuidGenerator().appUsageId(),
@@ -59,6 +63,7 @@ class PingJob extends Job {
       buildNumber: fixedMetadata.resolvedBuildNumber,
       buildVersion: fixedMetadata.resolvedBuildVersion,
       bundleId: fixedMetadata.appInfo.bundleId,
+      environment: environment,
       platformLocale: flutterInfo.platformLocale,
       platformOS: flutterInfo.platformOS,
       platformOSVersion: fixedMetadata.deviceInfo.osVersion,

--- a/lib/src/core/sync/ping_job.dart
+++ b/lib/src/core/sync/ping_job.dart
@@ -1,7 +1,7 @@
 import 'package:clock/clock.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
-import 'package:wiredash/src/core/options/environment_loader.dart';
+import 'package:wiredash/src/core/options/environment_detector.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/version.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
@@ -11,14 +11,14 @@ class PingJob extends Job {
   final Future<SharedPreferences> Function() sharedPreferencesProvider;
   final WuidGenerator Function() wuidGenerator;
   final MetaDataCollector Function() metaDataCollector;
-  final EnvironmentLoader Function() environmentLoader;
+  final EnvironmentDetector Function() environmentDetector;
 
   PingJob({
     required this.apiProvider,
     required this.sharedPreferencesProvider,
     required this.wuidGenerator,
     required this.metaDataCollector,
-    required this.environmentLoader,
+    required this.environmentDetector,
   });
 
   static const lastSuccessfulPingKey = 'io.wiredash.last_successful_ping';
@@ -55,7 +55,7 @@ class PingJob extends Job {
 
     final fixedMetadata = await metaDataCollector().collectFixedMetaData();
     final flutterInfo = metaDataCollector().collectFlutterInfo();
-    final environment = await environmentLoader().getEnvironment();
+    final environment = await environmentDetector().getEnvironment();
 
     final body = PingRequestBody(
       analyticsId: await wuidGenerator().appUsageId(),

--- a/lib/src/core/version.dart
+++ b/lib/src/core/version.dart
@@ -50,4 +50,5 @@
 /// 220 -> 2.2.0
 /// 221 -> 2.2.1
 /// 222 -> 2.2.2
-const wiredashSdkVersion = 222;
+/// 230 -> 2.3.0
+const wiredashSdkVersion = 230;

--- a/lib/src/core/wiredash_controller.dart
+++ b/lib/src/core/wiredash_controller.dart
@@ -220,10 +220,12 @@ class WiredashController {
     String eventName, {
     Map<String, Object?>? data,
   }) async {
+    final wiredash = _model.services.wiredashWidget;
     Wiredash.trackEvent(
       eventName,
       data: data,
-      projectId: _model.services.wiredashWidget.projectId,
+      projectId: wiredash?.projectId,
+      environment: wiredash?.environment,
     );
   }
 
@@ -271,7 +273,7 @@ class WiredashController {
 
   /// Captures the current locale of the app when opening wiredash
   Locale? _detectAppLocale() {
-    final context = _model.services.wiredashWidget.showBuildContext;
+    final context = _model.services.wiredashWidget?.showBuildContext;
     if (context == null) return null;
 
     final locale = Localizations.maybeLocaleOf(context);
@@ -331,7 +333,7 @@ class WiredashController {
 
   /// Search the user context for the material theme
   ThemeData? _detectMaterialTheme() {
-    final context = _model.services.wiredashWidget.showBuildContext;
+    final context = _model.services.wiredashWidget?.showBuildContext;
     if (context != null) {
       return Theme.of(context);
     }
@@ -340,7 +342,7 @@ class WiredashController {
 
   /// Search the user context for the cupertino theme
   CupertinoThemeData? _detectCupertinoTheme() {
-    final context = _model.services.wiredashWidget.showBuildContext;
+    final context = _model.services.wiredashWidget?.showBuildContext;
     if (context != null) {
       return CupertinoTheme.of(context);
     }

--- a/lib/src/core/wiredash_model.dart
+++ b/lib/src/core/wiredash_model.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/core/support/widget_binding_support.dart';
+import 'package:wiredash/src/core/wiredash_widget.dart';
 import 'package:wiredash/src/feedback/data/retrying_feedback_submitter.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
 import 'package:wiredash/wiredash.dart';
@@ -186,6 +188,17 @@ class WiredashModel with ChangeNotifier {
     } catch (e, stack) {
       reportWiredashInfo(e, stack, 'Unexpected error while submitting events');
     }
+  }
+
+  String get environment {
+    final widgetEnv = services.wiredashWidget.environment;
+    if (widgetEnv != null) {
+      return widgetEnv;
+    }
+    if (kReleaseMode) {
+      return 'prod';
+    }
+    return 'dev';
   }
 }
 

--- a/lib/src/core/wiredash_model.dart
+++ b/lib/src/core/wiredash_model.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/core/support/widget_binding_support.dart';
-import 'package:wiredash/src/core/wiredash_widget.dart';
 import 'package:wiredash/src/feedback/data/retrying_feedback_submitter.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
 import 'package:wiredash/wiredash.dart';

--- a/lib/src/core/wiredash_model.dart
+++ b/lib/src/core/wiredash_model.dart
@@ -80,7 +80,7 @@ class WiredashModel with ChangeNotifier {
   }
 
   WiredashFeedbackOptions? get feedbackOptions =>
-      _feedbackOptionsOverride ?? services.wiredashWidget.feedbackOptions;
+      _feedbackOptionsOverride ?? services.wiredashWidget?.feedbackOptions;
 
   /// The ps options passed into `Wiredash.of(context).showPromoterSurvey()` call
   PsOptions? _psOptionsOverride;
@@ -94,7 +94,7 @@ class WiredashModel with ChangeNotifier {
 
   PsOptions get psOptions =>
       _psOptionsOverride ??
-      services.wiredashWidget.psOptions ??
+      services.wiredashWidget?.psOptions ??
       defaultPsOptions;
 
   /// Deletes pending feedbacks
@@ -157,7 +157,7 @@ class WiredashModel with ChangeNotifier {
     CustomMetaDataCollector? fallbackCollector,
   ) async {
     final collector =
-        services.wiredashWidget.collectMetaData ?? fallbackCollector;
+        services.wiredashWidget?.collectMetaData ?? fallbackCollector;
 
     if (collector != null) {
       try {
@@ -189,7 +189,7 @@ class WiredashModel with ChangeNotifier {
   }
 
   String get environment {
-    final widgetEnv = services.wiredashWidget.environment;
+    final widgetEnv = services.wiredashWidget?.environment;
     if (widgetEnv != null) {
       return widgetEnv;
     }

--- a/lib/src/core/wiredash_model.dart
+++ b/lib/src/core/wiredash_model.dart
@@ -187,17 +187,6 @@ class WiredashModel with ChangeNotifier {
       reportWiredashInfo(e, stack, 'Unexpected error while submitting events');
     }
   }
-
-  String get environment {
-    final widgetEnv = services.wiredashWidget?.environment;
-    if (widgetEnv != null) {
-      return widgetEnv;
-    }
-    if (kReleaseMode) {
-      return 'prod';
-    }
-    return 'dev';
-  }
 }
 
 extension ChangeNotifierAsValueNotifier<C extends ChangeNotifier> on C {

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -49,6 +49,7 @@ class Wiredash extends StatefulWidget {
     super.key,
     required this.projectId,
     required this.secret,
+    this.environment,
     this.options,
     this.theme,
     this.feedbackOptions,
@@ -63,6 +64,23 @@ class Wiredash extends StatefulWidget {
 
   /// Your Wiredash project secret
   final String secret;
+
+  /// The environment of your app, like 'prod', 'dev', 'staging'
+  ///
+  /// Defaults to 'dev' for debug builds and 'prod' for release builds.
+  ///
+  /// Setting an environment is useful to differentiate between different
+  /// versions of your app allowing you to filter analytics and feedback by
+  /// environment.
+  ///
+  /// White-label apps can use this to differentiate between different clients,
+  /// when they share the same Wiredash project.
+  ///
+  /// The environment needs to be
+  /// - at least 2 characters long, max 32 characters
+  /// - only use A-Z, a-z, - and _
+  /// - start with a letter (a-zA-Z)
+  final String? environment;
 
   /// Customize Wiredash's behaviour and language
   final WiredashOptionsData? options;
@@ -277,7 +295,7 @@ class WiredashState extends State<Wiredash> {
         _services.syncEngine.onAppMovedToBackground();
       }
     });
-    _onProjectIdChanged();
+    _onProjectEnvChanged();
 
     _backButtonDispatcher = WiredashBackButtonDispatcher()..initialize();
   }
@@ -317,23 +335,26 @@ class WiredashState extends State<Wiredash> {
     _services.updateWidget(widget);
 
     if (oldWidget.projectId != widget.projectId ||
-        oldWidget.secret != widget.secret) {
+        oldWidget.secret != widget.secret ||
+        oldWidget.environment != widget.environment) {
       _services.projectCredentialValidator.validate(
         projectId: widget.projectId,
         secret: widget.secret,
       );
-
-      if (oldWidget.options?.localizationDelegate !=
-          widget.options?.localizationDelegate) {
-        _verifySyncLocalizationsDelegate();
-      }
-      _services.updateWidget(widget);
-
-      _onProjectIdChanged();
+      _onProjectEnvChanged();
     }
+
+    if (oldWidget.options?.localizationDelegate !=
+        widget.options?.localizationDelegate) {
+      _verifySyncLocalizationsDelegate();
+    }
+    _services.updateWidget(widget);
   }
 
-  void _onProjectIdChanged() {
+  void _onProjectEnvChanged() {
+    if (widget.environment != null) {
+      validateEnvironment(widget.environment!);
+    }
     final inFakeAsync = _services.testDetector.inFakeAsync();
     if (!inFakeAsync) {
       // start the sync engine
@@ -527,4 +548,66 @@ Locale get _defaultLocale {
   // ignore: unnecessary_nullable_for_final_variable_declarations, deprecated_member_use
   final Locale? locale = ui.window.locale;
   return locale ?? const Locale('en', 'US');
+}
+
+void validateEnvironment(String environment) {
+  if (environment.isEmpty) {
+    throw ArgumentError.value(
+      environment,
+      'environment',
+      'The environment must not be empty',
+    );
+  }
+  // at least two characters
+  if (environment.length < 2 || environment.length > 32) {
+    throw ArgumentError.value(
+      environment,
+      'environment',
+      '$environment must be between 2 and 32 characters long',
+    );
+  }
+
+  if (environment.contains(' ')) {
+    throw ArgumentError.value(
+      environment,
+      'environment',
+      '$environment must not contain spaces',
+    );
+  }
+
+  if (environment.contains('ä') ||
+      environment.contains('ö') ||
+      environment.contains('ü')) {
+    throw ArgumentError.value(
+      environment,
+      'environment',
+      '$environment must not contain umlauts',
+    );
+  }
+
+  String firstChar = String.fromCharCode(environment.codeUnitAt(0));
+  if (firstChar == '#') {
+    firstChar = String.fromCharCode(environment.codeUnitAt(1));
+  }
+  final regex = RegExp('^[A-Za-z]');
+  if (!regex.hasMatch(firstChar)) {
+    throw ArgumentError.value(
+      environment,
+      'environment',
+      '$environment must start with a letter (a-zA-Z)',
+    );
+  }
+
+  /// The complete regular expression to validate a event name.
+  ///
+  /// All checks in validateEventName are based on this regular expression but
+  /// are split up for better error messages.
+  final environmentRegExp = RegExp(r'^[A-Za-z][A-Za-z_-]+$');
+  if (!environmentRegExp.hasMatch(environment)) {
+    throw ArgumentError.value(
+      environment,
+      'environment',
+      '$environment does not match $environmentRegExp',
+    );
+  }
 }

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -78,7 +78,7 @@ class Wiredash extends StatefulWidget {
   ///
   /// The environment needs to be
   /// - at least 2 characters long, max 32 characters
-  /// - only use A-Z, a-z, - and _
+  /// - only use lowercase a-z, - and _
   /// - start with a letter (a-zA-Z)
   final String? environment;
 
@@ -248,8 +248,12 @@ class Wiredash extends StatefulWidget {
     String eventName, {
     Map<String, Object?>? data,
     String? projectId,
+    String? environment,
   }) async {
-    final analytics = WiredashAnalytics(projectId: projectId);
+    final analytics = WiredashAnalytics(
+      projectId: projectId,
+      environment: environment,
+    );
     await analytics.trackEvent(eventName, data: data);
   }
 }
@@ -589,12 +593,12 @@ void validateEnvironment(String environment) {
   if (firstChar == '#') {
     firstChar = String.fromCharCode(environment.codeUnitAt(1));
   }
-  final regex = RegExp('^[A-Za-z]');
+  final regex = RegExp('^[a-z]');
   if (!regex.hasMatch(firstChar)) {
     throw ArgumentError.value(
       environment,
       'environment',
-      '$environment must start with a letter (a-zA-Z)',
+      '$environment must start with a letter (a-z)',
     );
   }
 
@@ -602,7 +606,7 @@ void validateEnvironment(String environment) {
   ///
   /// All checks in validateEventName are based on this regular expression but
   /// are split up for better error messages.
-  final environmentRegExp = RegExp(r'^[A-Za-z][A-Za-z_-]+$');
+  final environmentRegExp = RegExp(r'^[a-z][a-z_-]+$');
   if (!environmentRegExp.hasMatch(environment)) {
     throw ArgumentError.value(
       environment,

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -79,7 +79,7 @@ class Wiredash extends StatefulWidget {
   /// The environment needs to be
   /// - at least 2 characters long, max 32 characters
   /// - only use lowercase a-z, - and _
-  /// - start with a letter (a-zA-Z)
+  /// - start with a letter (a-z)
   final String? environment;
 
   /// Customize Wiredash's behaviour and language

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -76,10 +76,7 @@ class Wiredash extends StatefulWidget {
   /// White-label apps can use this to differentiate between different clients,
   /// when they share the same Wiredash project.
   ///
-  /// The environment needs to be
-  /// - at least 2 characters long, max 32 characters
-  /// - only use lowercase a-z, - and _
-  /// - start with a letter (a-z)
+  /// {@macro environmentNameConstraints}
   final String? environment;
 
   /// Customize Wiredash's behaviour and language
@@ -352,7 +349,6 @@ class WiredashState extends State<Wiredash> {
         widget.options?.localizationDelegate) {
       _verifySyncLocalizationsDelegate();
     }
-    _services.updateWidget(widget);
   }
 
   void _onProjectEnvChanged() {
@@ -554,6 +550,14 @@ Locale get _defaultLocale {
   return locale ?? const Locale('en', 'US');
 }
 
+/// Validates [Wiredash.environment]
+///
+/// {@template environmentNameConstraints}
+/// The environment needs to be
+/// - at least 2 characters long, max 32 characters
+/// - only use lowercase a-z, - and _
+/// - start with a letter (a-z)
+/// {@endtemplate}
 void validateEnvironment(String environment) {
   if (environment.isEmpty) {
     throw ArgumentError.value(

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -67,7 +67,8 @@ class Wiredash extends StatefulWidget {
 
   /// The environment of your app, like 'prod', 'dev', 'staging'
   ///
-  /// Defaults to 'dev' for debug builds and 'prod' for release builds.
+  /// When null, defaults to 'prod' for release builds and 'dev' for debug builds and emulators.
+  /// To disable the automatic environment detection, set `environment: 'prod'`.
   ///
   /// Setting an environment is useful to differentiate between different
   /// versions of your app allowing you to filter analytics and feedback by
@@ -550,7 +551,7 @@ Locale get _defaultLocale {
   return locale ?? const Locale('en', 'US');
 }
 
-/// Validates [Wiredash.environment]
+/// Validates the value [Wiredash.environment]
 ///
 /// {@template environmentNameConstraints}
 /// The environment needs to be

--- a/lib/src/feedback/data/direct_feedback_submitter.dart
+++ b/lib/src/feedback/data/direct_feedback_submitter.dart
@@ -3,9 +3,9 @@ import 'package:wiredash/src/_wiredash_internal.dart';
 
 /// Submits feedback immediately to the wiredash backend
 class DirectFeedbackSubmitter implements FeedbackSubmitter {
-  DirectFeedbackSubmitter(WiredashApi api) : _api = api;
+  DirectFeedbackSubmitter(WiredashApi Function() api) : _api = api;
 
-  final WiredashApi _api;
+  final WiredashApi Function() _api;
 
   @override
   Future<SubmissionState> submit(FeedbackItem item) async {
@@ -16,7 +16,7 @@ class DirectFeedbackSubmitter implements FeedbackSubmitter {
       for (final attachment in item.attachments ?? []) {
         if (attachment is Screenshot) {
           // simplification: upload all attachments from memory
-          final id = await _api.uploadScreenshot(attachment.file.data!);
+          final id = await _api().uploadScreenshot(attachment.file.data!);
           final uploaded =
               attachment.copyWith(file: FileDataEventuallyOnDisk.uploaded(id));
           uploadedAttachments.add(uploaded);
@@ -26,7 +26,7 @@ class DirectFeedbackSubmitter implements FeedbackSubmitter {
       }
 
       final updatedItem = item.copyWith(attachments: uploadedAttachments);
-      await _api.sendFeedback(updatedItem);
+      await _api().sendFeedback(updatedItem);
 
       // ignore: avoid_print
       print('Feedback submitted ✌️ ${item.message}');

--- a/lib/src/feedback/data/pending_feedback_item.dart
+++ b/lib/src/feedback/data/pending_feedback_item.dart
@@ -175,6 +175,11 @@ extension on AllMetaData {
       }
     }
 
+    final _environment = environment;
+    if (_environment != null) {
+      values.addAll({'environment': _environment});
+    }
+
     assert(installId.length >= 16);
     values.addAll({'installId': nonNull(installId)});
 

--- a/lib/src/feedback/data/pending_feedback_item_parser_v3.dart
+++ b/lib/src/feedback/data/pending_feedback_item_parser_v3.dart
@@ -55,6 +55,7 @@ class PendingFeedbackItemParserV3 {
           },
         ),
         deviceModel: metadataJson['deviceModel'] as String?,
+        environment: metadataJson['environment'] as String?,
         installId: metadataJson['installId'] as String,
         platformBrightness: () {
           final value = metadataJson['platformBrightness'];

--- a/lib/src/feedback/data/retrying_feedback_submitter.dart
+++ b/lib/src/feedback/data/retrying_feedback_submitter.dart
@@ -19,7 +19,7 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
 
   final FileSystem fs;
   final PendingFeedbackItemStorage _pendingFeedbackItemStorage;
-  final WiredashApi _api;
+  final WiredashApi Function() _api;
 
   // Ensures that we're not starting multiple "submitPendingFeedbackItems()"
   // jobs in parallel.
@@ -155,7 +155,7 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
             assert(screenshot.isOnDisk || screenshot.isInMemory);
             if (screenshot.isInMemory) {
               final AttachmentId attachemntId =
-                  await _api.uploadScreenshot(screenshot.binaryData(fs)!);
+                  await _api().uploadScreenshot(screenshot.binaryData(fs)!);
 
               final uploaded = PersistedAttachment.screenshot(
                 file: FileDataEventuallyOnDisk.uploaded(attachemntId),
@@ -165,7 +165,7 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
               final file = fs.file(screenshot.pathToFile);
               if (file.existsSync()) {
                 final AttachmentId attachemntId =
-                    await _api.uploadScreenshot(screenshot.binaryData(fs)!);
+                    await _api().uploadScreenshot(screenshot.binaryData(fs)!);
 
                 final uploaded = PersistedAttachment.screenshot(
                   file: FileDataEventuallyOnDisk.uploaded(attachemntId),
@@ -185,7 +185,7 @@ class RetryingFeedbackSubmitter implements FeedbackSubmitter {
         );
 
         // actually submit the feedback
-        await _api.sendFeedback(copy.feedbackItem);
+        await _api().sendFeedback(copy.feedbackItem);
 
         // ignore: avoid_print
         print(

--- a/lib/src/feedback/feedback_backdrop.dart
+++ b/lib/src/feedback/feedback_backdrop.dart
@@ -19,7 +19,7 @@ class FeedbackBackdrop extends StatelessWidget {
   Widget build(BuildContext context) {
     return WiredashBackdrop(
       controller: context.wiredashModel.services.backdropController,
-      padding: context.wiredashModel.services.wiredashWidget.padding,
+      padding: context.wiredashModel.services.wiredashWidget?.padding,
       app: ScreenCapture(
         controller: context.wiredashModel.services.screenCaptureController,
         child: child,

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -274,7 +274,7 @@ class FeedbackModel extends ChangeNotifier2 {
 
     final image = _services.screenCaptureController.screenshot;
     if (image != null) {
-      final bg = _services.wiredashWidget.theme?.appBackgroundColor ??
+      final bg = _services.wiredashWidget?.theme?.appBackgroundColor ??
           const Color(0xffcccccc);
       final screenshot =
           await _services.picassoController.paintDrawingOntoImage(image, bg);

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -408,6 +408,7 @@ class FeedbackModel extends ChangeNotifier2 {
     final SessionMetaData? sessionMetadata =
         _services.wiredashModel.sessionMetaData;
     final flutterInfo = _services.metaDataCollector.collectFlutterInfo();
+    final environment = await _services.environmentLoader.getEnvironment();
 
     final email = () {
       if (_services.wiredashModel.feedbackOptions?.email ==
@@ -437,6 +438,7 @@ class FeedbackModel extends ChangeNotifier2 {
         fixedMetadata: fixedMetadata,
         flutterInfo: flutterInfo,
         installId: deviceId,
+        environment: environment,
         email: email,
       ),
     );

--- a/lib/src/feedback/feedback_model.dart
+++ b/lib/src/feedback/feedback_model.dart
@@ -408,7 +408,7 @@ class FeedbackModel extends ChangeNotifier2 {
     final SessionMetaData? sessionMetadata =
         _services.wiredashModel.sessionMetaData;
     final flutterInfo = _services.metaDataCollector.collectFlutterInfo();
-    final environment = await _services.environmentLoader.getEnvironment();
+    final environment = await _services.environmentDetector.getEnvironment();
 
     final email = () {
       if (_services.wiredashModel.feedbackOptions?.email ==

--- a/lib/src/metadata/all_meta_data.dart
+++ b/lib/src/metadata/all_meta_data.dart
@@ -20,6 +20,7 @@ class AllMetaData {
   final CompilationMode compilationMode;
   final Map<String, Object?>? custom;
   final String? deviceModel;
+  final String? environment;
 
   /// Either a 16 char nanoId or a 36 char uuid from SDK 1.7.X and earlier
   final String installId;
@@ -50,6 +51,7 @@ class AllMetaData {
     required this.compilationMode,
     this.custom,
     this.deviceModel,
+    this.environment,
     required this.installId,
     required this.platformBrightness,
     this.platformDartVersion,
@@ -74,6 +76,7 @@ class AllMetaData {
     required FixedMetaData fixedMetadata,
     required FlutterInfo flutterInfo,
     required String installId,
+    required String environment,
     String? email,
   }) get from => _from;
 
@@ -84,6 +87,7 @@ class AllMetaData {
     required FixedMetaData fixedMetadata,
     required FlutterInfo flutterInfo,
     required String installId,
+    required String environment,
     Object? email = defaultArgument,
   }) {
     return AllMetaData(
@@ -97,6 +101,7 @@ class AllMetaData {
       compilationMode: fixedMetadata.buildInfo.compilationMode,
       custom: customizableMetadata.custom,
       deviceModel: fixedMetadata.deviceInfo.deviceModel,
+      environment: environment,
       installId: installId,
       platformBrightness: flutterInfo.platformBrightness,
       platformDartVersion: flutterInfo.platformDartVersion,
@@ -132,6 +137,7 @@ class AllMetaData {
           compilationMode == other.compilationMode &&
           const DeepCollectionEquality().equals(custom, other.custom) &&
           deviceModel == other.deviceModel &&
+          environment == other.environment &&
           installId == other.installId &&
           platformBrightness == other.platformBrightness &&
           platformDartVersion == other.platformDartVersion &&
@@ -163,6 +169,7 @@ class AllMetaData {
       compilationMode.hashCode ^
       const DeepCollectionEquality().hash(custom) ^
       deviceModel.hashCode ^
+      environment.hashCode ^
       installId.hashCode ^
       platformBrightness.hashCode ^
       platformDartVersion.hashCode ^
@@ -192,6 +199,7 @@ class AllMetaData {
         'compilationMode: $compilationMode, '
         'custom: $custom, '
         'deviceModel: $deviceModel, '
+        'environment: $environment, '
         'installId: $installId, '
         'platformBrightness: $platformBrightness, '
         'platformDartVersion: $platformDartVersion, '
@@ -221,6 +229,7 @@ class AllMetaData {
     CompilationMode? compilationMode,
     Map<String, Object?>? custom,
     String? deviceModel,
+    String? environment,
     String? installId,
     Brightness? platformBrightness,
     String? platformDartVersion,
@@ -248,6 +257,7 @@ class AllMetaData {
       compilationMode: compilationMode ?? this.compilationMode,
       custom: custom ?? this.custom,
       deviceModel: deviceModel ?? this.deviceModel,
+      environment: environment ?? this.environment,
       installId: installId ?? this.installId,
       platformBrightness: platformBrightness ?? this.platformBrightness,
       platformDartVersion: platformDartVersion ?? this.platformDartVersion,

--- a/lib/src/metadata/meta_data_collector.dart
+++ b/lib/src/metadata/meta_data_collector.dart
@@ -241,6 +241,7 @@ class DeviceInfo {
   final String? deviceModel;
   final String? osVersion;
 
+  // TODO remove again
   /// Available on android/ios, some basic device categorization if the device
   /// is a physical device or emulated/simulated
   final bool? isPhysicalDevice;

--- a/lib/src/metadata/meta_data_collector.dart
+++ b/lib/src/metadata/meta_data_collector.dart
@@ -128,12 +128,14 @@ class MetaDataCollector {
         return DeviceInfo(
           deviceModel: deviceInfo.model,
           osVersion: deviceInfo.systemVersion,
+          isPhysicalDevice: deviceInfo.isPhysicalDevice,
         );
       }
       if (deviceInfo is AndroidDeviceInfo) {
         return DeviceInfo(
           deviceModel: deviceInfo.model,
           osVersion: deviceInfo.version.release,
+          isPhysicalDevice: deviceInfo.isPhysicalDevice,
         );
       }
       if (deviceInfo is LinuxDeviceInfo) {
@@ -239,9 +241,14 @@ class DeviceInfo {
   final String? deviceModel;
   final String? osVersion;
 
+  /// Available on android/ios, some basic device categorization if the device
+  /// is a physical device or emulated/simulated
+  final bool? isPhysicalDevice;
+
   const DeviceInfo({
     this.deviceModel,
     this.osVersion,
+    this.isPhysicalDevice,
   });
 
   @override
@@ -250,26 +257,31 @@ class DeviceInfo {
       (other is DeviceInfo &&
           runtimeType == other.runtimeType &&
           deviceModel == other.deviceModel &&
-          osVersion == other.osVersion);
+          osVersion == other.osVersion &&
+          isPhysicalDevice == other.isPhysicalDevice);
 
   @override
-  int get hashCode => deviceModel.hashCode ^ osVersion.hashCode;
+  int get hashCode =>
+      deviceModel.hashCode ^ osVersion.hashCode ^ isPhysicalDevice.hashCode;
 
   @override
   String toString() {
     return 'DeviceInfo{ '
         'deviceModel: $deviceModel, '
         'osVersion: $osVersion, '
+        'isPhysicalDevice: $isPhysicalDevice'
         '}';
   }
 
   DeviceInfo copyWith({
     String? deviceModel,
     String? osVersion,
+    bool? isPhysicalDevice,
   }) {
     return DeviceInfo(
       deviceModel: deviceModel ?? this.deviceModel,
       osVersion: osVersion ?? this.osVersion,
+      isPhysicalDevice: isPhysicalDevice ?? this.isPhysicalDevice,
     );
   }
 }

--- a/lib/src/metadata/meta_data_collector.dart
+++ b/lib/src/metadata/meta_data_collector.dart
@@ -241,7 +241,6 @@ class DeviceInfo {
   final String? deviceModel;
   final String? osVersion;
 
-  // TODO remove again
   /// Available on android/ios, some basic device categorization if the device
   /// is a physical device or emulated/simulated
   final bool? isPhysicalDevice;

--- a/lib/src/promoterscore/ps_backdrop.dart
+++ b/lib/src/promoterscore/ps_backdrop.dart
@@ -16,7 +16,7 @@ class PsBackdrop extends StatelessWidget {
   Widget build(BuildContext context) {
     return WiredashBackdrop(
       controller: context.wiredashModel.services.backdropController,
-      padding: context.wiredashModel.services.wiredashWidget.padding,
+      padding: context.wiredashModel.services.wiredashWidget?.padding,
       app: child,
       contentBuilder: (context) {
         return const PromoterScoreFlow();

--- a/lib/src/promoterscore/ps_model.dart
+++ b/lib/src/promoterscore/ps_model.dart
@@ -76,6 +76,7 @@ class PsModel extends ChangeNotifier2 {
         await _services.wiredashModel.collectSessionMetaData(fallbackCollector);
     final sessionMetadata = _services.wiredashModel.sessionMetaData;
     final flutterInfo = _services.metaDataCollector.collectFlutterInfo();
+    final environment = await _services.environmentLoader.getEnvironment();
 
     final body = PromoterScoreRequestBody(
       score: score,
@@ -86,6 +87,7 @@ class PsModel extends ChangeNotifier2 {
         sessionMetadata: sessionMetadata,
         fixedMetadata: fixedMetadata,
         flutterInfo: flutterInfo,
+        environment: environment,
         installId: submitId,
       ),
     );

--- a/lib/src/promoterscore/ps_model.dart
+++ b/lib/src/promoterscore/ps_model.dart
@@ -76,7 +76,7 @@ class PsModel extends ChangeNotifier2 {
         await _services.wiredashModel.collectSessionMetaData(fallbackCollector);
     final sessionMetadata = _services.wiredashModel.sessionMetaData;
     final flutterInfo = _services.metaDataCollector.collectFlutterInfo();
-    final environment = await _services.environmentLoader.getEnvironment();
+    final environment = await _services.environmentDetector.getEnvironment();
 
     final body = PromoterScoreRequestBody(
       score: score,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wiredash
 description: Wiredash is an interactive user feedback tool for Flutter apps including Promoter Score.
-version: 2.2.2
+version: 2.3.0
 homepage: https://wiredash.io
 repository: https://github.com/wiredashio/wiredash-sdk
 issue_tracker: https://github.com/wiredashio/wiredash-sdk/issues

--- a/test/analytics/analytics_test.dart
+++ b/test/analytics/analytics_test.dart
@@ -56,6 +56,7 @@ void main() {
     expect(event.buildVersion, '9.9.9');
     expect(event.bundleId, 'io.wiredash.test');
     expect(event.createdAt, now);
+    expect(event.environment, 'dev');
     expect(event.platformOS, isNotNull);
     if (!Platform.isLinux) {
       expect(event.platformOSVersion, '10.0.1');
@@ -781,6 +782,26 @@ void main() {
       () => analytics.trackEvent('test_event', data: {'param1': 'value1'}),
       returnsNormally,
     );
+  });
+
+  test('serialize event', () {
+    final event = AnalyticsEvent(
+      analyticsId: '01234567890123456',
+      buildCommit: 'abcdef3',
+      buildNumber: '9001',
+      buildVersion: '9.9.9',
+      bundleId: 'io.wiredash.test',
+      createdAt: DateTime(2024, 1, 1),
+      environment: 'custom',
+      eventName: 'test_event',
+      platformLocale: 'en-US',
+      platformOS: 'android',
+      platformOSVersion: '10.0.1',
+      sdkVersion: 250,
+    );
+    final serialized = serializeEventV1(event);
+    final deserialized = deserializeEventV1(serialized);
+    expect(deserialized, event);
   });
 }
 

--- a/test/analytics/analytics_test.dart
+++ b/test/analytics/analytics_test.dart
@@ -122,7 +122,9 @@ void main() {
     expect(event.eventData, {'param1': 'value1'});
   });
 
-  testWidgets('sendEvent (static) to environment from Widget', (tester) async {
+  testWidgets(
+      'Wiredash.trackEvent automatically users the environment from the widget',
+      (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       environment: 'custom',

--- a/test/analytics/analytics_test.dart
+++ b/test/analytics/analytics_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_redundant_argument_values
+
 import 'dart:convert';
 import 'dart:io';
 
@@ -12,7 +14,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/analytics/event_store.dart';
 import 'package:wiredash/src/core/network/send_events_request.dart';
-import 'package:wiredash/src/core/network/wiredash_api.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/version.dart';
 import 'package:wiredash/src/core/wiredash_widget.dart';

--- a/test/analytics/event_submitter_test.dart
+++ b/test/analytics/event_submitter_test.dart
@@ -16,8 +16,8 @@ void main() {
       final store = InMemoryEventStore.withDefaults();
       final api = MockWiredashApi();
       final DebounceEventSubmitter submitter = DebounceEventSubmitter(
-        eventStore: store,
-        api: api,
+        eventStore: () => store,
+        api: () => api,
         projectId: () => 'project-abc',
         initialThrottleDuration: const Duration(days: 1),
       );
@@ -46,8 +46,8 @@ void main() {
       final store = InMemoryEventStore.withDefaults();
       final api = MockWiredashApi();
       final DebounceEventSubmitter submitter = DebounceEventSubmitter(
-        eventStore: store,
-        api: api,
+        eventStore: () => store,
+        api: () => api,
         projectId: () => 'project-abc',
         initialThrottleDuration: const Duration(days: 1),
       );

--- a/test/common/network/wiredash_api_test.dart
+++ b/test/common/network/wiredash_api_test.dart
@@ -313,6 +313,7 @@ void main() {
     test('PingRequestBody.toBody() minimal', () {
       final ps = PingRequestBody(
         analyticsId: '0123456789123456',
+        environment: 'custom',
         sdkVersion: 180,
       );
       final body = ps.toRequestJson();
@@ -321,6 +322,7 @@ void main() {
         body,
         {
           'analyticsId': '0123456789123456',
+          'environment': 'custom',
           'sdkVersion': 180,
         },
       );
@@ -333,6 +335,7 @@ void main() {
         buildNumber: '543',
         buildCommit: 'abcdefg',
         bundleId: 'com.example.app',
+        environment: 'prod',
         platformOS: 'ios',
         platformOSVersion: '17.1',
         platformLocale: 'en_US',
@@ -348,6 +351,7 @@ void main() {
           'buildNumber': '543',
           'buildVersion': '1.2.3',
           'bundleId': 'com.example.app',
+          'environment': 'prod',
           'platformOS': 'ios',
           'platformOSVersion': '17.1',
           'platformLocale': 'en_US',

--- a/test/common/utils/environment_validator_test.dart
+++ b/test/common/utils/environment_validator_test.dart
@@ -45,7 +45,9 @@ void main() {
 
     test('do not allow spaces', () {
       expect(
-          () => validateEnvironment('env name'), argErrorContaining('space'));
+        () => validateEnvironment('env name'),
+        argErrorContaining('space'),
+      );
       expect(() => validateEnvironment('env '), argErrorContaining('space'));
       expect(() => validateEnvironment(' env'), argErrorContaining('space'));
     });

--- a/test/common/utils/environment_validator_test.dart
+++ b/test/common/utils/environment_validator_test.dart
@@ -8,6 +8,7 @@ void main() {
       expect(() => validateEnvironment('prod'), returnsNormally);
       expect(() => validateEnvironment('qa'), returnsNormally);
       expect(() => validateEnvironment('staging'), returnsNormally);
+      expect(() => validateEnvironment('whitelabel-dev'), returnsNormally);
     });
 
     test('minimum 2 characters', () {
@@ -16,24 +17,21 @@ void main() {
         argErrorContaining('between 2 and 32'),
       );
       expect(() => validateEnvironment('aa'), returnsNormally);
-      expect(
-        () => validateEnvironment('A'),
-        argErrorContaining('between 2 and 32'),
-      );
-      expect(() => validateEnvironment('AA'), returnsNormally);
+      expect(() => validateEnvironment('a_'), returnsNormally);
+      expect(() => validateEnvironment('a-'), returnsNormally);
     });
 
-    test('must start with a-zA-Z', () {
+    test('must start with a-z', () {
       expect(() => validateEnvironment('a__'), returnsNormally);
       expect(() => validateEnvironment('z__'), returnsNormally);
-      expect(() => validateEnvironment('A__'), returnsNormally);
-      expect(() => validateEnvironment('Z__'), returnsNormally);
+      expect(() => validateEnvironment('A__'), argErrorContaining('(a-z)'));
+      expect(() => validateEnvironment('Z__'), argErrorContaining('(a-z)'));
 
-      expect(() => validateEnvironment('1__'), argErrorContaining('(a-zA-Z)'));
-      expect(() => validateEnvironment('___'), argErrorContaining('(a-zA-Z)'));
-      expect(() => validateEnvironment('-__'), argErrorContaining('(a-zA-Z)'));
-      expect(() => validateEnvironment('\$__'), argErrorContaining('(a-zA-Z)'));
-      expect(() => validateEnvironment('?__'), argErrorContaining('(a-zA-Z)'));
+      expect(() => validateEnvironment('1__'), argErrorContaining('(a-z)'));
+      expect(() => validateEnvironment('___'), argErrorContaining('(a-z)'));
+      expect(() => validateEnvironment('-__'), argErrorContaining('(a-z)'));
+      expect(() => validateEnvironment('\$__'), argErrorContaining('(a-z)'));
+      expect(() => validateEnvironment('?__'), argErrorContaining('(a-z)'));
       expect(() => validateEnvironment('ä__'), argErrorContaining('umlaut'));
     });
 

--- a/test/common/utils/environment_validator_test.dart
+++ b/test/common/utils/environment_validator_test.dart
@@ -1,0 +1,63 @@
+import 'package:test/test.dart';
+import 'package:wiredash/src/core/wiredash_widget.dart';
+
+void main() {
+  group('env name', () {
+    test('common cases', () {
+      expect(() => validateEnvironment('dev'), returnsNormally);
+      expect(() => validateEnvironment('prod'), returnsNormally);
+      expect(() => validateEnvironment('qa'), returnsNormally);
+      expect(() => validateEnvironment('staging'), returnsNormally);
+    });
+
+    test('minimum 2 characters', () {
+      expect(
+        () => validateEnvironment('a'),
+        argErrorContaining('between 2 and 32'),
+      );
+      expect(() => validateEnvironment('aa'), returnsNormally);
+      expect(
+        () => validateEnvironment('A'),
+        argErrorContaining('between 2 and 32'),
+      );
+      expect(() => validateEnvironment('AA'), returnsNormally);
+    });
+
+    test('must start with a-zA-Z', () {
+      expect(() => validateEnvironment('a__'), returnsNormally);
+      expect(() => validateEnvironment('z__'), returnsNormally);
+      expect(() => validateEnvironment('A__'), returnsNormally);
+      expect(() => validateEnvironment('Z__'), returnsNormally);
+
+      expect(() => validateEnvironment('1__'), argErrorContaining('(a-zA-Z)'));
+      expect(() => validateEnvironment('___'), argErrorContaining('(a-zA-Z)'));
+      expect(() => validateEnvironment('-__'), argErrorContaining('(a-zA-Z)'));
+      expect(() => validateEnvironment('\$__'), argErrorContaining('(a-zA-Z)'));
+      expect(() => validateEnvironment('?__'), argErrorContaining('(a-zA-Z)'));
+      expect(() => validateEnvironment('ä__'), argErrorContaining('umlaut'));
+    });
+
+    test('may not contain umlauts', () {
+      expect(() => validateEnvironment('env_ä'), argErrorContaining('umlaut'));
+      expect(() => validateEnvironment('env_ö'), argErrorContaining('umlaut'));
+      expect(() => validateEnvironment('env_ü'), argErrorContaining('umlaut'));
+    });
+
+    test('do not allow spaces', () {
+      expect(
+          () => validateEnvironment('env name'), argErrorContaining('space'));
+      expect(() => validateEnvironment('env '), argErrorContaining('space'));
+      expect(() => validateEnvironment(' env'), argErrorContaining('space'));
+    });
+  });
+}
+
+Matcher argErrorContaining(String containing) {
+  return throwsA(
+    isA<ArgumentError>().having(
+      (e) => e.message,
+      'message',
+      contains(containing),
+    ),
+  );
+}

--- a/test/feedback/data/pending_feedback_item_test.dart
+++ b/test/feedback/data/pending_feedback_item_test.dart
@@ -219,6 +219,7 @@ void main() {
           'nestedObject': {'frodo': 'ring', 'sam': 'lembas'},
         },
         deviceModel: 'Google Pixel 8',
+        environment: 'staging',
         platformOS: 'android',
         platformOSVersion: 'RSR1.201013.001',
         platformDartVersion:
@@ -252,6 +253,7 @@ void main() {
           "nestedObject": {"frodo": "ring", "sam": "lembas"},
         },
         "deviceModel": "Google Pixel 8",
+        "environment": "staging",
         "installId": "8F821AB6-B3A7-41BA-882E-32D8367243C1",
         "physicalGeometry": [0.0, 0.0, 0.0, 0.0],
         "platformBrightness": "dark",

--- a/test/feedback/data/retrying_feedback_submitter_test.dart
+++ b/test/feedback/data/retrying_feedback_submitter_test.dart
@@ -41,7 +41,7 @@ void main() {
       retryingFeedbackSubmitter = RetryingFeedbackSubmitter(
         fileSystem,
         storage,
-        mockApi,
+        () => mockApi,
       );
     });
 

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -644,6 +644,17 @@ void main() {
 
       await gesture.up(); // let go of the app
     });
+
+    testWidgets('Send environment', (tester) async {
+      final robot = await WiredashTestRobot(tester).launchApp(
+        environment: 'staging',
+      );
+      await robot.submitMinimalFeedback();
+      final latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final submittedFeedback = latestCall[0] as FeedbackItem?;
+      expect(submittedFeedback!.metadata.environment, 'staging');
+    });
   });
 }
 

--- a/test/offline_feedback_test.dart
+++ b/test/offline_feedback_test.dart
@@ -207,6 +207,7 @@ Map get fullJsonV3 => {
         "labels": ["bug", "lbl-1234"],
         "message": "Pending Feedback Item v3",
         "metadata": {
+          "appBrightness": "dark",
           "appLocale": "en_US",
           "appName": "MyApp",
           "buildCommit": "abcdef12",
@@ -219,6 +220,7 @@ Map get fullJsonV3 => {
             "nestedObject": {"frodo": "ring", "sam": "lembas"},
           },
           "deviceModel": "Google Pixel 8",
+          "environment": "beta",
           "installId": "8F821AB6-B3A7-41BA-882E-32D8367243C1",
           "physicalGeometry": [0.0, 0.0, 0.0, 0.0],
           "platformBrightness": "dark",

--- a/test/promoterscore_flow_test.dart
+++ b/test/promoterscore_flow_test.dart
@@ -200,5 +200,15 @@ void main() {
 
       await gesture.up(); // let go of the app
     });
+
+    testWidgets('PS - sends environment', (tester) async {
+      final robot = await WiredashTestRobot(tester).launchApp(
+        environment: 'alpha',
+      );
+      await robot.openPromoterScore();
+      final psCalls = robot.mockServices.mockApi.sendPsInvocations.invocations;
+      final call = psCalls[0][0] as PromoterScoreRequestBody?;
+      expect(call!.metadata.environment, 'alpha');
+    });
   });
 }

--- a/test/sync/ping_job_test.dart
+++ b/test/sync/ping_job_test.dart
@@ -11,7 +11,6 @@ import 'package:wiredash/src/core/options/environment_loader.dart';
 import 'package:wiredash/src/core/sync/ping_job.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/version.dart';
-import 'package:wiredash/src/core/wiredash_widget.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
 
 import '../feedback/data/pending_feedback_item_storage_test.dart';

--- a/test/sync/ping_job_test.dart
+++ b/test/sync/ping_job_test.dart
@@ -7,9 +7,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
+import 'package:wiredash/src/core/options/environment_loader.dart';
 import 'package:wiredash/src/core/sync/ping_job.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/version.dart';
+import 'package:wiredash/src/core/wiredash_widget.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
 
 import '../feedback/data/pending_feedback_item_storage_test.dart';
@@ -36,6 +38,7 @@ void main() {
         wuidGenerator: () {
           return incrementalIdGenerator;
         },
+        environmentLoader: () => MockEnvironmentLoader('prod'),
       );
     }
 
@@ -150,6 +153,7 @@ void main() {
           sharedPreferencesProvider: prefsProvider,
           metaDataCollector: () => FakeMetaDataCollector(),
           wuidGenerator: () => IncrementalIdGenerator(),
+          environmentLoader: () => MockEnvironmentLoader('prod'),
         );
         pingJob.execute(SdkEvent.appStartDelayed);
         async.flushTimers();
@@ -172,6 +176,7 @@ void main() {
           sharedPreferencesProvider: prefsProvider,
           metaDataCollector: () => FakeMetaDataCollector(),
           wuidGenerator: () => IncrementalIdGenerator(),
+          environmentLoader: () => MockEnvironmentLoader('prod'),
         );
         pingJob.execute(SdkEvent.appStartDelayed);
         async.flushTimers();
@@ -222,5 +227,22 @@ class FakeMetaDataCollector with Fake implements MetaDataCollector {
       viewInsets: WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 685),
       physicalSize: Size(1280, 720),
     );
+  }
+}
+
+class MockEnvironmentLoader implements EnvironmentLoader {
+  final String environment;
+
+  MockEnvironmentLoader(this.environment);
+
+  @override
+  Future<String> getEnvironment() async {
+    return environment;
+  }
+
+  @override
+  Future<bool> isDevEnvironment() {
+    // TODO: implement isDevEnvironment
+    throw UnimplementedError();
   }
 }

--- a/test/sync/ping_job_test.dart
+++ b/test/sync/ping_job_test.dart
@@ -238,10 +238,4 @@ class MockEnvironmentLoader implements EnvironmentLoader {
   Future<String> getEnvironment() async {
     return environment;
   }
-
-  @override
-  Future<bool> isDevEnvironment() {
-    // TODO: implement isDevEnvironment
-    throw UnimplementedError();
-  }
 }

--- a/test/sync/ping_job_test.dart
+++ b/test/sync/ping_job_test.dart
@@ -7,7 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
-import 'package:wiredash/src/core/options/environment_loader.dart';
+import 'package:wiredash/src/core/options/environment_detector.dart';
 import 'package:wiredash/src/core/sync/ping_job.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/version.dart';
@@ -37,7 +37,7 @@ void main() {
         wuidGenerator: () {
           return incrementalIdGenerator;
         },
-        environmentLoader: () => MockEnvironmentLoader('prod'),
+        environmentDetector: () => FixedEnvironmentDetector('prod'),
       );
     }
 
@@ -152,7 +152,7 @@ void main() {
           sharedPreferencesProvider: prefsProvider,
           metaDataCollector: () => FakeMetaDataCollector(),
           wuidGenerator: () => IncrementalIdGenerator(),
-          environmentLoader: () => MockEnvironmentLoader('prod'),
+          environmentDetector: () => FixedEnvironmentDetector('prod'),
         );
         pingJob.execute(SdkEvent.appStartDelayed);
         async.flushTimers();
@@ -175,7 +175,7 @@ void main() {
           sharedPreferencesProvider: prefsProvider,
           metaDataCollector: () => FakeMetaDataCollector(),
           wuidGenerator: () => IncrementalIdGenerator(),
-          environmentLoader: () => MockEnvironmentLoader('prod'),
+          environmentDetector: () => FixedEnvironmentDetector('prod'),
         );
         pingJob.execute(SdkEvent.appStartDelayed);
         async.flushTimers();
@@ -229,10 +229,10 @@ class FakeMetaDataCollector with Fake implements MetaDataCollector {
   }
 }
 
-class MockEnvironmentLoader implements EnvironmentLoader {
+class FixedEnvironmentDetector implements EnvironmentDetector {
   final String environment;
 
-  MockEnvironmentLoader(this.environment);
+  FixedEnvironmentDetector(this.environment);
 
   @override
   Future<String> getEnvironment() async {

--- a/test/util/mock_api.dart
+++ b/test/util/mock_api.dart
@@ -9,8 +9,12 @@ import 'package:wiredash/src/core/network/wiredash_api.dart';
 
 import 'invocation_catcher.dart';
 
+int _mockApiIndex = 0;
+
 class MockWiredashApi implements WiredashApi {
   MockWiredashApi();
+
+  final index = _mockApiIndex++;
 
   /// Returns "success" responses
   factory MockWiredashApi.fake() {

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -141,6 +141,7 @@ class WiredashTestRobot {
   Future<WiredashTestRobot> launchApp({
     WiredashFeedbackOptions? feedbackOptions,
     PsOptions? psOptions,
+    String? environment,
     FutureOr<CustomizableWiredashMetaData> Function(
       CustomizableWiredashMetaData metaData,
     )? collectMetaData,
@@ -209,6 +210,7 @@ class WiredashTestRobot {
       child = Wiredash(
         projectId: projectId ?? 'test',
         secret: 'test',
+        environment: environment,
         feedbackOptions: feedbackOptions,
         psOptions: psOptions,
         collectMetaData: collectMetaData,
@@ -714,7 +716,7 @@ WiredashServices createMockServices({
     if (useDirectFeedbackSubmitter) {
       // replace submitter, because for testing we always want to submit directly
       services.inject<FeedbackSubmitter>(
-        (_) => DirectFeedbackSubmitter(services.api),
+        (_) => DirectFeedbackSubmitter(() => services.api),
       );
     } else {
       assert(
@@ -727,9 +729,9 @@ WiredashServices createMockServices({
         (_) {
           print('create direct submitter');
           return DirectEventSubmitter(
-            projectId: () => services.wiredashWidget.projectId,
-            eventStore: services.eventStore,
-            api: services.api,
+            projectId: () => services.wiredashWidget!.projectId,
+            eventStore: () => services.eventStore,
+            api: () => services.api,
           );
         },
       );

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -249,12 +249,14 @@ class WiredashTestRobot {
     return (element.state as WiredashState).debugServices;
   }
 
-  WiredashServices servicesForProject(String projectId) {
+  WiredashServices servicesWith({String? projectId, String? environment}) {
     final elements =
         find.byType(Wiredash).evaluate().map((e) => e as StatefulElement);
-    final element = elements.firstWhere(
-      (e) => (e.state as WiredashState).widget.projectId == projectId,
-    );
+    final element = elements.firstWhere((e) {
+      final widget = (e.state as WiredashState).widget;
+      return (projectId == null || widget.projectId == projectId) &&
+          (environment == null || widget.environment == environment);
+    });
     return (element.state as WiredashState).debugServices;
   }
 


### PR DESCRIPTION
Environments make it easier to separate your production data from other environments, without the need for two separate wiredash projects.


```dart
Wiredash(
  environment: 'staging',
)
```

Breaking, removes `projectId` from the `WiredashAnalytics` interface. While breaking, it should only affect test code, therefore a minor release.