### PR TITLE
Fix stale feedback page callback after submission

### DIFF
--- a/lib/src/feedback/feedback_flow.dart
+++ b/lib/src/feedback/feedback_flow.dart
@@ -62,19 +62,23 @@ class _WiredashFeedbackFlowState extends State<WiredashFeedbackFlow>
       stepCount: context.watchFeedbackModel.steps.length,
       pageIndex: _index,
       onPageChanged: (index) {
+        final feedbackModel = context.readFeedbackModel;
+        if (index < 0 || index >= feedbackModel.steps.length) {
+          return;
+        }
         setState(() {
           _index = index;
-          final stepIndex = context.readFeedbackModel.currentStepIndex;
+          final stepIndex = feedbackModel.currentStepIndex;
           if (stepIndex == null) {
             return;
           }
 
           if (stepIndex < _index) {
-            context.readFeedbackModel.goToNextStep();
+            feedbackModel.goToNextStep();
           }
 
           if (stepIndex > _index) {
-            context.readFeedbackModel.goToPreviousStep();
+            feedbackModel.goToPreviousStep();
           }
         });
       },

--- a/test/feedback_flow_test.dart
+++ b/test/feedback_flow_test.dart
@@ -659,6 +659,42 @@ void main() {
       await gesture.up(); // let go of the app
     });
 
+    testWidgets('Ignore stale page callback while submitting feedback',
+        (tester) async {
+      final robot = await WiredashTestRobot(tester).launchApp();
+
+      await robot.goToMinimalFeedbackSubmitStep();
+      final submission = await robot.startPendingFeedbackSubmission();
+
+      // Tapping submit starts the transition from the submit page to the
+      // submitting page. Advance the animation, but stop before it switches
+      // pages and invokes onPageChanged.
+      final pageIndex = robot.pageIndex;
+      final pageCount = robot.pageCount;
+      robot.verifyHasNextPage();
+      await tester.pump(const Duration(milliseconds: 30));
+      robot.verifyOnPage(pageIndex);
+
+      // The race happens here: the API responds while the page transition is
+      // still running. The model collapses its steps to the single success
+      // page, while the mounted LarryPageView still has the previous pages.
+      submission.complete();
+      await tester.idle();
+      expect(robot.services.feedbackModel.steps, hasLength(1));
+      robot.verifyPageCount(pageCount);
+
+      // Let the old transition finish. Its stale onPageChanged callback must
+      // be ignored because that next page no longer exists in the model.
+      await tester.pump(const Duration(milliseconds: 80));
+      expect(tester.takeException(), isNull);
+      expect(
+        robot.services.feedbackModel.feedbackFlowStatus,
+        FeedbackFlowStatus.submittingAndRetry,
+      );
+
+      await robot.waitUntilWiredashIsClosed();
+    });
+
     testWidgets('Send environment', (tester) async {
       final robot = await WiredashTestRobot(tester).launchApp(
         environment: 'staging',

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -271,6 +271,25 @@ class WiredashTestRobot {
   WidgetSelector<LarryPageView> get _spotPageView =>
       _spotBackdrop.spot<LarryPageView>();
 
+  LarryPageView get pageView =>
+      tester.widget<LarryPageView>(_spotPageView.finder);
+
+  int get pageIndex => pageView.pageIndex;
+
+  int get pageCount => pageView.stepCount;
+
+  void verifyOnPage(int index) {
+    expect(pageIndex, index);
+  }
+
+  void verifyHasNextPage() {
+    expect(pageIndex + 1, lessThan(pageCount));
+  }
+
+  void verifyPageCount(int count) {
+    expect(pageCount, count);
+  }
+
   Wiredash get widget {
     final element = find.byType(Wiredash).evaluate().first as StatefulElement;
     return element.widget as Wiredash;
@@ -307,13 +326,31 @@ class WiredashTestRobot {
   }
 
   Future<void> submitMinimalFeedback() async {
+    await goToMinimalFeedbackSubmitStep();
+    await submitFeedback();
+    await waitUntilWiredashIsClosed();
+  }
+
+  Future<void> goToMinimalFeedbackSubmitStep() async {
     await openWiredash();
     await enterFeedbackMessage('test message');
     await goToNextStep();
     await skipScreenshot();
     await skipEmail();
-    await submitFeedback();
-    await waitUntilWiredashIsClosed();
+  }
+
+  Future<PendingFeedbackSubmission> startPendingFeedbackSubmission() async {
+    final sendFeedback = Completer<void>();
+    mockServices.mockApi.sendFeedbackInvocations.interceptor =
+        (_) => sendFeedback.future;
+    await _tapSubmitFeedbackButton();
+    await tester.pump();
+
+    while (mockServices.mockApi.sendFeedbackInvocations.count == 0) {
+      await tester.pump();
+    }
+
+    return PendingFeedbackSubmission(sendFeedback);
   }
 
   Future<void> openWiredash() async {
@@ -446,6 +483,12 @@ class WiredashTestRobot {
 
   /// Actually calling [FeedbackModel.submitFeedback]
   Future<void> submitFeedback() async {
+    await _tapSubmitFeedbackButton();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> _tapSubmitFeedbackButton() async {
     final step = _spotPageView.spot<Step6Submit>()..existsOnce();
     await act.tap(
       step.spot<TronButton>(
@@ -453,8 +496,6 @@ class WiredashTestRobot {
       ).last(),
     );
     print('submit feedback');
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
   }
 
   Future<void> skipEmail({bool catchError = true}) async {
@@ -704,6 +745,16 @@ class WiredashTestRobot {
 
   Future<void> tapText(String text) {
     return act.tap(spotText(text));
+  }
+}
+
+class PendingFeedbackSubmission {
+  PendingFeedbackSubmission(this._sendFeedback);
+
+  final Completer<void> _sendFeedback;
+
+  void complete() {
+    _sendFeedback.complete();
   }
 }
 


### PR DESCRIPTION
A feedback submission can finish while the transition to the submitting page is still running. Successful submission collapses the feedback stack to one page, but the old animation can still emit its page-change callback and attempt to advance past the end of that stack.

Ignore page-change callbacks whose target no longer exists in the current feedback stack.

Before:
```text
Bad state: reached the end of the stack (length 1)
```

After: the stale animation callback is ignored and the success state remains visible.