### PR TITLE
[CHANGE] Make it possible to give Wiredash a custom implementation of local storage

### DIFF
--- a/lib/src/analytics/event_store.dart
+++ b/lib/src/analytics/event_store.dart
@@ -4,8 +4,8 @@ import 'dart:convert';
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:nanoid2/nanoid2.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/core/services/error_report.dart';
+import 'package:wiredash/src/core/services/local_storage.dart';
 
 /// Saves [AnalyticsEvent] when recorded until they are submitted to the backend
 abstract class AnalyticsEventStore {
@@ -118,22 +118,21 @@ class AnalyticsEvent {
 /// Saves [AnalyticsEvent] on disk
 class PersistentAnalyticsEventStore implements AnalyticsEventStore {
   PersistentAnalyticsEventStore({
-    required this.sharedPreferences,
+    required this.localStorageProvider,
   });
 
   static const Duration outdatedAfter = Duration(days: 3);
   static const String defaultProjectId = 'default';
 
   static const maximumDiskSizeInBytes = 1024 * 1024; // 1MB
-  static final eventKeyRegex =
-      RegExp(r'^io\.wiredash\.events\.([\w-]+)\|(\d+)\|([\w-]+)$');
+  static final eventKeyRegex = RegExp(r'^io\.wiredash\.events\.([\w-]+)\|(\d+)\|([\w-]+)$');
 
-  final Future<SharedPreferences> Function() sharedPreferences;
+  final Future<LocalStorage> Function() localStorageProvider;
 
   @override
   Future<void> saveEvent(AnalyticsEvent event, String? projectId) async {
-    final prefs = await sharedPreferences();
-    await prefs.reload();
+    final localStorage = await localStorageProvider();
+    await localStorage.reload();
 
     final project = projectId ?? defaultProjectId;
     final millis = event.createdAt!.millisecondsSinceEpoch;
@@ -144,14 +143,14 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
       'Invalid event key: $key',
     );
 
-    await prefs.setString(key, jsonEncode(serializeEventV1(event)));
+    await localStorage.setString(key, jsonEncode(serializeEventV1(event)));
   }
 
   @override
   Future<Map<String, AnalyticsEvent>> getEvents(String? projectId) async {
-    final prefs = await sharedPreferences();
-    await prefs.reload();
-    final keys = prefs.getKeys();
+    final localStorage = await localStorageProvider();
+    await localStorage.reload();
+    final keys = localStorage.getKeys();
 
     final Map<String, AnalyticsEvent> result = {};
     for (final key in keys) {
@@ -159,11 +158,10 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
       if (match == null) continue;
       final eventProjectId = match.group(1);
       if (eventProjectId == defaultProjectId || eventProjectId == projectId) {
-        final eventJson = prefs.getString(key);
+        final eventJson = localStorage.getString(key);
         if (eventJson == null) continue;
         try {
-          final AnalyticsEvent event =
-              deserializeEventV1(jsonDecode(eventJson) as Map<String, Object?>);
+          final AnalyticsEvent event = deserializeEventV1(jsonDecode(eventJson) as Map<String, Object?>);
           result[key] = event;
         } catch (e, stack) {
           reportWiredashInfo(
@@ -171,7 +169,7 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
             stack,
             'Error when parsing event $key. Removing.',
           );
-          await prefs.remove(key);
+          await localStorage.remove(key);
         }
       }
     }
@@ -180,15 +178,15 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
 
   @override
   Future<void> removeEvent(String key) async {
-    final prefs = await sharedPreferences();
-    await prefs.remove(key);
+    final localStorage = await localStorageProvider();
+    await localStorage.remove(key);
   }
 
   @override
   Future<void> deleteOutdatedEvents() async {
-    final prefs = await sharedPreferences();
-    await prefs.reload();
-    final keys = prefs.getKeys();
+    final localStorage = await localStorageProvider();
+    await localStorage.reload();
+    final keys = localStorage.getKeys();
 
     final now = clock.now();
     final threeDaysAgo = now.subtract(outdatedAfter);
@@ -198,16 +196,15 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
       if (match == null) continue;
       final millis = int.parse(match.group(2)!);
       if (millis < unixThreeDaysAgo) {
-        await prefs.remove(key);
+        await localStorage.remove(key);
       }
     }
   }
 
   @override
   Future<void> trimToDiskLimit() async {
-    final prefs = await sharedPreferences();
-    final eventKeys =
-        prefs.getKeys().where((key) => eventKeyRegex.hasMatch(key)).toList();
+    final localStorage = await localStorageProvider();
+    final eventKeys = localStorage.getKeys().where((key) => eventKeyRegex.hasMatch(key)).toList();
 
     final oldestLast = eventKeys
         .sortedBy<num>((key) {
@@ -220,7 +217,7 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
 
     int limit = maximumDiskSizeInBytes;
     for (final event in oldestLast.toList()) {
-      final String? data = prefs.getString(event);
+      final String? data = localStorage.getString(event);
       if (data == null) {
         continue;
       }
@@ -234,17 +231,16 @@ class PersistentAnalyticsEventStore implements AnalyticsEventStore {
 
     // remove remaining events that exceed the maximum size
     for (final event in oldestLast) {
-      await prefs.remove(event);
+      await localStorage.remove(event);
     }
   }
 
   @override
   Future<void> wipe() async {
-    final prefs = await sharedPreferences();
-    final eventKeys =
-        prefs.getKeys().where((key) => eventKeyRegex.hasMatch(key)).toList();
+    final localStorage = await localStorageProvider();
+    final eventKeys = localStorage.getKeys().where((key) => eventKeyRegex.hasMatch(key)).toList();
     for (final key in eventKeys) {
-      await prefs.remove(key);
+      await localStorage.remove(key);
     }
   }
 }
@@ -256,13 +252,11 @@ Map<String, Object?> serializeEventV1(AnalyticsEvent event) {
     if (event.buildNumber != null) "buildNumber": event.buildNumber,
     if (event.buildVersion != null) "buildVersion": event.buildVersion,
     if (event.bundleId != null) "bundleId": event.bundleId,
-    if (event.createdAt != null)
-      "createdAt": event.createdAt!.toIso8601String(),
+    if (event.createdAt != null) "createdAt": event.createdAt!.toIso8601String(),
     if (event.environment != null) "environment": event.environment,
     "eventName": event.eventName,
     if (event.platformOS != null) "platformOS": event.platformOS,
-    if (event.platformOSVersion != null)
-      "platformOSVersion": event.platformOSVersion,
+    if (event.platformOSVersion != null) "platformOSVersion": event.platformOSVersion,
     if (event.platformLocale != null) "platformLocale": event.platformLocale,
     "sdkVersion": event.sdkVersion,
     "version": 1,

--- a/lib/src/analytics/event_submitter.dart
+++ b/lib/src/analytics/event_submitter.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:clock/clock.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/analytics/event_store.dart';
 import 'package:wiredash/src/core/network/send_events_request.dart';
+import 'package:wiredash/src/core/services/local_storage.dart';
 import 'package:wiredash/src/utils/delay.dart';
 
 /// Abstract interface for submitting events to the backend
@@ -13,7 +13,7 @@ import 'package:wiredash/src/utils/delay.dart';
 /// - [DirectEventSubmitter] for immediate submission of events (usually web)
 /// - [DebounceEventSubmitter] for batching events within a certain time frame (usually mobile)
 abstract class EventSubmitter {
-  /// Submits all pending events in [AnalyticsEventStore] ([SharedPreferences]) to the backend
+  /// Submits all pending events in [AnalyticsEventStore] ([LocalStorage]) to the backend
   ///
   /// If [force] is `true`, the events are submitted immediately, regardless of the throttle duration.
   Future<void> submitEvents({bool? force});
@@ -91,8 +91,7 @@ class DebounceEventSubmitter implements EventSubmitter {
       return;
     }
 
-    final minInterval =
-        _initialSubmitted ? throttleDuration : initialThrottleDuration;
+    final minInterval = _initialSubmitted ? throttleDuration : initialThrottleDuration;
     assert(_delay == null);
     if (_lastSubmit == null) {
       _delay = Delay(minInterval);

--- a/lib/src/core/services/local_storage.dart
+++ b/lib/src/core/services/local_storage.dart
@@ -1,0 +1,56 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+abstract class LocalStorage {
+  bool containsKey(String key);
+  Set<String> getKeys();
+  String? getString(String key);
+  int? getInt(String key);
+  Future<void> setString(String key, String value);
+  Future<void> setInt(String key, int value);
+  List<String>? getStringList(String key);
+  Future<bool> setStringList(String key, List<String> value);
+  Future<void> remove(String key);
+  Future<void> clear();
+  Future<void> reload();
+}
+
+class SharedPreferencesStorage implements LocalStorage {
+  SharedPreferencesStorage(this._storage);
+
+  final SharedPreferences _storage;
+
+  SharedPreferences get sharedPreferences => _storage;
+
+  @override
+  bool containsKey(String key) => _storage.containsKey(key);
+
+  @override
+  Set<String> getKeys() => _storage.getKeys();
+
+  @override
+  String? getString(String key) => _storage.getString(key);
+
+  @override
+  int? getInt(String key) => _storage.getInt(key);
+
+  @override
+  Future<void> setString(String key, String value) => _storage.setString(key, value);
+
+  @override
+  Future<void> setInt(String key, int value) => _storage.setInt(key, value);
+
+  @override
+  List<String>? getStringList(String key) => _storage.getStringList(key);
+
+  @override
+  Future<bool> setStringList(String key, List<String> value) => _storage.setStringList(key, value);
+
+  @override
+  Future<void> remove(String key) => _storage.remove(key);
+
+  @override
+  Future<void> clear() => _storage.clear();
+
+  @override
+  Future<void> reload() => _storage.reload();
+}

--- a/lib/src/core/sync/event_upload_job.dart
+++ b/lib/src/core/sync/event_upload_job.dart
@@ -1,16 +1,11 @@
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/analytics/event_submitter.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 
 class EventUploadJob extends Job {
-  final Future<SharedPreferences> Function() sharedPreferencesProvider;
   final EventSubmitter Function() eventSubmitter;
 
-  EventUploadJob({
-    required this.sharedPreferencesProvider,
-    required this.eventSubmitter,
-  });
+  EventUploadJob({required this.eventSubmitter});
 
   @override
   bool shouldExecute(SdkEvent event) {

--- a/lib/src/core/sync/ping_job.dart
+++ b/lib/src/core/sync/ping_job.dart
@@ -1,21 +1,21 @@
 import 'package:clock/clock.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
 import 'package:wiredash/src/core/options/environment_detector.dart';
+import 'package:wiredash/src/core/services/local_storage.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
 import 'package:wiredash/src/core/version.dart';
 import 'package:wiredash/src/metadata/meta_data_collector.dart';
 
 class PingJob extends Job {
   final WiredashApi Function() apiProvider;
-  final Future<SharedPreferences> Function() sharedPreferencesProvider;
+  final Future<LocalStorage> Function() localStorageProvider;
   final WuidGenerator Function() wuidGenerator;
   final MetaDataCollector Function() metaDataCollector;
   final EnvironmentDetector Function() environmentDetector;
 
   PingJob({
     required this.apiProvider,
-    required this.sharedPreferencesProvider,
+    required this.localStorageProvider,
     required this.wuidGenerator,
     required this.metaDataCollector,
     required this.environmentDetector,
@@ -89,16 +89,16 @@ class PingJob extends Job {
 
   /// Silences the sdk, prevents automatic pings on app startup until the time is over
   Future<void> _silenceUntil(DateTime dateTime) async {
-    final preferences = await sharedPreferencesProvider();
+    final preferences = await localStorageProvider();
     preferences.setInt(silenceUntilKey, dateTime.millisecondsSinceEpoch);
     syncDebugPrint('Silenced Wiredash until $dateTime');
   }
 
   /// `true` when automatic pings should be prevented
   Future<bool> _isSilenced(DateTime now) async {
-    final preferences = await sharedPreferencesProvider();
+    final localStorage = await localStorageProvider();
 
-    final int? millis = preferences.getInt(silenceUntilKey);
+    final int? millis = localStorage.getInt(silenceUntilKey);
     if (millis == null) {
       return false;
     }
@@ -111,8 +111,8 @@ class PingJob extends Job {
   }
 
   Future<DateTime?> _getLastSuccessfulPing() async {
-    final preferences = await sharedPreferencesProvider();
-    final lastPingInt = preferences.getInt(lastSuccessfulPingKey);
+    final localStorage = await localStorageProvider();
+    final lastPingInt = localStorage.getInt(lastSuccessfulPingKey);
     if (lastPingInt == null) {
       return null;
     }
@@ -120,7 +120,7 @@ class PingJob extends Job {
   }
 
   Future<void> _saveLastSuccessfulPing(DateTime now) async {
-    final preferences = await sharedPreferencesProvider();
-    await preferences.setInt(lastSuccessfulPingKey, now.millisecondsSinceEpoch);
+    final localStorage = await localStorageProvider();
+    await localStorage.setInt(lastSuccessfulPingKey, now.millisecondsSinceEpoch);
   }
 }

--- a/lib/src/core/telemetry/app_telemetry.dart
+++ b/lib/src/core/telemetry/app_telemetry.dart
@@ -1,5 +1,5 @@
 import 'package:clock/clock.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/core/services/local_storage.dart';
 
 /// Telemetry data from the app that ships with Wiredash
 abstract class AppTelemetry {
@@ -20,13 +20,12 @@ abstract class AppTelemetry {
 
 /// A persistent storage for the app telemetry data
 class PersistentAppTelemetry extends AppTelemetry {
-  PersistentAppTelemetry(this.sharedPreferencesProvider);
+  PersistentAppTelemetry(this.localStorageProvider);
 
-  static const _deviceRegistrationDateKey =
-      'io.wiredash.device_registered_date';
+  static const _deviceRegistrationDateKey = 'io.wiredash.device_registered_date';
   static const _appStartsKey = 'io.wiredash.app_starts';
 
-  final Future<SharedPreferences> Function() sharedPreferencesProvider;
+  final Future<LocalStorage> Function() localStorageProvider;
 
   @override
   Future<void> onAppStart() async {
@@ -36,9 +35,9 @@ class PersistentAppTelemetry extends AppTelemetry {
 
   @override
   Future<DateTime?> firstAppStart() async {
-    final prefs = await sharedPreferencesProvider();
-    if (prefs.containsKey(_deviceRegistrationDateKey)) {
-      final recovered = prefs.getString(_deviceRegistrationDateKey);
+    final localStorage = await localStorageProvider();
+    if (localStorage.containsKey(_deviceRegistrationDateKey)) {
+      final recovered = localStorage.getString(_deviceRegistrationDateKey);
       if (recovered != null) {
         return DateTime.parse(recovered);
       }
@@ -47,25 +46,24 @@ class PersistentAppTelemetry extends AppTelemetry {
   }
 
   Future<void> _saveFirstAppStart() async {
-    final prefs = await sharedPreferencesProvider();
-    if (prefs.containsKey(_deviceRegistrationDateKey)) {
+    final localStorage = await localStorageProvider();
+    if (localStorage.containsKey(_deviceRegistrationDateKey)) {
       return;
     }
-    // not yet started
     final now = clock.now().toUtc();
-    await prefs.setString(_deviceRegistrationDateKey, now.toIso8601String());
+    await localStorage.setString(_deviceRegistrationDateKey, now.toIso8601String());
   }
 
   @override
   Future<int> appStartCount() async {
-    final prefs = await sharedPreferencesProvider();
-    final appStarts = prefs.getInt(_appStartsKey) ?? 0;
+    final localStorage = await localStorageProvider();
+    final appStarts = localStorage.getInt(_appStartsKey) ?? 0;
     return appStarts;
   }
 
   Future<void> _saveAppStartCount() async {
     final appStarts = await appStartCount();
-    final prefs = await sharedPreferencesProvider();
-    await prefs.setInt(_appStartsKey, appStarts + 1);
+    final localStorage = await localStorageProvider();
+    await localStorage.setInt(_appStartsKey, appStarts + 1);
   }
 }

--- a/lib/src/core/telemetry/wiredash_telemetry.dart
+++ b/lib/src/core/telemetry/wiredash_telemetry.dart
@@ -1,5 +1,5 @@
 import 'package:clock/clock.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/core/services/local_storage.dart';
 
 abstract class WiredashTelemetry {
   /// Event when promoter score survey was shown to the user
@@ -11,24 +11,24 @@ abstract class WiredashTelemetry {
 
 /// A persistent storage for the telemetry data from Wiredash
 class PersistentWiredashTelemetry extends WiredashTelemetry {
-  PersistentWiredashTelemetry(this.sharedPreferencesProvider);
+  PersistentWiredashTelemetry(this.localStorageProvider);
 
   static const _lastPromoterScoreSurveyKey = 'io.wiredash.last_ps_survey';
 
-  final Future<SharedPreferences> Function() sharedPreferencesProvider;
+  final Future<LocalStorage> Function() localStorageProvider;
 
   @override
   Future<void> onOpenedPromoterScoreSurvey() async {
-    final prefs = await sharedPreferencesProvider();
+    final localStorage = await localStorageProvider();
     final now = clock.now().toUtc();
-    await prefs.setString(_lastPromoterScoreSurveyKey, now.toIso8601String());
+    await localStorage.setString(_lastPromoterScoreSurveyKey, now.toIso8601String());
   }
 
   @override
   Future<DateTime?> lastPromoterScoreSurvey() async {
-    final prefs = await sharedPreferencesProvider();
-    if (prefs.containsKey(_lastPromoterScoreSurveyKey)) {
-      final recovered = prefs.getString(_lastPromoterScoreSurveyKey);
+    final localStorage = await localStorageProvider();
+    if (localStorage.containsKey(_lastPromoterScoreSurveyKey)) {
+      final recovered = localStorage.getString(_lastPromoterScoreSurveyKey);
       if (recovered != null) {
         return DateTime.parse(recovered);
       }

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -11,6 +11,7 @@ import 'package:wiredash/src/_wiredash_ui.dart';
 import 'package:wiredash/src/analytics/event_submitter.dart';
 import 'package:wiredash/src/core/context_cache.dart';
 import 'package:wiredash/src/core/lifecycle/lifecycle_notifier.dart';
+import 'package:wiredash/src/core/services/local_storage.dart';
 import 'package:wiredash/src/core/support/back_button_interceptor.dart';
 import 'package:wiredash/src/core/support/not_a_widgets_app.dart';
 import 'package:wiredash/src/feedback/feedback_backdrop.dart';
@@ -54,6 +55,7 @@ class Wiredash extends StatefulWidget {
     this.theme,
     this.feedbackOptions,
     this.psOptions,
+    this.customLocalStorage,
     this.padding,
     this.collectMetaData,
     required this.child,
@@ -112,6 +114,11 @@ class Wiredash extends StatefulWidget {
 
   /// Customize when to show the promoter score flow
   final PsOptions? psOptions;
+
+  /// Customize the way Wiredash stores its local data by providing a class that
+  /// implements [LocalStorage]
+  ///
+  final LocalStorage? customLocalStorage;
 
   /// Default visual properties, like colors and fonts for the Wiredash bottom
   /// sheet and the screenshot capture UI.
@@ -259,7 +266,7 @@ class Wiredash extends StatefulWidget {
 class WiredashState extends State<Wiredash> {
   final GlobalKey _appKey = GlobalKey(debugLabel: 'app');
 
-  final WiredashServices _services = WiredashServices();
+  late final WiredashServices _services;
 
   late final WiredashBackButtonDispatcher _backButtonDispatcher;
 
@@ -279,6 +286,8 @@ class WiredashState extends State<Wiredash> {
   @override
   void initState() {
     super.initState();
+    _services = WiredashServices(customLocalStorage: widget.customLocalStorage);
+
     _services.projectCredentialValidator.validate(
       projectId: widget.projectId,
       secret: widget.secret,
@@ -346,8 +355,7 @@ class WiredashState extends State<Wiredash> {
       _onProjectEnvChanged();
     }
 
-    if (oldWidget.options?.localizationDelegate !=
-        widget.options?.localizationDelegate) {
+    if (oldWidget.options?.localizationDelegate != widget.options?.localizationDelegate) {
       _verifySyncLocalizationsDelegate();
     }
   }
@@ -385,9 +393,7 @@ class WiredashState extends State<Wiredash> {
       return app;
     }
 
-    final theme = _services.wiredashModel.themeFromContext ??
-        widget.theme ??
-        WiredashThemeData();
+    final theme = _services.wiredashModel.themeFromContext ?? widget.theme ?? WiredashThemeData();
 
     final Widget flow = () {
       final active = _services.wiredashModel.activeFlow;
@@ -421,8 +427,7 @@ class WiredashState extends State<Wiredash> {
           builder: (context) {
             // Check if we have a Localizations widget as parent. This works because
             // WidgetsLocalizations is a required for construction
-            final parentLocalization =
-                Localizations.of(context, WidgetsLocalizations);
+            final parentLocalization = Localizations.of(context, WidgetsLocalizations);
 
             final wiredashL10nDelegate = widget.options?.localizationDelegate;
             final delegates = [
@@ -434,8 +439,7 @@ class WiredashState extends State<Wiredash> {
 
               // WidgetsLocalizations is required. Unless we know it already
               // exists, add it here
-              if (parentLocalization == null)
-                DefaultWidgetsLocalizations.delegate,
+              if (parentLocalization == null) DefaultWidgetsLocalizations.delegate,
             ];
 
             if (parentLocalization == null) {
@@ -584,9 +588,7 @@ void validateEnvironment(String environment) {
     );
   }
 
-  if (environment.contains('ä') ||
-      environment.contains('ö') ||
-      environment.contains('ü')) {
+  if (environment.contains('ä') || environment.contains('ö') || environment.contains('ü')) {
     throw ArgumentError.value(
       environment,
       'environment',

--- a/lib/src/core/wuid_generator.dart
+++ b/lib/src/core/wuid_generator.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 
 import 'package:async/async.dart' show ResultFuture;
 import 'package:nanoid2/nanoid2.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/_wiredash_internal.dart';
+import 'package:wiredash/src/core/services/local_storage.dart';
 import 'package:wiredash/src/utils/disposable.dart';
 
 /// Wiredash Unique Identifier Generator
@@ -12,7 +12,7 @@ abstract class WuidGenerator {
   /// Generates a unique random secure id of [length]. Every call returns a new id
   String generateId(int length);
 
-  /// Generates a unique random secure id of [length] and persists it in shared preferences
+  /// Generates a unique random secure id of [length] and persists it in local storage
   ///
   /// Calling it a second time with the same [key] will return the same id
   Future<String> generatePersistedId(String key, int length);
@@ -21,22 +21,20 @@ abstract class WuidGenerator {
   Disposable addOnKeyCreatedListener(void Function(String key) listener);
 }
 
-/// Persistent implementation of [WuidGenerator] that uses shared preferences
-class SharedPrefsWuidGenerator
-    with OnKeyCreatedNotifier
-    implements WuidGenerator {
-  final Future<SharedPreferences> Function() sharedPrefsProvider;
+/// Persistent implementation of [WuidGenerator] that uses local storage
+class LocalStorageWuidGenerator with OnKeyCreatedNotifier implements WuidGenerator {
+  final Future<LocalStorage> Function() localStorageProvider;
 
-  SharedPrefsWuidGenerator({
-    required this.sharedPrefsProvider,
+  LocalStorageWuidGenerator({
+    required this.localStorageProvider,
   });
 
   final Map<String, ResultFuture<String>> _cache = {};
 
   /// Generates a random secure nanoid with 36 characters and persists it in
-  /// shared preferences with the given [key]
+  /// local storage with the given [key]
   ///
-  /// The identifier stored in shared preferences is only deleted when the app
+  /// The identifier stored in local storage is only deleted when the app
   /// is reinstalled
   ///
   /// https://zelark.github.io/nano-id-cc/
@@ -65,49 +63,49 @@ class SharedPrefsWuidGenerator
       }
     }
 
-    final id = loadFromPrefs(key, length);
+    final id = loadFromLocalStorage(key, length);
     _cache[key] = ResultFuture(id);
     return id;
   }
 
-  Future<String> loadFromPrefs(String key, int length) async {
+  Future<String> loadFromLocalStorage(String key, int length) async {
     try {
-      final prefs = await sharedPrefsProvider().timeout(_sharedPrefsTimeout);
-      if (prefs.containsKey(key)) {
-        final recovered = prefs.getString(key);
+      final localStorage = await localStorageProvider().timeout(_localStorageTimeout);
+      if (localStorage.containsKey(key)) {
+        final recovered = localStorage.getString(key);
         if (recovered != null) {
-          // recovered id from prefs
+          // recovered id from local storage
           return recovered;
         }
       }
     } catch (e, stack) {
-      // might fail when users manipulate shared prefs. Creating a new id in
+      // might fail when users manipulate local storage. Creating a new id in
       // that case
-      reportWiredashInfo(e, stack, 'Could not read $key from shared prefs');
+      reportWiredashInfo(e, stack, 'Could not read $key from local storage');
     }
 
-    // first time generation or fallback in case of sharedPrefs error
+    // first time generation or fallback in case of local storage error
     final deviceId = generateId(length);
     Future(() => notifyKeyCreated(key));
     try {
-      final prefs = await sharedPrefsProvider().timeout(_sharedPrefsTimeout);
-      await prefs.setString(key, deviceId).timeout(_sharedPrefsTimeout);
+      final localStorage = await localStorageProvider().timeout(_localStorageTimeout);
+      await localStorage.setString(key, deviceId).timeout(_localStorageTimeout);
     } catch (e, stack) {
-      reportWiredashInfo(e, stack, 'Could not write $key to shared prefs');
+      reportWiredashInfo(e, stack, 'Could not write $key to local storage');
     }
     return deviceId;
   }
 
-  /// A rather short timeout for shared preferences
+  /// A rather short timeout for local storage
   ///
-  /// Usually shared preferences shouldn't fail. But if they do or don't react
+  /// Usually local storage shouldn't fail. But if it does or doesn't react
   /// the deviceId fallback should generate in finite time
-  static const _sharedPrefsTimeout = Duration(seconds: 2);
+  static const _localStorageTimeout = Duration(seconds: 2);
 }
 
 /// Allows notifying listeners when a new key is created
 ///
-/// Used by [SharedPrefsWuidGenerator] and `IncrementalIdGenerator` in tests
+/// Used by [LocalStorageWuidGenerator] and `IncrementalIdGenerator` in tests
 mixin OnKeyCreatedNotifier {
   final List<void Function(String key)> _onKeyCreatedListeners = [];
 

--- a/lib/wiredash.dart
+++ b/lib/wiredash.dart
@@ -11,10 +11,10 @@ export 'src/analytics/analytics.dart'
         TooManyEventParametersException,
         WiredashAnalytics;
 export 'src/core/options/wiredash_options_data.dart';
+export 'src/core/services/local_storage.dart' show LocalStorage;
 export 'src/core/theme/wiredash_theme_data.dart';
 export 'src/core/widgets/confidential.dart';
-export 'src/core/wiredash_controller.dart'
-    show PromoterScoreWiredash, WiredashController;
+export 'src/core/wiredash_controller.dart' show PromoterScoreWiredash, WiredashController;
 export 'src/core/wiredash_widget.dart' show Wiredash;
 export 'src/feedback/data/label.dart';
 export 'src/feedback/feedback_options.dart';

--- a/test/analytics/analytics_test.dart
+++ b/test/analytics/analytics_test.dart
@@ -102,8 +102,7 @@ void main() {
         return Scaffold(
           body: ElevatedButton(
             onPressed: () async {
-              await Wiredash.of(context)
-                  .trackEvent('test_event', data: {'param1': 'value1'});
+              await Wiredash.of(context).trackEvent('test_event', data: {'param1': 'value1'});
             },
             child: const Text('Send Event'),
           ),
@@ -123,9 +122,7 @@ void main() {
     expect(event.eventData, {'param1': 'value1'});
   });
 
-  testWidgets(
-      'Wiredash.trackEvent automatically users the environment from the widget',
-      (tester) async {
+  testWidgets('Wiredash.trackEvent automatically users the environment from the widget', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       environment: 'custom',
@@ -153,8 +150,7 @@ void main() {
     expect(event.environment, 'custom');
   });
 
-  testWidgets('sendEvent (static) to different environment from Widget',
-      (tester) async {
+  testWidgets('sendEvent (static) to different environment from Widget', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       environment: 'production',
@@ -188,8 +184,7 @@ void main() {
 
   testWidgets(
       'sendEvent top-level with two instances - '
-      'forwards to the first registered with warning - order 1',
-      (tester) async {
+      'forwards to the first registered with warning - order 1', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       wrapWithWiredash: false,
@@ -226,18 +221,15 @@ void main() {
     await robot.tapText('Send Event');
     await tester.pumpSmart();
 
-    final api1 =
-        robot.servicesWith(projectId: 'project1').api as MockWiredashApi;
-    final api2 =
-        robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
+    final api1 = robot.servicesWith(projectId: 'project1').api as MockWiredashApi;
+    final api2 = robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
     api1.sendEventsInvocations.verifyInvocationCount(1);
     api2.sendEventsInvocations.verifyInvocationCount(0);
   });
 
   testWidgets(
       'sendEvent top-level with two instances - '
-      'forwards to the first registered with warning - order 2',
-      (tester) async {
+      'forwards to the first registered with warning - order 2', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       wrapWithWiredash: false,
@@ -274,16 +266,13 @@ void main() {
     await robot.tapText('Send Event');
     await tester.pumpSmart();
 
-    final api1 =
-        robot.servicesWith(projectId: 'project1').api as MockWiredashApi;
-    final api2 =
-        robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
+    final api1 = robot.servicesWith(projectId: 'project1').api as MockWiredashApi;
+    final api2 = robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
     api1.sendEventsInvocations.verifyInvocationCount(0);
     api2.sendEventsInvocations.verifyInvocationCount(1);
   });
 
-  testWidgets('two instances - picks first project, ignores environment',
-      (tester) async {
+  testWidgets('two instances - picks first project, ignores environment', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       wrapWithWiredash: false,
@@ -323,9 +312,7 @@ void main() {
     await tester.pumpSmart();
 
     // picks first matching projectId, environment does not matter
-    final api = robot
-        .servicesWith(projectId: 'project1', environment: 'env-a')
-        .api as MockWiredashApi;
+    final api = robot.servicesWith(projectId: 'project1', environment: 'env-a').api as MockWiredashApi;
     final lastEvents = api.sendEventsInvocations.latest;
     final events = lastEvents[0] as List<RequestEvent>?;
     expect(events, hasLength(1));
@@ -334,8 +321,7 @@ void main() {
     expect(event.environment, 'env-b');
   });
 
-  testWidgets('two instances - picks correct project, ignores environment',
-      (tester) async {
+  testWidgets('two instances - picks correct project, ignores environment', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       wrapWithWiredash: false,
@@ -378,8 +364,7 @@ void main() {
     await robot.tapText('Send Event');
     await tester.pumpSmart();
 
-    final api =
-        robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
+    final api = robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
     final lastEvents = api.sendEventsInvocations.latest;
     final events = lastEvents[0] as List<RequestEvent>?;
     expect(events, hasLength(1));
@@ -391,8 +376,7 @@ void main() {
 
   testWidgets(
       'two instances - even when environment matches, '
-      'uses first Wiredash instance because no projectId is set',
-      (tester) async {
+      'uses first Wiredash instance because no projectId is set', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp(
       wrapWithWiredash: false,
@@ -434,8 +418,7 @@ void main() {
     await robot.tapText('Send Event');
     await tester.pumpSmart();
 
-    final api1 =
-        robot.servicesWith(projectId: 'project1').api as MockWiredashApi;
+    final api1 = robot.servicesWith(projectId: 'project1').api as MockWiredashApi;
     api1.sendEventsInvocations.verifyInvocationCount(1);
     final lastEvents = api1.sendEventsInvocations.latest;
     final events = lastEvents[0] as List<RequestEvent>?;
@@ -444,8 +427,7 @@ void main() {
     expect(event.eventName, 'test_event');
     expect(event.environment, 'env-b');
 
-    final api2 =
-        robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
+    final api2 = robot.servicesWith(projectId: 'project2').api as MockWiredashApi;
     api2.sendEventsInvocations.verifyInvocationCount(0);
   });
 
@@ -464,8 +446,7 @@ void main() {
         );
       },
     );
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       throw 'Blocked by ad blocker';
     };
 
@@ -526,8 +507,7 @@ void main() {
         );
       },
     );
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       throw 'offline';
     };
 
@@ -538,8 +518,7 @@ void main() {
 
     errors.restoreDefaultErrorHandlers();
     expect(errors.errors, isEmpty);
-    final presentErrors = errors.warnings
-        .where((element) => !element.toString().contains('offline'));
+    final presentErrors = errors.warnings.where((element) => !element.toString().contains('offline'));
     expect(presentErrors, isEmpty);
 
     // always save the last events
@@ -556,8 +535,7 @@ void main() {
     );
   });
 
-  testWidgets('default events are submitted with the next Wiredash instance',
-      (tester) async {
+  testWidgets('default events are submitted with the next Wiredash instance', (tester) async {
     final robot = WiredashTestRobot(tester);
     robot.setupMocks();
     await robot.regenerateAnalyticsId();
@@ -585,7 +563,7 @@ void main() {
 
     // event is saved locally for the "default" project
     final eventStore = PersistentAnalyticsEventStore(
-      sharedPreferences: SharedPreferences.getInstance,
+      localStorageProvider: SharedPreferences.getInstance,
     );
     final eventsOnDisk = await eventStore.getEvents('default');
     expect(eventsOnDisk, hasLength(1));
@@ -597,9 +575,7 @@ void main() {
     robot.mockServices.mockApi.sendEventsInvocations.verifyInvocationCount(1);
   });
 
-  testWidgets(
-      'project events are only submitted by the correct Wiredash instance',
-      (tester) async {
+  testWidgets('project events are only submitted by the correct Wiredash instance', (tester) async {
     final robot = WiredashTestRobot(tester);
     robot.setupMocks();
     await robot.regenerateAnalyticsId();
@@ -622,7 +598,7 @@ void main() {
 
     // event is saved locally for project1
     final eventStore = PersistentAnalyticsEventStore(
-      sharedPreferences: SharedPreferences.getInstance,
+      localStorageProvider: SharedPreferences.getInstance,
     );
     final eventsOnDisk = await eventStore.getEvents('project1');
     expect(eventsOnDisk, hasLength(1));
@@ -668,7 +644,7 @@ void main() {
     await tester.pumpSmart();
 
     final eventStore = PersistentAnalyticsEventStore(
-      sharedPreferences: SharedPreferences.getInstance,
+      localStorageProvider: SharedPreferences.getInstance,
     );
     final eventsOnDisk1 = await eventStore.getEvents('projectX');
     expect(eventsOnDisk1, hasLength(2));
@@ -678,8 +654,7 @@ void main() {
 
     // restart the app
     await robot.launchApp(projectId: 'projectX');
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       throw 'offline';
     };
     final eventsOnDisk2 = await robot.services.eventStore.getEvents('projectX');
@@ -696,8 +671,7 @@ void main() {
 
     // Tried to submit only the one that is not older than 3 days
     robot.mockServices.mockApi.sendEventsInvocations.verifyInvocationCount(1);
-    final submittedEvents = robot.mockServices.mockApi.sendEventsInvocations
-        .latest[0]! as List<RequestEvent>;
+    final submittedEvents = robot.mockServices.mockApi.sendEventsInvocations.latest[0]! as List<RequestEvent>;
     expect(submittedEvents, hasLength(1));
 
     // keep only that one on disk because submission failed
@@ -709,8 +683,7 @@ void main() {
     testWidgets('submit events after app moves to background', (tester) async {
       final robot = WiredashTestRobot(tester);
       await robot.launchApp();
-      robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-          (invocation) async {
+      robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
         throw 'offline';
       };
       await robot.triggerAnalyticsEvent();
@@ -722,9 +695,7 @@ void main() {
       robot.mockServices.mockApi.sendEventsInvocations.verifyInvocationCount(2);
     });
 
-    testWidgets(
-        'send first event immediately, then after 5s, then after 30s continuously',
-        (tester) async {
+    testWidgets('send first event immediately, then after 5s, then after 30s continuously', (tester) async {
       final start = clock.now();
       final robot = WiredashTestRobot(tester);
       await robot.launchApp(useDirectEventSubmitter: false);
@@ -735,8 +706,7 @@ void main() {
       final diff = clock.now().difference(start);
       expect(diff, const Duration(seconds: 65)); // one event each second
 
-      final List<AssertableInvocation> calls =
-          robot.mockServices.mockApi.sendEventsInvocations.invocations;
+      final List<AssertableInvocation> calls = robot.mockServices.mockApi.sendEventsInvocations.invocations;
       final batches = calls.map((e) => e[0]! as List<RequestEvent>).toList();
       expect(batches, hasLength(3));
       expect(batches[0], hasLength(5));
@@ -744,8 +714,7 @@ void main() {
       expect(batches[2], hasLength(30));
     });
 
-    testWidgets('send event immediately when no event was sent for 30s',
-        (tester) async {
+    testWidgets('send event immediately when no event was sent for 30s', (tester) async {
       final robot = WiredashTestRobot(tester);
       await robot.launchApp(useDirectEventSubmitter: false);
 
@@ -757,8 +726,7 @@ void main() {
       await robot.triggerAnalyticsEvent();
       await tester.pumpSmart(const Duration(milliseconds: 1));
 
-      final List<AssertableInvocation> calls =
-          robot.mockServices.mockApi.sendEventsInvocations.invocations;
+      final List<AssertableInvocation> calls = robot.mockServices.mockApi.sendEventsInvocations.invocations;
       final batches = calls.map((e) => e[0]! as List<RequestEvent>).toList();
       expect(batches, hasLength(2));
       expect(batches[0], hasLength(1));
@@ -771,8 +739,7 @@ void main() {
     await robot.launchApp();
 
     final errors = captureFlutterErrors();
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       final httpClient = MockClient((request) async {
         final body = jsonEncode(
           {
@@ -798,8 +765,7 @@ void main() {
         // }
         return Response.bytes(body.codeUnits, 200);
       });
-      final context =
-          ApiClientContext(httpClient: httpClient, secret: '', projectId: '');
+      final context = ApiClientContext(httpClient: httpClient, secret: '', projectId: '');
       return postSendEvents(
         context,
         'url',
@@ -837,10 +803,8 @@ void main() {
     await robot.launchApp();
 
     final errors = captureFlutterErrors();
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
-      const body =
-          '{"errorCode": 2201, "errorMessage": "can not process events at the moment"}';
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
+      const body = '{"errorCode": 2201, "errorMessage": "can not process events at the moment"}';
       final response = Response(body, 400);
       throw CouldNotHandleRequestException(response: response);
     };
@@ -876,14 +840,12 @@ void main() {
     await robot.launchApp();
 
     final errors = captureFlutterErrors();
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       final httpClient = MockClient((request) async {
         return Response.bytes([], 401); // unauthorized
       });
 
-      final context =
-          ApiClientContext(httpClient: httpClient, secret: '', projectId: '');
+      final context = ApiClientContext(httpClient: httpClient, secret: '', projectId: '');
       return postSendEvents(
         context,
         'url',
@@ -903,14 +865,12 @@ void main() {
     expect(eventsOnDisk, hasLength(0));
   });
 
-  testWidgets('Server could not handle requests - statuscode 500',
-      (tester) async {
+  testWidgets('Server could not handle requests - statuscode 500', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp();
 
     final errors = captureFlutterErrors();
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       throw WiredashApiException(response: Response('', 500));
     };
 
@@ -928,15 +888,12 @@ void main() {
     expect(eventsOnDisk, hasLength(1));
   });
 
-  testWidgets(
-      'server drops custom events of free projects - Reports PaidFeatureException once',
-      (tester) async {
+  testWidgets('server drops custom events of free projects - Reports PaidFeatureException once', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp();
 
     final errors = captureFlutterErrors();
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       final httpClient = MockClient((request) async {
         final body = jsonEncode(
           {
@@ -952,8 +909,7 @@ void main() {
         );
         return Response.bytes(body.codeUnits, 200);
       });
-      final context =
-          ApiClientContext(httpClient: httpClient, secret: '', projectId: '');
+      final context = ApiClientContext(httpClient: httpClient, secret: '', projectId: '');
       return postSendEvents(
         context,
         'url',
@@ -996,8 +952,7 @@ void main() {
     await robot.launchApp();
 
     bool thrown = false;
-    robot.mockServices.mockApi.sendEventsInvocations.interceptor =
-        (invocation) async {
+    robot.mockServices.mockApi.sendEventsInvocations.interceptor = (invocation) async {
       thrown = true;
       throw const SocketException('no internet');
     };
@@ -1055,8 +1010,7 @@ void main() {
     final analytics = WiredashAnalytics();
     await analytics.trackEvent('test_event');
     final events = await state.debugServices.eventStore.getEvents(null);
-    final testEvent = events.values
-        .firstWhereOrNull((event) => event.eventName == 'test_event');
+    final testEvent = events.values.firstWhereOrNull((event) => event.eventName == 'test_event');
     expect(testEvent!.environment, 'custom');
   });
 }

--- a/test/analytics/event_store_test.dart
+++ b/test/analytics/event_store_test.dart
@@ -9,7 +9,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final errors = captureFlutterErrors();
     final eventStore = PersistentAnalyticsEventStore(
-      sharedPreferences: SharedPreferences.getInstance,
+      localStorageProvider: SharedPreferences.getInstance,
     );
 
     final prefs = await SharedPreferences.getInstance();

--- a/test/feedback/data/pending_feedback_item_storage_test.dart
+++ b/test/feedback/data/pending_feedback_item_storage_test.dart
@@ -28,15 +28,13 @@ void main() {
       wuidGenerator = IncrementalIdGenerator();
       storage = PendingFeedbackItemStorage(
         fileSystem: fileSystem,
-        sharedPreferencesProvider: () async => prefs,
+        localStorageProvider: () async => prefs,
         dirPathProvider: () async => '.',
         wuidGenerator: wuidGenerator,
       );
     });
 
-    List<String> filesOnDisk() =>
-        fileSystem.directory('/').listSync().map((it) => it.path).toList()
-          ..sort();
+    List<String> filesOnDisk() => fileSystem.directory('/').listSync().map((it) => it.path).toList()..sort();
 
     test('can persist one feedback item', () async {
       await fileSystem.file('existing.png').writeAsBytes(kTransparentImage);
@@ -145,8 +143,7 @@ void main() {
       expect(filesOnDisk(), []);
     });
 
-    test('when has two items, preserves one while clearing the other one',
-        () async {
+    test('when has two items, preserves one while clearing the other one', () async {
       final first = createFeedback(
         attachments: [
           PersistedAttachment.screenshot(
@@ -181,9 +178,7 @@ void main() {
     });
 
     test('removes items which can not be parsed', () async {
-      await fileSystem
-          .file('<screenshot for invalid item>')
-          .writeAsBytes(kTransparentImage);
+      await fileSystem.file('<screenshot for invalid item>').writeAsBytes(kTransparentImage);
 
       final illegalSerializedItem = json.encode({
         // item has some required properties missing
@@ -195,9 +190,7 @@ void main() {
         'screenshotPath': '<screenshot for invalid item>',
       });
 
-      await fileSystem
-          .file('<existing item screenshot>')
-          .writeAsBytes(kTransparentImage);
+      await fileSystem.file('<existing item screenshot>').writeAsBytes(kTransparentImage);
 
       final pendingSerializedLegalItem = serializePendingFeedbackItem(
         PendingFeedbackItem(
@@ -205,8 +198,7 @@ void main() {
           feedbackItem: createFeedback(
             attachments: [
               PersistedAttachment.screenshot(
-                file:
-                    FileDataEventuallyOnDisk.file('<existing item screenshot>'),
+                file: FileDataEventuallyOnDisk.file('<existing item screenshot>'),
               ),
             ],
           ),
@@ -311,13 +303,11 @@ void main() {
 class InMemorySharedPreferences extends Fake implements SharedPreferences {
   final Map<String, Object?> _store = {};
 
-  final MethodInvocationCatcher setStringListInvocations =
-      MethodInvocationCatcher('setStringList');
+  final MethodInvocationCatcher setStringListInvocations = MethodInvocationCatcher('setStringList');
 
   @override
   Future<bool> setStringList(String key, List<String> value) async {
-    final mockedReturnValue =
-        setStringListInvocations.addAsyncMethodCall<bool>(args: [key, value]);
+    final mockedReturnValue = setStringListInvocations.addAsyncMethodCall<bool>(args: [key, value]);
     if (mockedReturnValue != null) {
       return mockedReturnValue.future;
     }
@@ -325,26 +315,22 @@ class InMemorySharedPreferences extends Fake implements SharedPreferences {
     return true;
   }
 
-  final MethodInvocationCatcher getStringListInvocations =
-      MethodInvocationCatcher('getStringList');
+  final MethodInvocationCatcher getStringListInvocations = MethodInvocationCatcher('getStringList');
 
   @override
   List<String>? getStringList(String key) {
-    final mockedReturnValue =
-        getStringListInvocations.addMethodCall<List<String>?>(args: [key]);
+    final mockedReturnValue = getStringListInvocations.addMethodCall<List<String>?>(args: [key]);
     if (mockedReturnValue != null) {
       return mockedReturnValue.value;
     }
     return _store[key] as List<String>?;
   }
 
-  final MethodInvocationCatcher setIntInvocations =
-      MethodInvocationCatcher('setInt');
+  final MethodInvocationCatcher setIntInvocations = MethodInvocationCatcher('setInt');
 
   @override
   Future<bool> setInt(String key, int value) async {
-    final mockedReturnValue =
-        setIntInvocations.addAsyncMethodCall<bool>(args: [key, value]);
+    final mockedReturnValue = setIntInvocations.addAsyncMethodCall<bool>(args: [key, value]);
     if (mockedReturnValue != null) {
       return mockedReturnValue.future;
     }
@@ -352,26 +338,22 @@ class InMemorySharedPreferences extends Fake implements SharedPreferences {
     return true;
   }
 
-  final MethodInvocationCatcher getIntInvocations =
-      MethodInvocationCatcher('getInt');
+  final MethodInvocationCatcher getIntInvocations = MethodInvocationCatcher('getInt');
 
   @override
   int? getInt(String key) {
-    final mockedReturnValue =
-        getIntInvocations.addMethodCall<int?>(args: [key]);
+    final mockedReturnValue = getIntInvocations.addMethodCall<int?>(args: [key]);
     if (mockedReturnValue != null) {
       return mockedReturnValue.value;
     }
     return _store[key] as int?;
   }
 
-  final MethodInvocationCatcher setStringInvocations =
-      MethodInvocationCatcher('setString');
+  final MethodInvocationCatcher setStringInvocations = MethodInvocationCatcher('setString');
 
   @override
   Future<bool> setString(String key, String value) async {
-    final mockedReturnValue =
-        setStringInvocations.addAsyncMethodCall<bool>(args: [key, value]);
+    final mockedReturnValue = setStringInvocations.addAsyncMethodCall<bool>(args: [key, value]);
     if (mockedReturnValue != null) {
       return mockedReturnValue.future;
     }
@@ -379,8 +361,7 @@ class InMemorySharedPreferences extends Fake implements SharedPreferences {
     return true;
   }
 
-  final MethodInvocationCatcher getStringInvocations =
-      MethodInvocationCatcher('getString');
+  final MethodInvocationCatcher getStringInvocations = MethodInvocationCatcher('getString');
 
   @override
   String? getString(String key) {
@@ -393,9 +374,7 @@ class InMemorySharedPreferences extends Fake implements SharedPreferences {
 }
 
 /// Creates string IDs that increment
-class IncrementalIdGenerator
-    with OnKeyCreatedNotifier
-    implements WuidGenerator {
+class IncrementalIdGenerator with OnKeyCreatedNotifier implements WuidGenerator {
   var _nextInt = 0;
 
   @override
@@ -436,8 +415,7 @@ FeedbackItem createFeedback({
       installId: '01234567890123456',
       platformBrightness: Brightness.light,
       platformDartVersion: '3.2.0',
-      platformGestureInsets:
-          WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 0),
+      platformGestureInsets: WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 0),
       platformLocale: 'en_US',
       platformOS: 'Android',
       platformOSVersion: '11',
@@ -446,8 +424,7 @@ FeedbackItem createFeedback({
       userId: 'Testy McTestFace',
       userEmail: 'email@example.com',
       windowInsets: WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 0),
-      windowPadding:
-          WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 0),
+      windowPadding: WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 0),
       windowPixelRatio: 2.0,
       windowSize: Size(800, 1200),
       windowTextScaleFactor: 1.0,

--- a/test/feedback/data/retrying_feedback_submitter_test.dart
+++ b/test/feedback/data/retrying_feedback_submitter_test.dart
@@ -32,7 +32,7 @@ void main() {
         fileSystem: fileSystem,
         wuidGenerator: idGenerator,
         dirPathProvider: () async => '.',
-        sharedPreferencesProvider: () async => preferences,
+        localStorageProvider: () async => preferences,
       );
       mockApi = MockWiredashApi();
       mockApi.uploadAttachmentInvocations.interceptor = (_) {
@@ -159,8 +159,7 @@ void main() {
       mockApi.sendFeedbackInvocations.verifyHasNoInvocation();
       final pendingItems = await storage.retrieveAllPendingItems();
       expect(pendingItems, hasLength(1));
-      final filePath =
-          pendingItems.first.feedbackItem.attachments!.first.file.pathToFile;
+      final filePath = pendingItems.first.feedbackItem.attachments!.first.file.pathToFile;
       expect(fileSystem.file(filePath).existsSync(), isTrue);
 
       // submission works now
@@ -178,8 +177,7 @@ void main() {
 
     test(
         'submit() - when has existing items and submits only the first one '
-        'successfully, does not remove the failed items from storage',
-        () async {
+        'successfully, does not remove the failed items from storage', () async {
       // Don't upload while submitting the items
       mockApi.sendFeedbackInvocations.interceptor = (iv) {
         throw "No internet";
@@ -222,9 +220,7 @@ void main() {
       expect(lastSendCall[0], item2);
     });
 
-    test(
-        'submitPendingFeedbackItems() - if fails, retries up to 8 times with exponential backoff',
-        () async {
+    test('submitPendingFeedbackItems() - if fails, retries up to 8 times with exponential backoff', () async {
       final item = createFeedback(message: '1');
 
       final initialTime = DateTime(2000, 01, 01, 00, 00, 00, 000);
@@ -248,8 +244,7 @@ void main() {
           async.elapse(const Duration(minutes: 5));
 
           // Sending one feedback item should be retried no more than 8 times.
-          final sendAttempts =
-              mockApi.sendFeedbackInvocations.invocations.where((iv) {
+          final sendAttempts = mockApi.sendFeedbackInvocations.invocations.where((iv) {
             return iv[0] == item;
           });
           expect(sendAttempts.length, 8);
@@ -295,9 +290,7 @@ void main() {
       );
     });
 
-    test(
-        'submitPendingFeedbackItems() - does not retry for UnauthenticatedWiredashApiException',
-        () async {
+    test('submitPendingFeedbackItems() - does not retry for UnauthenticatedWiredashApiException', () async {
       final item = createFeedback();
 
       final initialTime = DateTime(2000, 01, 01, 00, 00, 00, 000);
@@ -372,8 +365,7 @@ void main() {
       expect(await storage.retrieveAllPendingItems(), hasLength(0));
     });
 
-    test('submit() - does not retry when server reports unknown property',
-        () async {
+    test('submit() - does not retry when server reports unknown property', () async {
       final item = createFeedback();
 
       mockApi.sendFeedbackInvocations.interceptor = (iv) {

--- a/test/sync/ping_job_test.dart
+++ b/test/sync/ping_job_test.dart
@@ -30,7 +30,7 @@ void main() {
       final incrementalIdGenerator = IncrementalIdGenerator();
       return PingJob(
         apiProvider: () => api,
-        sharedPreferencesProvider: prefsProvider,
+        localStorageProvider: prefsProvider,
         metaDataCollector: () {
           return fakeMetaDataCollector;
         },
@@ -78,12 +78,10 @@ void main() {
       });
     });
 
-    test('ping sends buildVersion und buildNumber overrides from environment',
-        () {
+    test('ping sends buildVersion und buildNumber overrides from environment', () {
       fakeAsync((async) {
         final pingJob = createPingJob();
-        (pingJob.metaDataCollector() as FakeMetaDataCollector)
-            .buildInfoOverride = const BuildInfo(
+        (pingJob.metaDataCollector() as FakeMetaDataCollector).buildInfoOverride = const BuildInfo(
           buildVersion: '10.0.0',
           buildNumber: '1000',
           compilationMode: CompilationMode.profile,
@@ -149,7 +147,7 @@ void main() {
         };
         final pingJob = PingJob(
           apiProvider: () => api,
-          sharedPreferencesProvider: prefsProvider,
+          localStorageProvider: prefsProvider,
           metaDataCollector: () => FakeMetaDataCollector(),
           wuidGenerator: () => IncrementalIdGenerator(),
           environmentDetector: () => FixedEnvironmentDetector('prod'),
@@ -172,7 +170,7 @@ void main() {
         };
         final pingJob = PingJob(
           apiProvider: () => api,
-          sharedPreferencesProvider: prefsProvider,
+          localStorageProvider: prefsProvider,
           metaDataCollector: () => FakeMetaDataCollector(),
           wuidGenerator: () => IncrementalIdGenerator(),
           environmentDetector: () => FixedEnvironmentDetector('prod'),
@@ -220,8 +218,7 @@ class FakeMetaDataCollector with Fake implements MetaDataCollector {
       platformSupportedLocales: ['en_US', 'de_DE'],
       platformOS: 'android',
       platformBrightness: Brightness.dark,
-      gestureInsets:
-          WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 0),
+      gestureInsets: WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 0),
       viewPadding: WiredashWindowPadding(left: 0, top: 66, right: 0, bottom: 0),
       viewInsets: WiredashWindowPadding(left: 0, top: 0, right: 0, bottom: 685),
       physicalSize: Size(1280, 720),


### PR DESCRIPTION
We use Wiredash (which is a great product btw) in a Windows application where the application is installed on all Windows-users, and all analytics/data we store must be shared for the org. But (afaik) Shared Preferences can not be configured to save data outside of the default directory, which on Windows would be unique per user.

Our customers (organisations) will open the same application but from many different Windows users, and the following data would in our case therefore be overwritten/not updated correctly between Windows-users:

- flutter.io.wiredash.device_registered_date
- flutter.io.wiredash.app_starts

Please correct me if I'm wrong here, or if there's another (better) way for us to handle this!

We already need to use a custom local storage solution to save data that we need to make sure is the same between Windows-users, and for us this change would make it easy to simply use that as the "base" local storage solution in Wiredash as well.