### PR TITLE
Fix: Issue #393

### DIFF
--- a/lib/src/core/wiredash_controller.dart
+++ b/lib/src/core/wiredash_controller.dart
@@ -173,6 +173,10 @@ class WiredashController {
     final result = FeedbackResult(
       hasSubmittedFeedback: hasSubmittedFeedback,
     );
+
+    // reset the metadata at the end of the feedback flow to avoid leaking metadata between feedbacks
+    resetMetaData();
+
     return result;
   }
 

--- a/lib/src/core/wiredash_controller.dart
+++ b/lib/src/core/wiredash_controller.dart
@@ -150,6 +150,7 @@ class WiredashController {
     bool? inheritCupertinoTheme,
     WiredashFeedbackOptions? options,
   }) async {
+    print(options != null);
     _captureAppTheme(inheritMaterialTheme, inheritCupertinoTheme);
     _captureSessionMetaData();
     _model.feedbackOptionsOverride = options;
@@ -175,7 +176,8 @@ class WiredashController {
     );
 
     // reset the metadata at the end of the feedback flow to avoid leaking metadata between feedbacks
-    resetMetaData();
+    _model.customizableMetaData =
+        _model.customizableMetaData.copyWith(custom: {});
 
     return result;
   }

--- a/test/issues/issue_393_test.dart
+++ b/test/issues/issue_393_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wiredash/wiredash.dart';
+
+import '../util/robot.dart';
+
+void main() {
+  group('issue 393', () {
+    testWidgets('metadata should be encapsulated per opened Wiredash Feedback',
+        (tester) async {
+      final robot = WiredashTestRobot(tester);
+
+      MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+
+      CustomizableWiredashMetaData? metadata;
+      await robot.launchApp(
+        builder: (context) {
+          return Scaffold(
+            body: Column(
+              children: [
+                GestureDetector(
+                  onTap: () async {
+                    final wiredash = Wiredash.of(context);
+                    wiredash.modifyMetaData((metaData) {
+                      return metadata = metaData
+                        ..custom[customMetaData.key] = customMetaData.value;
+                    });
+                    wiredash.show();
+                  },
+                  child: const Text('Feedback'),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+      await robot.openWiredash();
+      expect(metadata!.custom['foo'], 'bar');
+      await robot.closeWiredash();
+
+      customMetaData = const MapEntry('bar', 'foo');
+      await robot.openWiredash();
+      expect(metadata!.custom.length, 1);
+      expect(metadata!.custom['bar'], 'foo');
+    });
+  });
+}

--- a/test/issues/issue_393_test.dart
+++ b/test/issues/issue_393_test.dart
@@ -8,175 +8,250 @@ import '../util/robot.dart';
 
 void main() {
   group('issue 393', () {
-    testWidgets(
-        'metadata should be encapsulated per opened Wiredash Feedback and be merged with collectMetaData',
-        (tester) async {
-      final robot = WiredashTestRobot(tester);
+    group('collectMetaData', () {
+      testWidgets(
+          'metadata should be encapsulated per opened Wiredash Feedback and be merged with collectMetaData and modifyMetaData',
+          (tester) async {
+        final robot = WiredashTestRobot(tester);
 
-      MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+        MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
 
-      await robot.launchApp(
-        collectMetaData: (metaData) {
-          return metaData
-            ..userEmail = "user@mail.com"
-            ..userId = "123"
-            ..custom['foz'] = 'baz';
-        },
-        builder: (context) {
-          return Scaffold(
-            body: Column(
-              children: [
-                GestureDetector(
-                  onTap: () async {
-                    final wiredash = Wiredash.of(context);
-                    wiredash.modifyMetaData((metaData) {
-                      return metaData
-                        ..custom[customMetaData.key] = customMetaData.value;
-                    });
-                    wiredash.show();
-                  },
-                  child: const Text('Feedback'),
-                ),
-              ],
-            ),
-          );
-        },
-      );
-
-      await robot.submitMinimalFeedback();
-      AssertableInvocation latestCall =
-          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
-      final firstFeedback = latestCall[0] as FeedbackItem?;
-      expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
-      expect(firstFeedback.metadata.userId, '123');
-      expect(firstFeedback.metadata.custom!['foz'], 'baz');
-      expect(firstFeedback.metadata.custom!['foo'], 'bar');
-
-      customMetaData = const MapEntry('bar', 'foo');
-
-      await robot.submitMinimalFeedback();
-      latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
-      final secondFeedback = latestCall[0] as FeedbackItem?;
-      expect(secondFeedback!.metadata.userEmail, 'user@mail.com');
-      expect(secondFeedback.metadata.userId, '123');
-      expect(secondFeedback.metadata.custom!['foz'], 'baz');
-      expect(secondFeedback.metadata.custom!['bar'], 'foo');
-    });
-
-    testWidgets(
-        'metadata should be encapsulated per opened Wiredash Feedback and be merged with feedbackOptions.collectMetaData',
-        (tester) async {
-      final robot = WiredashTestRobot(tester);
-
-      MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
-
-      await robot.launchApp(
-        feedbackOptions: WiredashFeedbackOptions(
+        await robot.launchApp(
           collectMetaData: (metaData) {
             return metaData
               ..userEmail = "user@mail.com"
               ..userId = "123"
               ..custom['foz'] = 'baz';
           },
-        ),
-        builder: (context) {
-          return Scaffold(
-            body: Column(
-              children: [
-                GestureDetector(
-                  onTap: () async {
-                    final wiredash = Wiredash.of(context);
-                    wiredash.modifyMetaData((metaData) {
-                      return metaData
-                        ..custom[customMetaData.key] = customMetaData.value;
-                    });
-                    wiredash.show();
-                  },
-                  child: const Text('Feedback'),
-                ),
-              ],
-            ),
-          );
-        },
-      );
+          builder: (context) {
+            return Scaffold(
+              body: Column(
+                children: [
+                  GestureDetector(
+                    onTap: () async {
+                      final wiredash = Wiredash.of(context);
 
-      await robot.submitMinimalFeedback();
-      AssertableInvocation latestCall =
-          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
-      final firstFeedback = latestCall[0] as FeedbackItem?;
-      expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
-      expect(firstFeedback.metadata.userId, '123');
-      expect(firstFeedback.metadata.custom!['foz'], 'baz');
-      expect(firstFeedback.metadata.custom!['foo'], 'bar');
+                      wiredash.modifyMetaData(
+                        (metaData) {
+                          return metaData
+                            ..custom[customMetaData.key] = customMetaData.value;
+                        },
+                      );
+                      wiredash.show();
+                    },
+                    child: const Text('Feedback'),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
 
-      customMetaData = const MapEntry('bar', 'foo');
+        await robot.submitMinimalFeedback();
+        AssertableInvocation latestCall =
+            robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final firstFeedback = latestCall[0] as FeedbackItem?;
 
-      await robot.submitMinimalFeedback();
-      latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
-      final secondFeedback = latestCall[0] as FeedbackItem?;
-      expect(secondFeedback!.metadata.custom, hasLength(2));
-      expect(secondFeedback.metadata.userEmail, 'user@mail.com');
-      expect(secondFeedback.metadata.userId, '123');
-      expect(secondFeedback.metadata.custom!['foz'], 'baz');
-      expect(secondFeedback.metadata.custom!['bar'], 'foo');
-    });
+        expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
+        expect(firstFeedback.metadata.userId, '123');
+        expect(firstFeedback.metadata.custom!['foz'], 'baz');
+        expect(firstFeedback.metadata.custom!['foo'], 'bar');
 
-    testWidgets(
-        'metadata should be encapsulated per opened Wiredash Feedback and be merged with feedbackOptions.collectMetaData',
-        (tester) async {
-      final robot = WiredashTestRobot(tester);
+        customMetaData = const MapEntry('bar', 'foo');
 
-      MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+        await robot.submitMinimalFeedback();
+        latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final secondFeedback = latestCall[0] as FeedbackItem?;
+        expect(secondFeedback!.metadata.custom, hasLength(2));
 
-      await robot.launchApp(
-        feedbackOptions: WiredashFeedbackOptions(
+        expect(secondFeedback.metadata.userEmail, 'user@mail.com');
+        expect(secondFeedback.metadata.userId, '123');
+        expect(secondFeedback.metadata.custom!['foz'], 'baz');
+        expect(secondFeedback.metadata.custom!['bar'], 'foo');
+      });
+
+      testWidgets(
+          'metadata should be encapsulated per opened Wiredash Feedback and be merged with collectMetaData',
+          (tester) async {
+        final robot = WiredashTestRobot(tester);
+
+        MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+
+        await robot.launchApp(
           collectMetaData: (metaData) {
             return metaData
               ..userEmail = "user@mail.com"
               ..userId = "123"
               ..custom['foz'] = 'baz';
           },
-        ),
-        builder: (context) {
-          return Scaffold(
-            body: Column(
-              children: [
-                GestureDetector(
-                  onTap: () async {
-                    final wiredash = Wiredash.of(context);
-                    wiredash.modifyMetaData((metaData) {
-                      return metaData
-                        ..custom[customMetaData.key] = customMetaData.value;
-                    });
-                    wiredash.show();
-                  },
-                  child: const Text('Feedback'),
-                ),
-              ],
-            ),
-          );
-        },
-      );
+          builder: (context) {
+            return Scaffold(
+              body: Column(
+                children: [
+                  GestureDetector(
+                    onTap: () async {
+                      final wiredash = Wiredash.of(context);
+                      wiredash.show(
+                        options: WiredashFeedbackOptions(
+                          collectMetaData: (metaData) {
+                            return metaData
+                              ..custom[customMetaData.key] =
+                                  customMetaData.value;
+                          },
+                        ),
+                      );
+                    },
+                    child: const Text('Feedback'),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
 
-      await robot.submitMinimalFeedback();
-      AssertableInvocation latestCall =
-          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
-      final firstFeedback = latestCall[0] as FeedbackItem?;
-      expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
-      expect(firstFeedback.metadata.userId, '123');
-      expect(firstFeedback.metadata.custom!['foz'], 'baz');
-      expect(firstFeedback.metadata.custom!['foo'], 'bar');
+        await robot.submitMinimalFeedback();
+        AssertableInvocation latestCall =
+            robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final firstFeedback = latestCall[0] as FeedbackItem?;
 
-      customMetaData = const MapEntry('bar', 'foo');
+        expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
+        expect(firstFeedback.metadata.userId, '123');
+        expect(firstFeedback.metadata.custom!['foz'], 'baz');
+        expect(firstFeedback.metadata.custom!['foo'], 'bar');
 
-      await robot.submitMinimalFeedback();
-      latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
-      final secondFeedback = latestCall[0] as FeedbackItem?;
-      expect(secondFeedback!.metadata.custom, hasLength(2));
-      expect(secondFeedback.metadata.userEmail, 'user@mail.com');
-      expect(secondFeedback.metadata.userId, '123');
-      expect(secondFeedback.metadata.custom!['foz'], 'baz');
-      expect(secondFeedback.metadata.custom!['bar'], 'foo');
+        customMetaData = const MapEntry('bar', 'foo');
+
+        await robot.submitMinimalFeedback();
+        latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final secondFeedback = latestCall[0] as FeedbackItem?;
+
+        expect(secondFeedback!.metadata.custom, hasLength(2));
+        expect(secondFeedback.metadata.userEmail, 'user@mail.com');
+        expect(secondFeedback.metadata.userId, '123');
+        expect(secondFeedback.metadata.custom!['foz'], 'baz');
+        expect(secondFeedback.metadata.custom!['bar'], 'foo');
+      });
+    });
+    group('WiredashFeedbackOptions.collectMetaData', () {
+      testWidgets('''
+          metadata should be encapsulated per opened Wiredash Feedback 
+          and be merged with WiredashFeedbackOptions.collectMetaData when calling modifyMetaData''',
+          (tester) async {
+        final robot = WiredashTestRobot(tester);
+
+        MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+
+        await robot.launchApp(
+          feedbackOptions: WiredashFeedbackOptions(
+            collectMetaData: (metaData) {
+              return metaData
+                ..userEmail = "user@mail.com"
+                ..userId = "123"
+                ..custom['foz'] = 'baz';
+            },
+          ),
+          builder: (context) {
+            return Scaffold(
+              body: Column(
+                children: [
+                  GestureDetector(
+                    onTap: () async {
+                      final wiredash = Wiredash.of(context);
+                      wiredash.modifyMetaData(
+                        (metaData) {
+                          return metaData
+                            ..custom[customMetaData.key] = customMetaData.value;
+                        },
+                      );
+                      wiredash.show();
+                    },
+                    child: const Text('Feedback'),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+
+        await robot.submitMinimalFeedback();
+        AssertableInvocation latestCall =
+            robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final firstFeedback = latestCall[0] as FeedbackItem?;
+
+        expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
+        expect(firstFeedback.metadata.userId, '123');
+        expect(firstFeedback.metadata.custom!['foz'], 'baz');
+        expect(firstFeedback.metadata.custom!['foo'], 'bar');
+
+        customMetaData = const MapEntry('bar', 'foo');
+
+        await robot.submitMinimalFeedback();
+        latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final secondFeedback = latestCall[0] as FeedbackItem?;
+        expect(secondFeedback!.metadata.custom, hasLength(2));
+        expect(secondFeedback.metadata.userEmail, 'user@mail.com');
+        expect(secondFeedback.metadata.userId, '123');
+        expect(secondFeedback.metadata.custom!['foz'], 'baz');
+        expect(secondFeedback.metadata.custom!['bar'], 'foo');
+      });
+
+      testWidgets('''
+      metadata should be encapsulated per opened Wiredash Feedback
+      and feedbackOptions of show should override WiredashFeedbackOptions.collectMetaData''',
+          (tester) async {
+        final robot = WiredashTestRobot(tester);
+
+        MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+
+        await robot.launchApp(
+          feedbackOptions: WiredashFeedbackOptions(
+            collectMetaData: (metaData) {
+              return metaData
+                ..userEmail = "user@mail.com"
+                ..userId = "123"
+                ..custom['foz'] = 'baz';
+            },
+          ),
+          builder: (context) {
+            return Scaffold(
+              body: Column(
+                children: [
+                  GestureDetector(
+                    onTap: () async {
+                      final wiredash = Wiredash.of(context);
+                      wiredash.show(
+                        options: WiredashFeedbackOptions(
+                          collectMetaData: (metaData) {
+                            return metaData
+                              ..custom[customMetaData.key] =
+                                  customMetaData.value;
+                          },
+                        ),
+                      );
+                    },
+                    child: const Text('Feedback'),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+
+        await robot.submitMinimalFeedback();
+        AssertableInvocation latestCall =
+            robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final firstFeedback = latestCall[0] as FeedbackItem?;
+
+        expect(firstFeedback!.metadata.custom!['foo'], 'bar');
+
+        customMetaData = const MapEntry('bar', 'foo');
+
+        await robot.submitMinimalFeedback();
+        latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+        final secondFeedback = latestCall[0] as FeedbackItem?;
+        expect(secondFeedback!.metadata.custom, hasLength(1));
+        expect(secondFeedback.metadata.custom!['bar'], 'foo');
+      });
     });
 
     testWidgets(
@@ -194,11 +269,12 @@ void main() {
                 GestureDetector(
                   onTap: () async {
                     final wiredash = Wiredash.of(context);
-                    wiredash.modifyMetaData((metaData) {
-                      return metaData
-                        ..custom[customMetaData.key] = customMetaData.value;
-                    });
-                    wiredash.show();
+                    wiredash.show(options: WiredashFeedbackOptions(
+                      collectMetaData: (metaData) {
+                        return metaData
+                          ..custom[customMetaData.key] = customMetaData.value;
+                      },
+                    ));
                   },
                   child: const Text('Feedback'),
                 ),

--- a/test/issues/issue_393_test.dart
+++ b/test/issues/issue_393_test.dart
@@ -77,6 +77,8 @@ void main() {
 
         MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
 
+        int collectMetaDataFunctionCalls = 0;
+
         await robot.launchApp(
           collectMetaData: (metaData) {
             return metaData
@@ -94,6 +96,7 @@ void main() {
                       wiredash.show(
                         options: WiredashFeedbackOptions(
                           collectMetaData: (metaData) {
+                            collectMetaDataFunctionCalls++;
                             return metaData
                               ..custom[customMetaData.key] =
                                   customMetaData.value;
@@ -113,6 +116,8 @@ void main() {
         AssertableInvocation latestCall =
             robot.mockServices.mockApi.sendFeedbackInvocations.latest;
         final firstFeedback = latestCall[0] as FeedbackItem?;
+
+        expect(collectMetaDataFunctionCalls, 1); // we fail here
 
         expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
         expect(firstFeedback.metadata.userId, '123');

--- a/test/issues/issue_393_test.dart
+++ b/test/issues/issue_393_test.dart
@@ -1,19 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wiredash/src/feedback/feedback_model.dart';
 import 'package:wiredash/wiredash.dart';
 
+import '../util/invocation_catcher.dart';
 import '../util/robot.dart';
 
 void main() {
   group('issue 393', () {
-    testWidgets('metadata should be encapsulated per opened Wiredash Feedback',
+    testWidgets(
+        'metadata should be encapsulated per opened Wiredash Feedback and be merged with collectMetaData',
         (tester) async {
       final robot = WiredashTestRobot(tester);
 
       MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
 
-      CustomizableWiredashMetaData? metadata;
       await robot.launchApp(
+        collectMetaData: (metaData) {
+          return metaData
+            ..userEmail = "user@mail.com"
+            ..userId = "123"
+            ..custom['foz'] = 'baz';
+        },
         builder: (context) {
           return Scaffold(
             body: Column(
@@ -22,7 +30,7 @@ void main() {
                   onTap: () async {
                     final wiredash = Wiredash.of(context);
                     wiredash.modifyMetaData((metaData) {
-                      return metadata = metaData
+                      return metaData
                         ..custom[customMetaData.key] = customMetaData.value;
                     });
                     wiredash.show();
@@ -34,14 +42,194 @@ void main() {
           );
         },
       );
-      await robot.openWiredash();
-      expect(metadata!.custom['foo'], 'bar');
-      await robot.closeWiredash();
+
+      await robot.submitMinimalFeedback();
+      AssertableInvocation latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final firstFeedback = latestCall[0] as FeedbackItem?;
+      expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
+      expect(firstFeedback.metadata.userId, '123');
+      expect(firstFeedback.metadata.custom!['foz'], 'baz');
+      expect(firstFeedback.metadata.custom!['foo'], 'bar');
 
       customMetaData = const MapEntry('bar', 'foo');
-      await robot.openWiredash();
-      expect(metadata!.custom.length, 1);
-      expect(metadata!.custom['bar'], 'foo');
+
+      await robot.submitMinimalFeedback();
+      latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final secondFeedback = latestCall[0] as FeedbackItem?;
+      expect(secondFeedback!.metadata.userEmail, 'user@mail.com');
+      expect(secondFeedback.metadata.userId, '123');
+      expect(secondFeedback.metadata.custom!['foz'], 'baz');
+      expect(secondFeedback.metadata.custom!['bar'], 'foo');
+    });
+
+    testWidgets(
+        'metadata should be encapsulated per opened Wiredash Feedback and be merged with feedbackOptions.collectMetaData',
+        (tester) async {
+      final robot = WiredashTestRobot(tester);
+
+      MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+
+      await robot.launchApp(
+        feedbackOptions: WiredashFeedbackOptions(
+          collectMetaData: (metaData) {
+            return metaData
+              ..userEmail = "user@mail.com"
+              ..userId = "123"
+              ..custom['foz'] = 'baz';
+          },
+        ),
+        builder: (context) {
+          return Scaffold(
+            body: Column(
+              children: [
+                GestureDetector(
+                  onTap: () async {
+                    final wiredash = Wiredash.of(context);
+                    wiredash.modifyMetaData((metaData) {
+                      return metaData
+                        ..custom[customMetaData.key] = customMetaData.value;
+                    });
+                    wiredash.show();
+                  },
+                  child: const Text('Feedback'),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      await robot.submitMinimalFeedback();
+      AssertableInvocation latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final firstFeedback = latestCall[0] as FeedbackItem?;
+      expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
+      expect(firstFeedback.metadata.userId, '123');
+      expect(firstFeedback.metadata.custom!['foz'], 'baz');
+      expect(firstFeedback.metadata.custom!['foo'], 'bar');
+
+      customMetaData = const MapEntry('bar', 'foo');
+
+      await robot.submitMinimalFeedback();
+      latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final secondFeedback = latestCall[0] as FeedbackItem?;
+      expect(secondFeedback!.metadata.custom, hasLength(2));
+      expect(secondFeedback.metadata.userEmail, 'user@mail.com');
+      expect(secondFeedback.metadata.userId, '123');
+      expect(secondFeedback.metadata.custom!['foz'], 'baz');
+      expect(secondFeedback.metadata.custom!['bar'], 'foo');
+    });
+
+    testWidgets(
+        'metadata should be encapsulated per opened Wiredash Feedback and be merged with feedbackOptions.collectMetaData',
+        (tester) async {
+      final robot = WiredashTestRobot(tester);
+
+      MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+
+      await robot.launchApp(
+        feedbackOptions: WiredashFeedbackOptions(
+          collectMetaData: (metaData) {
+            return metaData
+              ..userEmail = "user@mail.com"
+              ..userId = "123"
+              ..custom['foz'] = 'baz';
+          },
+        ),
+        builder: (context) {
+          return Scaffold(
+            body: Column(
+              children: [
+                GestureDetector(
+                  onTap: () async {
+                    final wiredash = Wiredash.of(context);
+                    wiredash.modifyMetaData((metaData) {
+                      return metaData
+                        ..custom[customMetaData.key] = customMetaData.value;
+                    });
+                    wiredash.show();
+                  },
+                  child: const Text('Feedback'),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      await robot.submitMinimalFeedback();
+      AssertableInvocation latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final firstFeedback = latestCall[0] as FeedbackItem?;
+      expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
+      expect(firstFeedback.metadata.userId, '123');
+      expect(firstFeedback.metadata.custom!['foz'], 'baz');
+      expect(firstFeedback.metadata.custom!['foo'], 'bar');
+
+      customMetaData = const MapEntry('bar', 'foo');
+
+      await robot.submitMinimalFeedback();
+      latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final secondFeedback = latestCall[0] as FeedbackItem?;
+      expect(secondFeedback!.metadata.custom, hasLength(2));
+      expect(secondFeedback.metadata.userEmail, 'user@mail.com');
+      expect(secondFeedback.metadata.userId, '123');
+      expect(secondFeedback.metadata.custom!['foz'], 'baz');
+      expect(secondFeedback.metadata.custom!['bar'], 'foo');
+    });
+
+    testWidgets(
+        'metadata should be encapsulated per opened Wiredash Feedback and be merged with setUserData',
+        (tester) async {
+      final robot = WiredashTestRobot(tester);
+
+      MapEntry<String, String> customMetaData = const MapEntry('foo', 'bar');
+
+      await robot.launchApp(
+        builder: (context) {
+          return Scaffold(
+            body: Column(
+              children: [
+                GestureDetector(
+                  onTap: () async {
+                    final wiredash = Wiredash.of(context);
+                    wiredash.modifyMetaData((metaData) {
+                      return metaData
+                        ..custom[customMetaData.key] = customMetaData.value;
+                    });
+                    wiredash.show();
+                  },
+                  child: const Text('Feedback'),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+
+      robot.wiredashController.setUserProperties(
+        userEmail: "user@mail.com",
+        userId: "123",
+      );
+
+      await robot.submitMinimalFeedback();
+      AssertableInvocation latestCall =
+          robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final firstFeedback = latestCall[0] as FeedbackItem?;
+      expect(firstFeedback!.metadata.userEmail, 'user@mail.com');
+      expect(firstFeedback.metadata.userId, '123');
+      expect(firstFeedback.metadata.custom!['foo'], 'bar');
+
+      customMetaData = const MapEntry('bar', 'foo');
+
+      await robot.submitMinimalFeedback();
+      latestCall = robot.mockServices.mockApi.sendFeedbackInvocations.latest;
+      final secondFeedback = latestCall[0] as FeedbackItem?;
+      expect(secondFeedback!.metadata.custom, hasLength(1));
+      expect(secondFeedback.metadata.userEmail, 'user@mail.com');
+      expect(secondFeedback.metadata.userId, '123');
+      expect(secondFeedback.metadata.custom!['bar'], 'foo');
     });
   });
 }


### PR DESCRIPTION
- Fixes the Bug described in Issue #393 where Metadata that was set in `show()` leaked to consecutive calls of `show()`.
- Added a test to reproduce the issue and validate the fix