### PR TITLE
Remove WidgetInspector due to breaking API change

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,3 +14,36 @@
 - Update wiredash-demo project for website
 - Update latest SDK version in `console`
 - Announce release on Twitter 🎉
+
+
+## Handling deprecations of the Flutter SDK and dependencies
+
+The Wiredash SDK strives to be compatible with all `stable` [Flutter releases](https://docs.flutter.dev/release/archive) within the last year as well as the current `master` channel.
+To achieve this, we go the extra mile and work around breaking API changes or contribute fixes directly to the Flutter SDK to ensure compatibility.
+
+The goal is to always have a single commit, being compatible with all versions.
+This way we can make sure to deliver the latest features and bug fixes to all of our users.
+
+These are the current deprecated APIs the Wiredash SDK is currently using as long as the deprecated APIs are not removed (usually after 12 months).
+
+### Flutter v3.28 / Dart 3.6.0
+
+- New `WidgetInspector` constructor https://github.com/flutter/flutter/pull/158219
+
+### Flutter 3.27 / Dart 3.6.0
+
+Multiple `Color` API changes 
+- https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework
+- https://github.com/flutter/engine/pull/54737
+
+- `Color.alpha` -> `Color.a`
+- `Color.red` -> `Color.r`
+- `Color.green` -> `Color.g`
+- `Color.blue` -> `Color.b`
+- `Color.withOpacity()` -> `Color.withValues()`
+- `Color.value` -> ?
+
+### Flutter 3.10 / Dart 3.0.0
+
+- `Iterable<T?>.whereNotNull()` -> `Iterable<T>.nonNulls` (Caused by pinned [`collection: 1.19.0`](https://pub.dev/packages/collection/changelog#1190) package)
+- `MediaQuery.fromWindow` -> `MediaQuery.fromView` (deprecated in Flutter v3.7.0-32.0.pre) https://github.com/flutter/flutter/pull/119647

--- a/examples/theme_editor/lib/marianos_clones/netflix_clone.dart
+++ b/examples/theme_editor/lib/marianos_clones/netflix_clone.dart
@@ -189,8 +189,11 @@ class _InitScreenState extends State<InitScreen> {
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 colors: [
+                  // ignore: deprecated_member_use
                   Colors.black.withOpacity(0.8),
+                  // ignore: deprecated_member_use
                   Colors.black.withOpacity(0.42),
+                  // ignore: deprecated_member_use
                   Colors.black.withOpacity(0.9),
                 ],
                 begin: Alignment.topCenter,
@@ -910,8 +913,11 @@ class _LoginScreenState extends State<LoginScreen> {
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   colors: [
+                    // ignore: deprecated_member_use
                     Colors.black.withOpacity(0.8),
+                    // ignore: deprecated_member_use
                     Colors.black.withOpacity(0.42),
+                    // ignore: deprecated_member_use
                     Colors.black.withOpacity(0.9),
                   ],
                   begin: Alignment.topCenter,
@@ -938,6 +944,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   Container(
                     width: 450,
                     height: 675,
+                    // ignore: deprecated_member_use
                     color: Colors.black.withOpacity(0.8),
                     padding: EdgeInsets.symmetric(
                       horizontal: breakpoint(size.width, 60, 40, 30),
@@ -1090,6 +1097,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   SizedBox(height: 100),
                   Container(
                     width: size.width,
+                    // ignore: deprecated_member_use
                     color: Colors.black.withOpacity(0.5),
                     height: 240,
                     child: Column(
@@ -1156,6 +1164,7 @@ class _LoginScreenState extends State<LoginScreen> {
             height: 60,
             width: 140,
             decoration: BoxDecoration(
+              // ignore: deprecated_member_use
               color: Colors.black.withOpacity(0.8),
               border: Border.all(color: Color(0xFF333333), width: 2),
             ),
@@ -1202,6 +1211,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     decoration: BoxDecoration(
                       gradient: LinearGradient(
                         colors: [
+                          // ignore: deprecated_member_use
                           Colors.black.withOpacity(0.8),
                           Colors.transparent,
                         ],
@@ -1936,7 +1946,9 @@ class _BrowseScreenState extends State<BrowseScreen> {
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   colors: [
+                    // ignore: deprecated_member_use
                     Color(0xFF060606).withOpacity(_fadePercentage),
+                    // ignore: deprecated_member_use
                     Color(0xFF141414).withOpacity(_fadePercentage),
                   ],
                   begin: Alignment.topCenter,
@@ -1994,7 +2006,9 @@ class _BrowseScreenState extends State<BrowseScreen> {
       decoration: BoxDecoration(
         gradient: LinearGradient(
           colors: [
+            // ignore: deprecated_member_use
             Color(0xFF060606).withOpacity(0.8),
+            // ignore: deprecated_member_use
             Color(0xFF141414).withOpacity(0.0),
           ],
           begin: Alignment.topCenter,
@@ -2012,7 +2026,9 @@ class _BrowseScreenState extends State<BrowseScreen> {
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   colors: [
+                    // ignore: deprecated_member_use
                     Color(0xFF060606).withOpacity(_fadePercentage),
+                    // ignore: deprecated_member_use
                     Color(0xFF141414).withOpacity(_fadePercentage),
                   ],
                   begin: Alignment.topCenter,
@@ -2135,6 +2151,7 @@ class _BrowseScreenState extends State<BrowseScreen> {
               height: 150,
               decoration: BoxDecoration(
                 gradient: LinearGradient(
+                  // ignore: deprecated_member_use
                   colors: [Color(0xFF141414).withOpacity(0), Color(0xFF141414)],
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
@@ -2253,6 +2270,7 @@ class _BrowseScreenState extends State<BrowseScreen> {
               height: 150,
               decoration: BoxDecoration(
                 gradient: LinearGradient(
+                  // ignore: deprecated_member_use
                   colors: [Color(0xFF141414).withOpacity(0), Color(0xFF141414)],
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
@@ -2770,10 +2788,12 @@ class NetflixPainter extends CustomPainter {
         ..lineTo(legWidth + 70, 0)
         ..close();
       final shadowPaint = Paint()
+        // ignore: deprecated_member_use
         ..color = Colors.black.withOpacity(anim.middleLegOpacity)
         ..maskFilter = MaskFilter.blur(BlurStyle.normal, 30);
       final middleLegPaint = Paint()
         ..color =
+            // ignore: deprecated_member_use
             NetflixColors.netflixDarkRed.withOpacity(anim.middleLegOpacity);
       canvas.clipRect(middleLegClipPath);
       canvas.drawPath(shadowPath, shadowPaint);
@@ -2860,6 +2880,7 @@ class NetflixPainter extends CustomPainter {
     canvas.save();
     if (anim.leftLegOpacity > 0) {
       final leftLegPaint = Paint()
+        // ignore: deprecated_member_use
         ..color = NetflixColors.netflixDarkRed.withOpacity(anim.leftLegOpacity);
 
       canvas.drawRect(
@@ -2883,6 +2904,7 @@ class NetflixPainter extends CustomPainter {
             rect,
             Paint()
               ..color = rainbowColors[i % rainbowColors.length]!
+                  // ignore: deprecated_member_use
                   .withOpacity(1.0 - anim.leftLegOpacity)
               ..maskFilter = MaskFilter.blur(BlurStyle.normal, 3),
           );

--- a/examples/theme_editor/lib/marianos_clones/whatsapp_clone.dart
+++ b/examples/theme_editor/lib/marianos_clones/whatsapp_clone.dart
@@ -917,6 +917,7 @@ class ContactItem extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
                           fontSize: 14,
+                          // ignore: deprecated_member_use
                           color: Colors.black.withOpacity(0.6),
                         ),
                       ),
@@ -1037,9 +1038,11 @@ class _ChatItemState extends State<ChatItem> {
                                     color: _lastMessageMine(
                                       widget.conversation,
                                     )
+                                        // ignore: deprecated_member_use
                                         ? Colors.black.withOpacity(0.6)
                                         : _countUnread(widget.conversation) > 0
                                             ? Colors.black
+                                            // ignore: deprecated_member_use
                                             : Colors.black.withOpacity(0.6),
                                   ),
                                 ),
@@ -1779,12 +1782,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     SizedBox(height: 15),
                     Text(
                       'Your Name',
+                      // ignore: deprecated_member_use
                       style: TextStyle(color: Colors.black.withOpacity(0.5)),
                     ),
                     SizedBox(height: 20),
                     Text(
                       widget.user.name,
                       style: TextStyle(
+                        // ignore: deprecated_member_use
                         color: Colors.black.withOpacity(0.8),
                         fontSize: 18,
                       ),
@@ -1803,6 +1808,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     const EdgeInsets.symmetric(horizontal: 30, vertical: 15),
                 child: Text(
                   'This is not your username or pin. This name will be visible to your WhatsApp contacts.',
+                  // ignore: deprecated_member_use
                   style: TextStyle(color: Colors.black.withOpacity(0.5)),
                 ),
               ),
@@ -1817,12 +1823,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     SizedBox(height: 15),
                     Text(
                       'About',
+                      // ignore: deprecated_member_use
                       style: TextStyle(color: Colors.black.withOpacity(0.5)),
                     ),
                     SizedBox(height: 20),
                     Text(
                       widget.user.status,
                       style: TextStyle(
+                        // ignore: deprecated_member_use
                         color: Colors.black.withOpacity(0.8),
                         fontSize: 18,
                       ),
@@ -2037,7 +2045,9 @@ class ContactScreenState extends State<ContactScreen> {
                                             decoration: BoxDecoration(
                                               gradient: LinearGradient(
                                                 colors: [
+                                                  // ignore: deprecated_member_use
                                                   Colors.black.withOpacity(0.0),
+                                                  // ignore: deprecated_member_use
                                                   Colors.black.withOpacity(0.8)
                                                 ],
                                                 begin: Alignment.topCenter,
@@ -2170,6 +2180,7 @@ class ContactScreenState extends State<ContactScreen> {
                                   Text(
                                     'About and phone number',
                                     style: TextStyle(
+                                      // ignore: deprecated_member_use
                                       color: Colors.black.withOpacity(0.5),
                                     ),
                                   ),
@@ -2177,6 +2188,7 @@ class ContactScreenState extends State<ContactScreen> {
                                   Text(
                                     _user!.status,
                                     style: TextStyle(
+                                      // ignore: deprecated_member_use
                                       color: Colors.black.withOpacity(0.8),
                                     ),
                                   ),

--- a/examples/theming/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/theming/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/lib/src/core/network/api_exceptions.dart
+++ b/lib/src/core/network/api_exceptions.dart
@@ -149,6 +149,8 @@ extension WiredashApiWarnings on Response {
       return warnings
           .whereType<Map>()
           .map((w) => WiredashApiWarning.tryParse(w))
+          // Switch to .nonNulls when minSdk is Dart 3.0
+          // ignore: deprecated_member_use
           .whereNotNull()
           .toList();
     } catch (_) {

--- a/lib/src/core/support/not_a_widgets_app.dart
+++ b/lib/src/core/support/not_a_widgets_app.dart
@@ -30,20 +30,54 @@ class _NotAWidgetsAppState extends State<NotAWidgetsApp> {
       child: widget.child,
     );
 
-    // Allow inspection of widgets
-    // ignore: deprecated_member_use
-    if (kDebugMode && WidgetsApp.debugShowWidgetInspectorOverride) {
-      child = WidgetInspector(
-        selectButtonBuilder: (BuildContext context, void Function() onPressed) {
-          return FloatingActionButton(
-            onPressed: onPressed,
-            mini: true,
-            child: const Icon(Icons.search),
-          );
-        },
-        child: child,
-      );
-    }
+    // Allow inspection of widgets, use to debug layout issues
+    // Not part of the codebase since https://github.com/flutter/flutter/pull/158219 introduced a breaking API change.
+    // Re-enable when we drop support for Flutter v3.27.0
+    // if (kDebugMode && WidgetsApp.debugShowWidgetInspectorOverride) {
+    //   child = WidgetInspector(
+    //     exitWidgetSelectionButtonBuilder: (
+    //       BuildContext context, {
+    //       required VoidCallback onPressed,
+    //       required GlobalKey key,
+    //     }) {
+    //       final ThemeData theme = Theme.of(context);
+    //       return FloatingActionButton(
+    //         key: key,
+    //         onPressed: onPressed,
+    //         mini: true,
+    //         backgroundColor: theme.colorScheme.onPrimaryContainer,
+    //         foregroundColor: theme.colorScheme.primaryContainer,
+    //         child: const Icon(
+    //           Icons.close,
+    //           semanticLabel: 'Exit Select Widget mode.',
+    //         ),
+    //       );
+    //     },
+    //     moveExitWidgetSelectionButtonBuilder: (
+    //       BuildContext context, {
+    //       required VoidCallback onPressed,
+    //       bool isLeftAligned = true,
+    //     }) {
+    //       final ThemeData theme = Theme.of(context);
+    //       return IconButton(
+    //         color: theme.colorScheme.onPrimaryContainer,
+    //         padding: EdgeInsets.zero,
+    //         iconSize: 32,
+    //         onPressed: onPressed,
+    //         constraints: const BoxConstraints(
+    //           minWidth: 40,
+    //           minHeight: 40,
+    //         ),
+    //         icon: Icon(
+    //           isLeftAligned ? Icons.arrow_right : Icons.arrow_left,
+    //           semanticLabel:
+    //               'Move "Exit Select Widget mode" button to the ${isLeftAligned ? 'right' : 'left'}.',
+    //         ),
+    //       );
+    //     },
+    //     child: child,
+    //   );
+    // }
 
     // Any Text requires a directionality
     child = Directionality(

--- a/lib/src/core/support/not_a_widgets_app.dart
+++ b/lib/src/core/support/not_a_widgets_app.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: join_return_with_assignment
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Wrapper with default that most widgets required that are now wrapped by a

--- a/lib/src/core/theme/color_ext.dart
+++ b/lib/src/core/theme/color_ext.dart
@@ -93,6 +93,8 @@ extension ColorBrightness on Color {
   }
 
   Brightness get brightness {
+    // Changed in Flutter 3.26 https://github.com/flutter/engine/pull/54737
+    // ignore: deprecated_member_use
     final grayscale = (0.299 * red) + (0.587 * green) + (0.114 * blue);
 
     if (grayscale > 128) {

--- a/lib/src/core/theme/wiredash_theme_data.dart
+++ b/lib/src/core/theme/wiredash_theme_data.dart
@@ -62,6 +62,8 @@ class WiredashThemeData {
     Color? secondaryColor,
     required Brightness brightness,
   }) {
+    // Changed in Flutter 3.26 https://github.com/flutter/engine/pull/54737
+    // ignore: deprecated_member_use
     if (secondaryColor?.value == primaryColor.value) {
       secondaryColor = null;
     }
@@ -255,6 +257,8 @@ class WiredashThemeData {
     }
     final merged =
         Color.lerp(primaryBackgroundColor, secondaryBackgroundColor, 0.5)!;
+    // Changed in Flutter 3.26 https://github.com/flutter/engine/pull/54737
+    // ignore: deprecated_member_use
     final palette = CorePalette.of(merged.value);
 
     final tone = isLight ? 10 : 100;
@@ -269,6 +273,8 @@ class WiredashThemeData {
     }
     final merged =
         Color.lerp(primaryBackgroundColor, secondaryBackgroundColor, 0.5)!;
+    // Changed in Flutter 3.26 https://github.com/flutter/engine/pull/54737
+    // ignore: deprecated_member_use
     final palette = CorePalette.of(merged.value);
 
     final tone = isLight ? 40 : 70;
@@ -301,6 +307,7 @@ class WiredashThemeData {
   }
 
   Color get secondaryTextOnSurfaceColor {
+    // ignore: deprecated_member_use
     return _primaryTone.onSurface.withOpacity(0.8);
   }
 
@@ -894,6 +901,7 @@ class SurfaceBasedTextStyle {
     theme,
     theme.textTheme.body2Medium,
     'body2Medium',
+    // ignore: deprecated_member_use
     colorMutation: (color) => color.withOpacity(0.7),
   );
 
@@ -901,6 +909,7 @@ class SurfaceBasedTextStyle {
     theme,
     theme.textTheme.body2Small,
     'body2Small',
+    // ignore: deprecated_member_use
     colorMutation: (color) => color.withOpacity(0.7),
   );
 
@@ -1068,6 +1077,8 @@ enum DeviceClass {
 /// Based on the theory in https://m3.material.io/styles/color/dynamic-color/user-generated-color
 class MaterialColorTone {
   MaterialColorTone(this.baseColor, this.brightness)
+      // Changed in Flutter 3.26 https://github.com/flutter/engine/pull/54737
+      // ignore: deprecated_member_use
       : palette = CorePalette.of(baseColor.value);
   final Color baseColor;
   final CorePalette palette;

--- a/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
+++ b/lib/src/core/widgets/backdrop/fake_app_status_bar.dart
@@ -51,6 +51,7 @@ class FakeAppStatusBar extends StatelessWidget {
                     children: [
                       Icon(
                         Wirecons.cheveron_up,
+                        // ignore: deprecated_member_use
                         color: blackOrWhite.withOpacity(0.80),
                         size: 16,
                       ),
@@ -59,6 +60,7 @@ class FakeAppStatusBar extends StatelessWidget {
                       const SizedBox(width: 16),
                       Icon(
                         Wirecons.cheveron_up,
+                        // ignore: deprecated_member_use
                         color: blackOrWhite.withOpacity(0.80),
                         size: 16,
                       ),

--- a/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
+++ b/lib/src/core/widgets/backdrop/wiredash_backdrop.dart
@@ -592,6 +592,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
           decoration: BoxDecoration(
             border: Border.all(
               width: 4,
+              // ignore: deprecated_member_use
               color: Colors.yellow.withOpacity(0.5),
             ),
           ),
@@ -603,6 +604,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
           decoration: BoxDecoration(
             border: Border.all(
               width: 3,
+              // ignore: deprecated_member_use
               color: Colors.blue.withOpacity(0.5),
             ),
           ),
@@ -616,6 +618,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         bottom: _mediaQueryData.size.height - _mediaQueryData.padding.top,
         child: DecoratedBox(
           decoration: BoxDecoration(
+            // ignore: deprecated_member_use
             color: Colors.orange.withOpacity(0.1),
             border: Border.all(
               color: Colors.orange,
@@ -631,6 +634,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         height: widget.padding?.top ?? 0,
         child: DecoratedBox(
           decoration: BoxDecoration(
+            // ignore: deprecated_member_use
             color: Colors.pink.withOpacity(0.1),
             border: Border.all(
               color: Colors.pink,
@@ -645,6 +649,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         top: _mediaQueryData.padding.top + context.theme.minContentHeight,
         child: DecoratedBox(
           decoration: BoxDecoration(
+            // ignore: deprecated_member_use
             color: Colors.greenAccent.withOpacity(0.1),
             border: Border.all(
               color: Colors.greenAccent,
@@ -660,6 +665,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         top: _mediaQueryData.size.height - _mediaQueryData.padding.bottom,
         child: DecoratedBox(
           decoration: BoxDecoration(
+            // ignore: deprecated_member_use
             color: Colors.orange.withOpacity(0.1),
             border: Border.all(
               color: Colors.orange,
@@ -672,6 +678,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         child: DecoratedBox(
           decoration: BoxDecoration(
             border: Border.all(
+              // ignore: deprecated_member_use
               color: Colors.red.withOpacity(0.5),
             ),
           ),
@@ -685,6 +692,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
         bottom: 0,
         child: DecoratedBox(
           decoration: BoxDecoration(
+            // ignore: deprecated_member_use
             color: Colors.orange.withOpacity(0.1),
             border: Border.all(
               color: Colors.orange,
@@ -745,11 +753,13 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
               borderRadius: _cornerRadiusAnimation.value,
               boxShadow: [
                 BoxShadow(
+                  // ignore: deprecated_member_use
                   color: const Color(0xFF000000).withOpacity(0.04),
                   offset: const Offset(0, 10),
                   blurRadius: 10,
                 ),
                 BoxShadow(
+                  // ignore: deprecated_member_use
                   color: const Color(0xFF000000).withOpacity(0.10),
                   offset: const Offset(0, 20),
                   blurRadius: 25,
@@ -799,6 +809,7 @@ class _WiredashBackdropState extends State<WiredashBackdrop>
                         opacity: _appHandleAnimation.value,
                         child: ColoredBox(
                           color: context.theme.appHandleBackgroundColor
+                              // ignore: deprecated_member_use
                               .withOpacity(0.1),
                         ),
                       ),

--- a/lib/src/core/widgets/tron/tron_button.dart
+++ b/lib/src/core/widgets/tron/tron_button.dart
@@ -97,6 +97,7 @@ class _TronButtonState extends State<TronButton>
     final textColor = widget.textColor;
     if (textColor != null) {
       if (!_enabled) {
+        // ignore: deprecated_member_use
         return textColor.withOpacity(0.3);
       }
       return textColor;
@@ -108,9 +109,11 @@ class _TronButtonState extends State<TronButton>
         luminance < 0.4 ? const Color(0xffffffff) : const Color(0xff000000);
 
     if (!_enabled) {
+      // ignore: deprecated_member_use
       return blackOrWhite.withOpacity(0.3);
     }
 
+    // ignore: deprecated_member_use
     return blackOrWhite.withOpacity(math.max(hsl.saturation, 0.9));
   }
 

--- a/lib/src/core/widgets/tron/tron_labeled_button.dart
+++ b/lib/src/core/widgets/tron/tron_labeled_button.dart
@@ -120,15 +120,18 @@ class _LabeledButtonState extends AnimatedWidgetBaseState<TronLabeledButton> {
       _colorTween,
       () {
         if (widget.onTap == null) {
+          // ignore: deprecated_member_use
           return color.withOpacity(0);
         }
         if (_pressed) {
-          // ignore: avoid_redundant_argument_values
+          // ignore: avoid_redundant_argument_values, deprecated_member_use
           return color.withOpacity(0.4);
         }
         if (_hovered) {
+          // ignore: deprecated_member_use
           return color.withOpacity(0.2);
         }
+        // ignore: deprecated_member_use
         return color.withOpacity(0);
       }(),
       (dynamic value) => ColorTween(begin: value as Color?),

--- a/lib/src/core/widgets/tron/tron_progress_indicator.dart
+++ b/lib/src/core/widgets/tron/tron_progress_indicator.dart
@@ -94,6 +94,7 @@ class _TronProgressIndicatorState extends State<TronProgressIndicator>
               context.theme.primaryColor,
               _currentProgress,
               context.theme.primaryColor.darken(0.05),
+              // ignore: deprecated_member_use
               context.theme.primaryColor.withOpacity(0.2),
               _nextProgress,
             ),

--- a/lib/src/core/wiredash_registry.dart
+++ b/lib/src/core/wiredash_registry.dart
@@ -54,6 +54,8 @@ class WiredashRegistry {
 
   List<WiredashState> get allWidgets {
     purge();
+    // Switch to .nonNulls when minSdk is Dart 3.0
+    // ignore: deprecated_member_use
     return _refs.map((ref) => ref.target).whereNotNull().toList();
   }
 
@@ -88,6 +90,8 @@ extension WiredashRegistryExt on WiredashRegistry {
     return _refs
         .map((ref) => ref.target)
         .where((state) => state?.widget.projectId == projectId)
+        // Switch to .nonNulls when minSdk is Dart 3.0
+        // ignore: deprecated_member_use
         .whereNotNull()
         .toList();
   }

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -503,7 +503,10 @@ class WiredashState extends State<Wiredash> {
       widget.options?.locale,
       // Use what users see in the app
       _services.wiredashModel.sessionMetaData?.appLocale,
-    ].whereNotNull();
+    ]
+        // Switch to .nonNulls when minSdk is Dart 3.0
+        // ignore: deprecated_member_use
+        .whereNotNull();
 
     for (final locale in localesInOrder) {
       if (_isLocaleSupported(locale)) {

--- a/lib/src/feedback/steps/step_1_feedback_message.dart
+++ b/lib/src/feedback/steps/step_1_feedback_message.dart
@@ -92,6 +92,7 @@ class _Step1FeedbackMessageState extends State<Step1FeedbackMessage>
                 contentPadding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
                 hintStyle: context.text.input.onSurface.copyWith(
+                  // ignore: deprecated_member_use
                   color: context.text.input.onSurface.color?.withOpacity(0.6),
                 ),
                 errorStyle: context.text.inputError.textStyle.copyWith(
@@ -147,8 +148,10 @@ Widget? _getCounterText(
 
   Color getCounterColor() {
     if (remaining >= 150) {
+      // ignore: deprecated_member_use
       return Colors.green.shade400.withOpacity(0.8);
     } else if (remaining >= 50) {
+      // ignore: deprecated_member_use
       return Colors.orange.withOpacity(0.8);
     }
     return context.theme.errorColor;

--- a/lib/src/feedback/steps/step_2_labels.dart
+++ b/lib/src/feedback/steps/step_2_labels.dart
@@ -131,6 +131,7 @@ class _Label extends StatelessWidget {
               border: Border.all(
                 width: 2,
                 // tint
+                // ignore: deprecated_member_use
                 color: context.theme.textOnPrimaryContainerColor.withOpacity(
                   () {
                     if (state.pressed || state.selected) {

--- a/lib/src/feedback/steps/step_3_screenshot_overview.dart
+++ b/lib/src/feedback/steps/step_3_screenshot_overview.dart
@@ -301,11 +301,13 @@ class Elevation extends StatelessWidget {
       decoration: BoxDecoration(
         boxShadow: [
           BoxShadow(
+            // ignore: deprecated_member_use
             color: const Color(0xFF000000).withOpacity(0.04),
             offset: Offset(0, elevation),
             blurRadius: elevation,
           ),
           BoxShadow(
+            // ignore: deprecated_member_use
             color: const Color(0xFF000000).withOpacity(0.10),
             offset: Offset(0, elevation * 3),
             blurRadius: elevation * 3,

--- a/lib/src/feedback/steps/step_5_email.dart
+++ b/lib/src/feedback/steps/step_5_email.dart
@@ -100,6 +100,7 @@ class _Step5EmailState extends State<Step5Email> with TickerProviderStateMixin {
                 contentPadding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
                 hintStyle: context.text.input.onSurface.copyWith(
+                  // ignore: deprecated_member_use
                   color: context.text.input.onSurface.color?.withOpacity(0.6),
                 ),
                 errorStyle: context.text.inputError.textStyle.copyWith(

--- a/lib/src/feedback/ui/color_palette.dart
+++ b/lib/src/feedback/ui/color_palette.dart
@@ -374,8 +374,10 @@ class _AnimatedColorDotState extends State<AnimatedColorDot>
     if (widget.isSelected) {
       color = widget.color;
     } else if (_hovered) {
+      // ignore: deprecated_member_use
       color = Color.alphaBlend(widget.color.withOpacity(0.85), Colors.white);
     } else {
+      // ignore: deprecated_member_use
       color = Color.alphaBlend(widget.color.withOpacity(0.7), Colors.white);
     }
 
@@ -405,6 +407,7 @@ class _AnimatedColorDotState extends State<AnimatedColorDot>
           // outer ring
           child: AnimatedShape(
             color: widget.isSelected
+                // ignore: deprecated_member_use
                 ? outerCircleColor.withOpacity(0.5)
                 : outerCircleColor,
             shape: const StadiumBorder(),

--- a/lib/src/feedback/ui/slider/stroke_width_slider_painter.dart
+++ b/lib/src/feedback/ui/slider/stroke_width_slider_painter.dart
@@ -18,6 +18,7 @@ class StrokeWidthSliderPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
+      // ignore: deprecated_member_use
       ..color = color.withOpacity(0.2)
       ..style = PaintingStyle.stroke
       ..strokeCap = StrokeCap.round
@@ -29,6 +30,7 @@ class StrokeWidthSliderPainter extends CustomPainter {
       paint,
     );
 
+    // ignore: deprecated_member_use
     paint.color = color.withOpacity(0.7);
     canvas.drawLine(
       Offset(0, size.height / 2),

--- a/lib/src/metadata/device_info/device_info.dart
+++ b/lib/src/metadata/device_info/device_info.dart
@@ -163,7 +163,6 @@ class FlutterInfo {
   @override
   int get hashCode =>
       platformLocale.hashCode ^
-      // ignore: deprecated_member_use
       Object.hashAll(platformSupportedLocales) ^
       viewPadding.hashCode ^
       physicalSize.hashCode ^

--- a/lib/src/promoterscore/step_1_rating.dart
+++ b/lib/src/promoterscore/step_1_rating.dart
@@ -238,7 +238,9 @@ class _RatingCardState extends State<RatingCard>
     const animDuration = Duration(milliseconds: 210);
 
     final colorTween = ColorTween(
+      // ignore: deprecated_member_use
       begin: context.theme.primaryColor.withOpacity(0.25),
+      // ignore: deprecated_member_use
       end: context.theme.primaryColor.withOpacity(1.0),
     );
 

--- a/lib/src/promoterscore/step_2_message.dart
+++ b/lib/src/promoterscore/step_2_message.dart
@@ -79,6 +79,7 @@ class _PsStep2MessageState extends State<PsStep2Message>
                 contentPadding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
                 hintStyle: context.text.input.onSurface.copyWith(
+                  // ignore: deprecated_member_use
                   color: context.text.input.onSurface.color?.withOpacity(0.6),
                 ),
                 errorStyle: context.text.inputError.textStyle.copyWith(
@@ -132,8 +133,10 @@ Widget? _getCounterText(
 
   Color getCounterColor() {
     if (remaining >= 150) {
+      // ignore: deprecated_member_use
       return Colors.green.shade400.withOpacity(0.8);
     } else if (remaining >= 50) {
+      // ignore: deprecated_member_use
       return Colors.orange.withOpacity(0.8);
     }
     return context.theme.errorColor;

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -58,6 +58,7 @@ class WiredashTestRobot {
         version: '',
         buildNumber: '',
         buildSignature: '',
+        installerStore: '',
       ),
     );
     TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
Related https://github.com/flutter/flutter/pull/158219

I can't keep it in the code and support the new and old API. This minor feature does not justify bumping the min-sdk version