### PR TITLE
chore: bump package_info_plus to <11 and device_info_plus to <14

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   async: ^2.0.0
   clock: ^1.1.0
   collection: ">=1.15.0 <2.0.0"
-  device_info_plus: ">=8.0.0 <13.0.0"
+  device_info_plus: ">=8.0.0 <14.0.0"
   file: ">=6.0.0 <8.0.0"
   flutter:
     sdk: flutter
@@ -30,7 +30,7 @@ dependencies:
   intl: ">=0.16.0 <2.0.0" # whatever "sdk: flutter" depends on
   material_color_utilities: ">=0.1.2 <1.0.0"
   nanoid2: ^2.0.1
-  package_info_plus: ">=3.0.0 <10.0.0"
+  package_info_plus: ">=3.0.0 <11.0.0"
   path_provider: ">=2.0.0 <3.0.0"
   platform: ">=3.1.0 <5.0.0"
   shared_preferences: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
Widens the dependency ranges to allow the latest `package_info_plus` (10.x) and `device_info_plus` (13.x).

  - `package_info_plus`: `>=3.0.0 <10.0.0` → `>=3.0.0 <11.0.0`
  - `device_info_plus`: `>=8.0.0 <13.0.0` → `>=8.0.0 <14.0.0`

  Both have to move together: `package_info_plus 10.x` requires `win32 ^6.0.0`, which conflicts with every `device_info_plus` below 13.x. Bumping only `package_info_plus` would leave 10.x unreachable for users.

  The `PackageInfo.fromPlatform()` API and the `DeviceInfoPlugin().deviceInfo` types used in `lib/src/metadata/meta_data_collector.dart` are unchanged in the new majors, so no source changes are needed.

  The lower bounds are intentionally kept wide so apps on older Flutter/Dart SDKs (including the Flutter 3.0 path tested by the `pr-min` CI job) continue to resolve to compatible 3.x–9.x / 8.x–12.x versions via the pub solver.

  ## Breaking change notice

  Apps that pick up `package_info_plus >= 10.0.0` or `device_info_plus >= 13.0.0` inherit those plugins' platform requirements:

  - `package_info_plus 10.x`: Flutter >=3.38.1, Dart >=3.10.0, iOS >=13.0, macOS >=10.15
  - `win32 6.x` is transitive on Windows

  ## Test plan

  - [x] `flutter pub get` resolves to `package_info_plus 10.1.0` + `device_info_plus 13.1.0` + `win32 6.2.0` with the new ranges
  - [x] `flutter analyze lib/` — no new issues
  - [x] `flutter test` — passes (4 Windows-only failures are pre-existing on `stable` baseline, CI runs on Linux/macOS)
  - [x] `examples/theming` web build (matches `pr-stable` CI step)