### PR TITLE
Deliver background-isolate analytics events without delay

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Build
         run: cd examples/theming && ./../../wiresdk flutter build web
 
-  pr-stable-integration:
+  pr-stable-integration-macos:
     # Avoid macos-15: `flutter test -d macos` hits "Failed to foreground
     # app; open returned 1" and then hangs forever waiting for the
     # VM-service handshake.
@@ -81,6 +81,32 @@ jobs:
         timeout-minutes: 10
         working-directory: examples/theming
         run: ./../../wiresdk flutter test -d macos integration_test
+
+  pr-stable-integration-linux:
+    # Runs the integration tests on Linux desktop, where shared_preferences
+    # keeps a per-isolate cache. This guards the background-isolate analytics
+    # path (events_on_isolate_test.dart) on the platform that exposed the bug.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - name: Install Linux desktop dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev xvfb
+      - name: Flutter version
+        run: flutter doctor -v
+      - name: Enable Linux desktop
+        run: flutter config --enable-linux-desktop
+      - name: Download dependencies
+        run: ./wiresdk deps
+      - name: Run integration test
+        timeout-minutes: 10
+        working-directory: examples/theming
+        run: xvfb-run -a ./../../wiresdk flutter test -d linux integration_test
 
   pr-beta:
     runs-on: ubuntu-latest

--- a/examples/theming/integration_test/events_on_isolate_test.dart
+++ b/examples/theming/integration_test/events_on_isolate_test.dart
@@ -1,38 +1,267 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/wiredash.dart';
+import 'package:wiredash_theming/main.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('track event from isolate', (tester) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.clear();
-    // do not fire first launch event
-    await prefs.setString('_wiredashAppUsageID', 'asdfasdfasdfasdf');
+  testWidgets(
+      'event tracked from a background isolate is written to disk '
+      'where the main isolate can read it', (tester) async {
+    final eventsDir = await _resetEventState();
 
     final token = ServicesBinding.rootIsolateToken!;
     await tester.runAsync(() async {
-      await compute(
-        (RootIsolateToken token) async {
-          BackgroundIsolateBinaryMessenger.ensureInitialized(token);
-          await Wiredash.trackEvent('test_event');
-        },
-        token,
-      );
+      await compute(_trackEventOnBackgroundIsolate, token);
     });
 
-    await tester.pumpAndSettle(Duration(seconds: 1));
+    // The main isolate reads the file the background isolate wrote, fresh from
+    // disk. With shared_preferences on Linux and Windows the main isolate's
+    // in-memory cache doesn't pick up that write until the process restarts, so
+    // the upload was delayed until the next app launch instead of being prompt.
+    final eventFiles = _eventFiles(eventsDir);
+    expect(eventFiles, hasLength(1));
 
-    // has recorded one event from isolate
-    await prefs.reload();
-    final events = prefs
-        .getKeys()
-        .where((element) => element.startsWith('io.wiredash.events.default'))
-        .toList();
-    expect(events, hasLength(1));
+    // The event keeps the environment it was given on the background isolate, so
+    // it is later submitted to the API with that exact environment.
+    final event = jsonDecode(eventFiles.single.readAsStringSync())
+        as Map<String, Object?>;
+    expect(event['eventName'], 'test_event');
+    expect(event['environment'], 'background-isolate-env');
   });
+
+  testWidgets(
+      'event tracked from a background isolate reaches the mounted Wiredash '
+      'widget on the main isolate and is uploaded to the backend',
+      (tester) async {
+    await _resetEventState();
+
+    // Intercept the real dart:io HttpClient (package:http's default Client uses
+    // it under the hood) so we can observe the actual network request without
+    // hitting the backend.
+    final captured = Completer<_CapturedRequest>();
+    HttpOverrides.global = _CapturingHttpOverrides((request) {
+      final isSendEvents = request.url.path.endsWith('/sendEvents');
+      if (isSendEvents &&
+          request.body.contains('test_event') &&
+          !captured.isCompleted) {
+        captured.complete(request);
+      }
+    });
+    addTearDown(() => HttpOverrides.global = null);
+
+    // Mount the real app so a Wiredash instance is registered on the main
+    // isolate and listens for the background isolate's wake-up ping.
+    await tester.pumpWidget(WiredashExampleApp());
+    await tester.pump();
+
+    final token = ServicesBinding.rootIsolateToken!;
+    late final _CapturedRequest request;
+    await tester.runAsync(() async {
+      // Track on a background isolate. After saving the event the SDK pings the
+      // main isolate, which reloads the event from disk and uploads it without
+      // waiting for the next lifecycle flush.
+      await compute(_trackEventOnBackgroundIsolate, token);
+      request = await captured.future.timeout(const Duration(seconds: 20));
+    });
+
+    // Full circle: the event the background isolate wrote left the device as a
+    // POST to the Wiredash backend, carrying the event name and the exact
+    // environment it was given on the background isolate.
+    expect(request.method, 'POST');
+    expect(request.url.host, 'api.wiredash.io');
+    expect(request.url.path, endsWith('/sendEvents'));
+    expect(request.headers['project'], isNotEmpty);
+    expect(request.body, contains('test_event'));
+    expect(request.body, contains('background-isolate-env'));
+  });
+}
+
+/// Tracks a single event from a background isolate.
+///
+/// Top-level so it can be passed to [compute], which can only run functions that
+/// are sendable across isolates.
+Future<void> _trackEventOnBackgroundIsolate(RootIsolateToken token) async {
+  BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+  await Wiredash.trackEvent(
+    'test_event',
+    environment: 'background-isolate-env',
+  );
+}
+
+/// Clears any events left over from a previous run and suppresses the automatic
+/// first-launch event, so the tracked event is the only one in play.
+Future<Directory> _resetEventState() async {
+  final supportDir = await getApplicationSupportDirectory();
+  final eventsDir = Directory(p.join(supportDir.path, 'wiredash', 'events'));
+  if (eventsDir.existsSync()) {
+    eventsDir.deleteSync(recursive: true);
+  }
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString('_wiredashAppUsageID', 'asdfasdfasdfasdf');
+  return eventsDir;
+}
+
+List<File> _eventFiles(Directory eventsDir) {
+  if (!eventsDir.existsSync()) {
+    return [];
+  }
+  return eventsDir
+      .listSync()
+      .whereType<File>()
+      .where((file) => p.basename(file.path).contains('io.wiredash.events'))
+      .toList();
+}
+
+/// What the SDK actually sent over the wire, captured by [_CapturingHttpOverrides].
+class _CapturedRequest {
+  _CapturedRequest({
+    required this.method,
+    required this.url,
+    required this.headers,
+    required this.body,
+  });
+
+  final String method;
+  final Uri url;
+  final Map<String, String> headers;
+  final String body;
+}
+
+/// Routes every dart:io HttpClient request through a fake that records it and
+/// answers with an empty `200`, so no request leaves the machine.
+class _CapturingHttpOverrides extends HttpOverrides {
+  _CapturingHttpOverrides(this.onRequest);
+
+  final void Function(_CapturedRequest request) onRequest;
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return _FakeHttpClient(onRequest);
+  }
+}
+
+class _FakeHttpClient implements HttpClient {
+  _FakeHttpClient(this.onRequest);
+
+  final void Function(_CapturedRequest request) onRequest;
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) async {
+    return _FakeHttpClientRequest(method, url, onRequest);
+  }
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpClientRequest implements HttpClientRequest {
+  _FakeHttpClientRequest(this.method, this.uri, this._onRequest);
+
+  @override
+  final String method;
+
+  @override
+  final Uri uri;
+
+  final void Function(_CapturedRequest request) _onRequest;
+
+  @override
+  final HttpHeaders headers = _FakeHttpHeaders();
+
+  final List<int> _body = [];
+
+  @override
+  bool followRedirects = true;
+
+  @override
+  int maxRedirects = 5;
+
+  @override
+  int contentLength = -1;
+
+  @override
+  bool persistentConnection = true;
+
+  @override
+  void add(List<int> data) => _body.addAll(data);
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await for (final chunk in stream) {
+      _body.addAll(chunk);
+    }
+  }
+
+  @override
+  Future<HttpClientResponse> close() async {
+    _onRequest(
+      _CapturedRequest(
+        method: method,
+        url: uri,
+        headers: (headers as _FakeHttpHeaders).values,
+        body: utf8.decode(_body),
+      ),
+    );
+    return _FakeHttpClientResponse();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpHeaders implements HttpHeaders {
+  final Map<String, String> values = {};
+
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
+    values[name] = value.toString();
+  }
+
+  @override
+  void forEach(void Function(String name, List<String> values) action) {
+    values.forEach((name, value) => action(name, [value]));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpClientResponse extends StreamView<List<int>>
+    implements HttpClientResponse {
+  _FakeHttpClientResponse() : super(Stream.value(utf8.encode('{}')));
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  String get reasonPhrase => 'OK';
+
+  @override
+  int get contentLength => -1;
+
+  @override
+  bool get isRedirect => false;
+
+  @override
+  bool get persistentConnection => false;
+
+  @override
+  HttpHeaders get headers => _FakeHttpHeaders();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/examples/theming/pubspec.yaml
+++ b/examples/theming/pubspec.yaml
@@ -19,6 +19,8 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   lint: '>=1.0.0 <=3.0.0'
+  path: ">=1.8.0 <2.0.0"
+  path_provider: ">=2.0.0 <3.0.0"
 
 flutter:
   uses-material-design: true

--- a/lib/src/an4lytics/an4lytics.dart
+++ b/lib/src/an4lytics/an4lytics.dart
@@ -6,6 +6,8 @@ import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_store.dart';
+import 'package:wiredash/src/an4lytics/isolate_messenger.dart'
+    if (dart.library.io) 'package:wiredash/src/an4lytics/isolate_messenger_io.dart';
 import 'package:wiredash/src/core/services/error_report.dart';
 import 'package:wiredash/src/core/services/services.dart';
 import 'package:wiredash/src/core/version.dart';
@@ -112,9 +114,10 @@ class WiredashAnalytics {
   ///
   /// **Background Isolates:**
   ///
-  /// When calling [trackEvent] from a background isolate, the event will be stored locally.
-  /// The main isolate will pick up these events and send them along with the next batch or
-  /// when the app goes to the background.
+  /// When calling [trackEvent] from a background isolate, the event is stored
+  /// locally and the background isolate wakes the main isolate to upload it.
+  /// If no [Wiredash] widget is mounted yet, the event is sent with the next
+  /// batch or when the app goes to the background.
   ///
   /// **See also**
   ///
@@ -194,108 +197,128 @@ class WiredashAnalytics {
     });
   }
 
-  /// Checks the currently mounted [Wiredash] widgets and notifies the correct one
-  /// to send the event.
-  /// This ensures only a single instance sends the event on the main isolate,
-  /// making batching and sending more efficient.
+  /// Notifies the [Wiredash] instance that should upload the just-tracked event.
+  ///
+  /// On a background isolate there is no mounted widget, so it wakes the main
+  /// isolate (see [registerMainIsolateAnalyticsListener]); the main isolate then
+  /// routes to the matching instance via [notifyMatchingWiredashInstance], the
+  /// same way a main-isolate event does.
   Future<void> _notifyWiredashInstance(
     String? projectId,
     String? environment,
     String eventName,
   ) async {
-    final allWidget = WiredashRegistry.instance.allWidgets;
-    if (allWidget.isEmpty) {
-      // no Wiredash instance is running. Wait for next mount to send the event
-
-      final bool isMainIsolate = Isolate.current.debugName == 'main';
-      if (!isMainIsolate) {
-        // The event will be picked up automatically by the main isolate,
-        // when the next event is sent from the main isolate.
-        return;
-      }
-      reportWiredashInfo(
-        NoWiredashInstanceFoundException(),
-        StackTrace.current,
-        "No Wiredash widget is mounted. "
-        "The event '$eventName' was captured but not yet submitted to the server. "
-        "Please make sure to wrap your app with Wiredash. "
-        "See https://docs.wiredash.com/guide/start",
-      );
-
-      return;
-    }
-
-    if (allWidget.length == 1) {
-      final WiredashState state = allWidget.first;
-      final widget = state.widget;
-      if (projectId == null || widget.projectId == projectId) {
-        // projectId and environment match when set, notify the only and correct Wiredash instance
-        await state.triggerAnalyticsEventUpload();
-        return;
-      }
-      // The only registered Wiredash instance has a different projectId
-      reportWiredashInfo(
-        NoWiredashInstanceFoundException(),
-        StackTrace.current,
-        "Wiredash is registered with projectId:${widget.projectId}. "
-        "The event event '$eventName' was explicit sent to projectId projectId:$projectId. "
-        "No Wiredash instance was found with projectId:$projectId. "
-        "Please double check the projectId.",
-      );
-      return;
-    }
-    assert(allWidget.length > 1, "Multiple Wiredash instances are mounted.");
-
-    if (projectId == null) {
-      final firstWidgetState = allWidget.first;
-
-      final ids = allWidget.map((e) {
-        return "projectId:${e.widget.projectId}/environment:${e.widget.environment}";
-      }).join(", ");
-      reportWiredashInfo(
-        NoProjectIdSpecifiedException(),
-        StackTrace.current,
-        "Multiple Wiredash instances with different projectIds are mounted ($ids). "
-        "Please specify a projectId when using multiple Wiredash instances like this:\n"
-        "    Wiredash.trackEvent('$eventName', projectId: 'your_project_id');\n"
-        "    WiredashAnalytics(projectId: 'your_project_id').trackEvent('$eventName');\n"
-        "    Wiredash.of(context).trackEvent('$eventName');\n"
-        "The event '$eventName' was sent to project '${firstWidgetState.widget.projectId} "
-        "because that Wiredash widget was registered first.",
-      );
-      await firstWidgetState.triggerAnalyticsEventUpload();
-      return;
-    }
-
-    // Use first matching Wiredash instance by projectId. environment does not matter
-    final projectInstances = allWidget
-        .where((element) => element.widget.projectId == projectId)
-        .toList();
-
-    if (projectInstances.isEmpty) {
-      reportWiredashInfo(
-        NoWiredashInstanceFoundException(),
-        StackTrace.current,
-        "No Wiredash instance was found with projectId:$projectId. "
-        "Please double check the projectId.",
-      );
-      return;
+    final bool isMainIsolate = Isolate.current.debugName == 'main';
+    if (isMainIsolate) {
+      await notifyMatchingWiredashInstance(projectId, environment, eventName);
     } else {
-      // multiple with the same projectId, take the first one
-      await projectInstances.first.triggerAnalyticsEventUpload();
+      // Background isolate: no Wiredash widgets are mounted here (the registry is
+      // per-isolate), so wake the main isolate to reload the just-saved event
+      // from disk and upload it now, instead of waiting for the next main-isolate
+      // event or app lifecycle trigger.
+      notifyMainIsolateOfNewEvent(projectId, environment, eventName);
     }
-
-    debugPrint(
-      "Multiple Wiredash instances are mounted! "
-      "Please specify a projectId to avoid sending events to all instances, "
-      "or use Wiredash.of(context).trackEvent() to send events to a specific instance.",
-    );
   }
 
   @override
   String toString() {
     return 'WiredashAnalytics{projectId: $_projectId, environment: $_environment}';
   }
+}
+
+/// Triggers the upload of pending events on the single mounted [Wiredash]
+/// instance that matches [projectId], reporting a misconfiguration warning when
+/// the target is ambiguous (multiple instances, or none with that projectId).
+///
+/// Routing is by [projectId] only; the event keeps its own [environment], so the
+/// chosen instance's environment does not have to match. [environment] and
+/// [eventName] are only used in the warning messages.
+///
+/// Picking one instance keeps batching efficient and avoids sending the same
+/// event to multiple backends. Used both when an event is tracked on the main
+/// isolate and when a background isolate wakes the main isolate via
+/// [registerMainIsolateAnalyticsListener], so both paths route identically.
+Future<void> notifyMatchingWiredashInstance(
+  String? projectId,
+  String? environment,
+  String eventName,
+) async {
+  final allWidget = WiredashRegistry.instance.allWidgets;
+  if (allWidget.isEmpty) {
+    reportWiredashInfo(
+      NoWiredashInstanceFoundException(),
+      StackTrace.current,
+      "No Wiredash widget is mounted. "
+      "The event '$eventName' (environment: $environment) was captured but not "
+      "yet submitted to the server. "
+      "Please make sure to wrap your app with Wiredash. "
+      "See https://docs.wiredash.com/guide/start",
+    );
+    return;
+  }
+
+  if (allWidget.length == 1) {
+    final WiredashState state = allWidget.first;
+    final widget = state.widget;
+    if (projectId == null || widget.projectId == projectId) {
+      // projectId matches when set, notify the only and correct Wiredash
+      // instance. The event keeps its own environment, so the instance's
+      // environment does not have to match.
+      await state.triggerAnalyticsEventUpload();
+      return;
+    }
+    // The only registered Wiredash instance has a different projectId
+    reportWiredashInfo(
+      NoWiredashInstanceFoundException(),
+      StackTrace.current,
+      "Wiredash is registered with projectId:${widget.projectId}. "
+      "The event event '$eventName' was explicit sent to projectId projectId:$projectId. "
+      "No Wiredash instance was found with projectId:$projectId. "
+      "Please double check the projectId.",
+    );
+    return;
+  }
+  assert(allWidget.length > 1, "Multiple Wiredash instances are mounted.");
+
+  if (projectId == null) {
+    final firstWidgetState = allWidget.first;
+
+    final ids = allWidget.map((e) {
+      return "projectId:${e.widget.projectId}/environment:${e.widget.environment}";
+    }).join(", ");
+    reportWiredashInfo(
+      NoProjectIdSpecifiedException(),
+      StackTrace.current,
+      "Multiple Wiredash instances with different projectIds are mounted ($ids). "
+      "Please specify a projectId when using multiple Wiredash instances like this:\n"
+      "    Wiredash.trackEvent('$eventName', projectId: 'your_project_id');\n"
+      "    WiredashAnalytics(projectId: 'your_project_id').trackEvent('$eventName');\n"
+      "    Wiredash.of(context).trackEvent('$eventName');\n"
+      "The event '$eventName' was sent to project '${firstWidgetState.widget.projectId} "
+      "because that Wiredash widget was registered first.",
+    );
+    await firstWidgetState.triggerAnalyticsEventUpload();
+    return;
+  }
+
+  // Use the first matching Wiredash instance by projectId.
+  final projectInstances = WiredashRegistry.instance.findByProjectId(projectId);
+  if (projectInstances.isEmpty) {
+    reportWiredashInfo(
+      NoWiredashInstanceFoundException(),
+      StackTrace.current,
+      "No Wiredash instance was found with projectId:$projectId. "
+      "Please double check the projectId.",
+    );
+    return;
+  }
+  // multiple with the same projectId, take the first one
+  await projectInstances.first.triggerAnalyticsEventUpload();
+  debugPrint(
+    "Multiple Wiredash instances are mounted! "
+    "Please specify a projectId to avoid sending events to all instances, "
+    "or use Wiredash.of(context).trackEvent() to send events to a specific instance.",
+  );
 }
 
 /// Reported when [WiredashAnalytics.trackEvent] but no [Wiredash] widget is mounted.

--- a/lib/src/an4lytics/ev3nt_file_store.dart
+++ b/lib/src/an4lytics/ev3nt_file_store.dart
@@ -1,0 +1,265 @@
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:file/file.dart';
+import 'package:flutter/foundation.dart';
+import 'package:nanoid2/nanoid2.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/an4lytics/ev3nt_store.dart';
+import 'package:wiredash/src/core/services/error_report.dart';
+
+/// Stores [AnalyticsEvent]s as one file per event on disk.
+///
+/// Unlike [SharedPreferencesAnalyticsEventStore] (which uses `shared_preferences`),
+/// this store reads straight from disk on every call, so an event a background
+/// isolate writes is immediately visible to the main isolate that uploads it.
+/// `shared_preferences` can't do that on Linux/Windows: it keeps a per-isolate
+/// in-memory cache over its JSON file that `reload()` does not refresh.
+///
+/// One file per event (named after the event key) means isolates never rewrite
+/// a shared file from a stale snapshot, so concurrent writes can't clobber each
+/// other.
+///
+/// Used on every platform except web, which has no background isolates and
+/// keeps using [SharedPreferencesAnalyticsEventStore].
+class FileAnalyticsEventStore implements AnalyticsEventStore {
+  FileAnalyticsEventStore({
+    required this.fileSystem,
+    required this.directoryProvider,
+    this.sharedPreferences,
+  });
+
+  static const Duration outdatedAfter = Duration(days: 3);
+  static const String defaultProjectId = 'default';
+  static const int maximumDiskSizeInBytes = 1024 * 1024; // 1MB
+  static final RegExp eventKeyRegex =
+      RegExp(r'^io\.wiredash\.events\.([\w-]+)\|(\d+)\|([\w-]+)$');
+
+  final FileSystem fileSystem;
+
+  /// Returns the parent directory in which the `wiredash/events` directory is
+  /// created, usually the application support directory.
+  final Future<String> Function() directoryProvider;
+
+  /// Only used once to migrate events written by older SDK versions that stored
+  /// them in `shared_preferences`. `null` disables the migration (tests).
+  final Future<SharedPreferences> Function()? sharedPreferences;
+
+  /// Test hook that points every store instance at one shared backing.
+  ///
+  /// `Wiredash.trackEvent` creates its own [WiredashServices], so the store that
+  /// saves an event and the store that reads it back are different instances.
+  /// In production they share the on-disk directory; in tests there is no disk,
+  /// so set these (and reset them afterwards) to share an in-memory file system,
+  /// the same way `SharedPreferences.setMockInitialValues` works.
+  @visibleForTesting
+  static FileSystem? debugFileSystem;
+
+  /// See [debugFileSystem].
+  @visibleForTesting
+  static String? debugDirectory;
+
+  bool _migrated = false;
+
+  FileSystem get _fileSystem => debugFileSystem ?? fileSystem;
+
+  Future<String> _baseDirectory() async =>
+      debugDirectory ?? await directoryProvider();
+
+  Future<Directory> _eventsDirectory() async {
+    final fileSystem = _fileSystem;
+    final path =
+        fileSystem.path.join(await _baseDirectory(), 'wiredash', 'events');
+    final directory = fileSystem.directory(path);
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+    }
+    return directory;
+  }
+
+  String _fileName(String key) => '${Uri.encodeComponent(key)}.json';
+
+  String? _keyForFile(File file) {
+    final name = _fileSystem.path.basename(file.path);
+    if (!name.endsWith('.json')) {
+      return null;
+    }
+    final String key;
+    try {
+      key = Uri.decodeComponent(name.substring(0, name.length - 5));
+    } catch (_) {
+      // Not a file we wrote (malformed percent-encoding); ignore it.
+      return null;
+    }
+    if (!eventKeyRegex.hasMatch(key)) {
+      return null;
+    }
+    return key;
+  }
+
+  @override
+  Future<void> saveEvent(AnalyticsEvent event, String? projectId) async {
+    final project = projectId ?? defaultProjectId;
+    final millis = event.createdAt!.millisecondsSinceEpoch;
+    final discriminator = nanoid(length: 6);
+    final key = "io.wiredash.events.$project|$millis|$discriminator";
+    assert(
+      eventKeyRegex.hasMatch(key),
+      'Invalid event key: $key',
+    );
+
+    final directory = await _eventsDirectory();
+    // Write to a temp file and rename it into place. Rename is atomic, so a
+    // concurrent reader (e.g. the main isolate uploading) never sees a
+    // half-written file and mistakes it for a corrupt event. The '.tmp' suffix
+    // also keeps it out of [_keyForFile], which only matches '.json'.
+    final file = directory.childFile(_fileName(key));
+    final tempFile = directory.childFile('${_fileName(key)}.tmp');
+    await tempFile.writeAsString(jsonEncode(serializeEventV1(event)));
+    await tempFile.rename(file.path);
+  }
+
+  @override
+  Future<Map<String, AnalyticsEvent>> getEvents(String? projectId) async {
+    await _migrateFromSharedPreferences();
+    final directory = await _eventsDirectory();
+
+    final Map<String, AnalyticsEvent> result = {};
+    for (final entity in await directory.list().toList()) {
+      if (entity is! File) {
+        continue;
+      }
+      final key = _keyForFile(entity);
+      if (key == null) {
+        continue;
+      }
+      final eventProjectId = eventKeyRegex.firstMatch(key)!.group(1);
+      if (eventProjectId != defaultProjectId && eventProjectId != projectId) {
+        continue;
+      }
+      try {
+        final eventJson = await entity.readAsString();
+        result[key] =
+            deserializeEventV1(jsonDecode(eventJson) as Map<String, Object?>);
+      } catch (e, stack) {
+        reportWiredashInfo(
+          e,
+          stack,
+          'Error when parsing event $key. Removing.',
+        );
+        await entity.delete();
+      }
+    }
+    return result;
+  }
+
+  @override
+  Future<void> removeEvent(String key) async {
+    final directory = await _eventsDirectory();
+    final file = directory.childFile(_fileName(key));
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  @override
+  Future<void> deleteOutdatedEvents() async {
+    final directory = await _eventsDirectory();
+    final unixThreeDaysAgo =
+        clock.now().subtract(outdatedAfter).millisecondsSinceEpoch;
+
+    for (final entity in await directory.list().toList()) {
+      if (entity is! File) {
+        continue;
+      }
+      final key = _keyForFile(entity);
+      if (key == null) {
+        continue;
+      }
+      final millis = int.parse(eventKeyRegex.firstMatch(key)!.group(2)!);
+      if (millis < unixThreeDaysAgo) {
+        await entity.delete();
+      }
+    }
+  }
+
+  @override
+  Future<void> trimToDiskLimit() async {
+    final directory = await _eventsDirectory();
+    final eventFiles = <File>[];
+    for (final entity in await directory.list().toList()) {
+      if (entity is File && _keyForFile(entity) != null) {
+        eventFiles.add(entity);
+      }
+    }
+
+    int millisOf(File file) =>
+        int.parse(eventKeyRegex.firstMatch(_keyForFile(file)!)!.group(2)!);
+    // newest first, so the oldest events are dropped when over the limit
+    eventFiles.sort((a, b) => millisOf(b).compareTo(millisOf(a)));
+
+    int limit = maximumDiskSizeInBytes;
+    final Set<String> keep = {};
+    for (final file in eventFiles) {
+      limit -= await file.length();
+      if (limit < 0) {
+        break;
+      }
+      keep.add(file.path);
+    }
+
+    for (final file in eventFiles) {
+      if (!keep.contains(file.path)) {
+        await file.delete();
+      }
+    }
+  }
+
+  @override
+  Future<void> wipe() async {
+    final directory = await _eventsDirectory();
+    for (final entity in await directory.list().toList()) {
+      if (entity is File && _keyForFile(entity) != null) {
+        await entity.delete();
+      }
+    }
+  }
+
+  /// Moves events written by older SDK versions from `shared_preferences` into
+  /// this store, once. Best-effort: failures are reported and ignored.
+  ///
+  /// Runs on [getEvents] only, which the submitter calls on the main isolate, so
+  /// it never writes `shared_preferences` from a background isolate.
+  Future<void> _migrateFromSharedPreferences() async {
+    if (_migrated) {
+      return;
+    }
+    _migrated = true;
+    final prefsProvider = sharedPreferences;
+    if (prefsProvider == null) {
+      return;
+    }
+    try {
+      final prefs = await prefsProvider();
+      await prefs.reload();
+      final keys = prefs.getKeys().where(eventKeyRegex.hasMatch).toList();
+      if (keys.isEmpty) {
+        return;
+      }
+      final directory = await _eventsDirectory();
+      for (final key in keys) {
+        final eventJson = prefs.getString(key);
+        if (eventJson != null) {
+          await directory.childFile(_fileName(key)).writeAsString(eventJson);
+        }
+        await prefs.remove(key);
+      }
+    } catch (e, stack) {
+      reportWiredashInfo(
+        e,
+        stack,
+        'Failed to migrate analytics events from shared_preferences',
+      );
+    }
+  }
+}

--- a/lib/src/an4lytics/ev3nt_store.dart
+++ b/lib/src/an4lytics/ev3nt_store.dart
@@ -116,8 +116,8 @@ class AnalyticsEvent {
 }
 
 /// Saves [AnalyticsEvent] on disk
-class PersistentAnalyticsEventStore implements AnalyticsEventStore {
-  PersistentAnalyticsEventStore({
+class SharedPreferencesAnalyticsEventStore implements AnalyticsEventStore {
+  SharedPreferencesAnalyticsEventStore({
     required this.sharedPreferences,
   });
 

--- a/lib/src/an4lytics/isolate_messenger.dart
+++ b/lib/src/an4lytics/isolate_messenger.dart
@@ -1,0 +1,36 @@
+/// Wakes the main isolate when a background isolate records an analytics event.
+///
+/// A background isolate (e.g. one spawned via `compute`) only buffers events to
+/// disk; it has no shared memory with the main isolate that uploads them.
+/// Without a signal the events would wait for the next app lifecycle trigger
+/// (app backgrounded, restarted, or another main-isolate event) — which can be
+/// hours or days on a long-lived foreground session, exceeding the event TTL.
+///
+/// The main isolate publishes a port via [registerMainIsolateAnalyticsListener];
+/// a background isolate pings it via [notifyMainIsolateOfNewEvent], which makes
+/// the main isolate reload pending events from disk and upload them.
+///
+/// No-op on the web, which has no background isolates (the io variant uses
+/// `IsolateNameServer`).
+library;
+
+/// Publishes the main isolate's wake-up port and runs [onEvent] with the pinged
+/// event's `projectId`, `environment` and `eventName` on each ping.
+///
+/// Idempotent: the first registration handles any number of Wiredash widgets.
+void registerMainIsolateAnalyticsListener(
+  void Function(String? projectId, String? environment, String eventName)
+      onEvent,
+) {}
+
+/// Removes the main isolate's wake-up port. Call when the last Wiredash widget
+/// is disposed.
+void unregisterMainIsolateAnalyticsListener() {}
+
+/// Pings the main isolate from a background isolate so it routes and uploads the
+/// just-saved event. No-op if no main isolate has registered a listener.
+void notifyMainIsolateOfNewEvent(
+  String? projectId,
+  String? environment,
+  String eventName,
+) {}

--- a/lib/src/an4lytics/isolate_messenger_io.dart
+++ b/lib/src/an4lytics/isolate_messenger_io.dart
@@ -1,0 +1,59 @@
+import 'dart:isolate';
+import 'dart:ui';
+
+/// Name under which the main isolate publishes its analytics wake-up port in the
+/// process-wide [IsolateNameServer]. See `isolate_messenger.dart`.
+const String _portName = 'io.wiredash.analytics.events';
+
+ReceivePort? _receivePort;
+
+/// Publishes the main isolate's wake-up port and runs [onEvent] with the pinged
+/// event's `projectId`, `environment` and `eventName`.
+void registerMainIsolateAnalyticsListener(
+  void Function(String? projectId, String? environment, String eventName)
+      onEvent,
+) {
+  if (_receivePort != null) {
+    // Already listening. [onEvent] routes to the matching instance, so a single
+    // registration is enough regardless of how many widgets mount.
+    return;
+  }
+  final port = ReceivePort();
+  // Drop a mapping left over from a previous run (e.g. after a hot restart),
+  // otherwise registering the new port would fail.
+  IsolateNameServer.removePortNameMapping(_portName);
+  final registered =
+      IsolateNameServer.registerPortWithName(port.sendPort, _portName);
+  if (!registered) {
+    port.close();
+    return;
+  }
+  _receivePort = port;
+  port.listen((message) {
+    try {
+      // The port name is process-global, so ignore anything that isn't the
+      // [projectId, environment, eventName] shape we send.
+      final list = message as List<Object?>;
+      onEvent(list[0] as String?, list[1] as String?, list[2]! as String);
+    } catch (_) {
+      // Malformed message from a foreign sender; ignore it.
+    }
+  });
+}
+
+/// Removes the main isolate's wake-up port.
+void unregisterMainIsolateAnalyticsListener() {
+  IsolateNameServer.removePortNameMapping(_portName);
+  _receivePort?.close();
+  _receivePort = null;
+}
+
+/// Pings the main isolate from a background isolate.
+void notifyMainIsolateOfNewEvent(
+  String? projectId,
+  String? environment,
+  String eventName,
+) {
+  final sendPort = IsolateNameServer.lookupPortByName(_portName);
+  sendPort?.send(<Object?>[projectId, environment, eventName]);
+}

--- a/lib/src/core/services/services.dart
+++ b/lib/src/core/services/services.dart
@@ -1,6 +1,7 @@
 import 'package:file/local.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:wiredash/src/an4lytics/ev3nt_file_store.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_store.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_submitter.dart';
 import 'package:wiredash/src/core/network/wiredash_api.dart';
@@ -223,7 +224,21 @@ void registerProdWiredashServices(WiredashServices sl) {
     );
   });
   sl.inject<AnalyticsEventStore>((_) {
-    return PersistentAnalyticsEventStore(
+    if (kIsWeb) {
+      // Web has no background isolates, so the per-isolate cache is a non-issue;
+      // shared_preferences (localStorage) keeps working.
+      return SharedPreferencesAnalyticsEventStore(
+        sharedPreferences: sl.sharedPreferencesProvider,
+      );
+    }
+    // Mobile/desktop: store each event in its own file so an event a background
+    // isolate writes is immediately visible to the main isolate that uploads
+    // it. shared_preferences can't do that on Linux/Windows (per-isolate cache
+    // that reload() does not refresh).
+    return FileAnalyticsEventStore(
+      fileSystem: const LocalFileSystem(),
+      directoryProvider: () async =>
+          (await getApplicationSupportDirectory()).path,
       sharedPreferences: sl.sharedPreferencesProvider,
     );
   });

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -4,6 +4,9 @@ import 'dart:ui' as ui;
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:wiredash/src/an4lytics/an4lytics.dart';
+import 'package:wiredash/src/an4lytics/isolate_messenger.dart'
+    if (dart.library.io) 'package:wiredash/src/an4lytics/isolate_messenger_io.dart';
 import 'package:wiredash/src/core/context_cache.dart';
 import 'package:wiredash/src/core/services/error_report.dart';
 import 'package:wiredash/src/core/support/back_button_interceptor.dart';
@@ -228,9 +231,10 @@ class Wiredash extends StatefulWidget {
   ///
   /// **Background Isolates:**
   ///
-  /// When calling [trackEvent] from a background isolate, the event will be stored locally.
-  /// The main isolate will pick up these events and send them along with the next batch or
-  /// when the app goes to the background.
+  /// When calling [trackEvent] from a background isolate, the event is stored
+  /// locally and the background isolate wakes the main isolate to upload it.
+  /// If no [Wiredash] widget is mounted yet, the event is sent with the next
+  /// batch or when the app goes to the background.
   ///
   /// **See also**
   ///
@@ -295,6 +299,15 @@ class WiredashState extends State<Wiredash> {
     _verifySyncLocalizationsDelegate();
 
     _unregister = WiredashRegistry.instance.register(this);
+    // Let background isolates wake the main isolate to upload events they
+    // buffered to disk, instead of waiting for the next lifecycle trigger. The
+    // ping carries the projectId so it routes to the matching instance, exactly
+    // like a main-isolate trackEvent.
+    registerMainIsolateAnalyticsListener((projectId, environment, eventName) {
+      unawaited(
+        notifyMatchingWiredashInstance(projectId, environment, eventName),
+      );
+    });
     _services.updateWidget(widget);
     _services.addListener(_markNeedsBuild);
     _services.wiredashModel.addListener(_markNeedsBuild);
@@ -331,6 +344,10 @@ class WiredashState extends State<Wiredash> {
   @override
   void dispose() {
     _unregister?.dispose();
+    if (WiredashRegistry.instance.allWidgets.isEmpty) {
+      // Last Wiredash widget gone, stop listening for background-isolate pings.
+      unregisterMainIsolateAnalyticsListener();
+    }
     _services.dispose();
     _backButtonDispatcher.dispose();
     _appFocusScopeNode.dispose();

--- a/test/analytics/analytics_test.dart
+++ b/test/analytics/analytics_test.dart
@@ -7,9 +7,11 @@ import 'dart:io';
 import 'package:async/async.dart';
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
+import 'package:file/memory.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
+import 'package:wiredash/src/an4lytics/ev3nt_file_store.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_store.dart';
 import 'package:wiredash/src/core/network/wiredash_api.dart';
 import 'package:wiredash/src/core/services/services.dart';
@@ -584,9 +586,7 @@ void main() {
     await tester.pumpSmart();
 
     // event is saved locally for the "default" project
-    final eventStore = PersistentAnalyticsEventStore(
-      sharedPreferences: SharedPreferences.getInstance,
-    );
+    final eventStore = _debugFileEventStore();
     final eventsOnDisk = await eventStore.getEvents('default');
     expect(eventsOnDisk, hasLength(1));
 
@@ -621,9 +621,7 @@ void main() {
     await tester.pumpSmart();
 
     // event is saved locally for project1
-    final eventStore = PersistentAnalyticsEventStore(
-      sharedPreferences: SharedPreferences.getInstance,
-    );
+    final eventStore = _debugFileEventStore();
     final eventsOnDisk = await eventStore.getEvents('project1');
     expect(eventsOnDisk, hasLength(1));
     final defaultEventsOnDisk = await eventStore.getEvents('default');
@@ -667,9 +665,7 @@ void main() {
     await robot.tapText('Send Event');
     await tester.pumpSmart();
 
-    final eventStore = PersistentAnalyticsEventStore(
-      sharedPreferences: SharedPreferences.getInstance,
-    );
+    final eventStore = _debugFileEventStore();
     final eventsOnDisk1 = await eventStore.getEvents('projectX');
     expect(eventsOnDisk1, hasLength(2));
 
@@ -1041,6 +1037,7 @@ void main() {
 
   test('WiredashAnalytics() accesses env from widget', () async {
     SharedPreferences.setMockInitialValues({});
+    _useInMemoryEventStore();
 
     const widget = Wiredash(
       projectId: '',
@@ -1128,4 +1125,25 @@ class _ThrowingEnvironmentDetector implements EnvironmentDetector {
   Future<String> getEnvironment() async {
     throw UnsupportedError('unsupported');
   }
+}
+
+/// Reads events from the shared in-memory store the robot set up via
+/// [FileAnalyticsEventStore.debugFileSystem]; the constructor args are ignored
+/// while that override is active.
+FileAnalyticsEventStore _debugFileEventStore() {
+  return FileAnalyticsEventStore(
+    fileSystem: MemoryFileSystem.test(),
+    directoryProvider: () async => '',
+  );
+}
+
+/// Points the analytics event store at a shared in-memory file system for tests
+/// that don't go through [WiredashTestRobot.setupMocks].
+void _useInMemoryEventStore() {
+  FileAnalyticsEventStore.debugFileSystem = MemoryFileSystem.test();
+  FileAnalyticsEventStore.debugDirectory = '/wiredash-test';
+  addTearDown(() {
+    FileAnalyticsEventStore.debugFileSystem = null;
+    FileAnalyticsEventStore.debugDirectory = null;
+  });
 }

--- a/test/analytics/event_store_test.dart
+++ b/test/analytics/event_store_test.dart
@@ -1,38 +1,131 @@
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wiredash/src/an4lytics/ev3nt_file_store.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_store.dart';
 
 import '../util/flutter_error.dart';
 
 void main() {
-  test('ignore invalid events on disk', () async {
-    SharedPreferences.setMockInitialValues({});
+  FileAnalyticsEventStore createStore(
+    FileSystem fs, {
+    Future<SharedPreferences> Function()? sharedPreferences,
+  }) {
+    return FileAnalyticsEventStore(
+      fileSystem: fs,
+      directoryProvider: () async => '/support',
+      sharedPreferences: sharedPreferences,
+    );
+  }
+
+  test('saves and reads an event back', () async {
+    final store = createStore(MemoryFileSystem.test());
+    await store.saveEvent(_event(eventName: 'click'), null);
+
+    final events = await store.getEvents(null);
+    expect(events, hasLength(1));
+    expect(events.values.single.eventName, 'click');
+  });
+
+  // The reason this store exists: a second store instance (= another isolate)
+  // reading the same backing directory sees an event the first one just wrote,
+  // with no stale per-isolate cache in between.
+  test('a second store instance sees an event the first one wrote', () async {
+    final fs = MemoryFileSystem.test();
+    final isolateA = createStore(fs);
+    final isolateB = createStore(fs);
+
+    expect(await isolateB.getEvents(null), isEmpty);
+
+    await isolateA.saveEvent(_event(eventName: 'from_other_isolate'), null);
+
+    final events = await isolateB.getEvents(null);
+    expect(events, hasLength(1));
+    expect(events.values.single.eventName, 'from_other_isolate');
+  });
+
+  test('removeEvent deletes the event', () async {
+    final store = createStore(MemoryFileSystem.test());
+    await store.saveEvent(_event(), null);
+    final key = (await store.getEvents(null)).keys.single;
+
+    await store.removeEvent(key);
+
+    expect(await store.getEvents(null), isEmpty);
+  });
+
+  test('ignores and removes an unparsable event file', () async {
+    final fs = MemoryFileSystem.test();
+    final store = createStore(fs);
+    final dir = fs.directory('/support/wiredash/events')
+      ..createSync(recursive: true);
+    const key = 'io.wiredash.events.default|1234567890|abcdef';
+    final file = dir.childFile('${Uri.encodeComponent(key)}.json')
+      ..writeAsStringSync('{"invalid": "event"}');
+
     final errors = captureFlutterErrors();
-    final eventStore = PersistentAnalyticsEventStore(
+    final events = await store.getEvents(null);
+    errors.restoreDefaultErrorHandlers();
+
+    expect(events, isEmpty);
+    expect(errors.warningText, contains('Error when parsing event $key'));
+    expect(
+      file.existsSync(),
+      isFalse,
+      reason: 'invalid file should be removed',
+    );
+  });
+
+  test('deleteOutdatedEvents removes events older than 3 days', () async {
+    final now = DateTime.utc(2024, 6, 5);
+    await withClock(Clock.fixed(now), () async {
+      final store = createStore(MemoryFileSystem.test());
+      await store.saveEvent(
+        _event(createdAt: now.subtract(const Duration(days: 4))),
+        null,
+      );
+      await store.saveEvent(_event(createdAt: now), null);
+
+      await store.deleteOutdatedEvents();
+
+      expect(await store.getEvents(null), hasLength(1));
+    });
+  });
+
+  test('migrates events from shared_preferences once', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    const key = 'io.wiredash.events.default|1717286400000|legacy0';
+    await prefs.setString(key, jsonEncode(serializeEventV1(_event())));
+
+    final store = createStore(
+      MemoryFileSystem.test(),
       sharedPreferences: SharedPreferences.getInstance,
     );
 
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(
-      'io.wiredash.events.default|1234567890|abc',
-      '{"invalid": "event"}',
-    );
-    final events = await eventStore.getEvents(null);
+    final events = await store.getEvents(null);
 
-    errors.restoreDefaultErrorHandlers();
-
-    expect(events, hasLength(0));
-    // reported warning
+    expect(events, hasLength(1));
     expect(
-      errors.warningText,
-      contains(
-        'Error when parsing event io.wiredash.events.default|1234567890|abc. Removing',
-      ),
-    );
-    expect(
-      prefs.getString('io.wiredash.events.default|1234567890|abc'),
-      isNull,
-      reason: 'Invalid event should be removed from disk',
+      prefs.getKeys(),
+      isNot(contains(key)),
+      reason: 'migrated event should be removed from shared_preferences',
     );
   });
+}
+
+AnalyticsEvent _event({
+  String eventName = 'test_event',
+  DateTime? createdAt,
+}) {
+  return AnalyticsEvent(
+    analyticsId: 'analytics-id',
+    createdAt: createdAt ?? DateTime.utc(2024, 6, 2),
+    eventName: eventName,
+    sdkVersion: 1,
+  );
 }

--- a/test/analytics/isolate_messenger_test.dart
+++ b/test/analytics/isolate_messenger_test.dart
@@ -1,0 +1,37 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wiredash/src/an4lytics/isolate_messenger_io.dart';
+
+void main() {
+  // The real cross-isolate wake-up runs across two isolates; here we exercise
+  // the IsolateNameServer round-trip within one isolate, which is enough to
+  // prove a ping reaches the registered listener.
+  test('a ping delivers projectId, environment and eventName to the listener',
+      () async {
+    final pinged = Completer<(String?, String?, String)>();
+    registerMainIsolateAnalyticsListener((projectId, environment, eventName) {
+      if (!pinged.isCompleted) {
+        pinged.complete((projectId, environment, eventName));
+      }
+    });
+    addTearDown(unregisterMainIsolateAnalyticsListener);
+
+    notifyMainIsolateOfNewEvent('my_project', 'prod', 'test_event');
+
+    final received = await pinged.future.timeout(const Duration(seconds: 5));
+    expect(received, ('my_project', 'prod', 'test_event'));
+  });
+
+  test('notifying without a listener is a no-op', () async {
+    unregisterMainIsolateAnalyticsListener();
+    // Must not throw when no main isolate has registered a port.
+    expect(
+      () => notifyMainIsolateOfNewEvent(null, null, 'test_event'),
+      returnsNormally,
+    );
+  });
+}

--- a/test/util/robot.dart
+++ b/test/util/robot.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:file/memory.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -11,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nanoid2/nanoid2.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:spot/spot.dart';
+import 'package:wiredash/src/an4lytics/ev3nt_file_store.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_submitter.dart';
 import 'package:wiredash/src/core/theme/wirecons.dart';
 import 'package:wiredash/src/core/widgets/backdrop/step_page_scaffold.dart';
@@ -55,6 +57,14 @@ class WiredashTestRobot {
       'mocked': true,
     });
     addTearDown(() => SharedPreferences.setMockInitialValues({}));
+    // Every WiredashServices() (incl. the one Wiredash.trackEvent creates) reads
+    // analytics events from this shared in-memory file system instead of disk.
+    FileAnalyticsEventStore.debugFileSystem = MemoryFileSystem.test();
+    FileAnalyticsEventStore.debugDirectory = '/wiredash-test';
+    addTearDown(() {
+      FileAnalyticsEventStore.debugFileSystem = null;
+      FileAnalyticsEventStore.debugDirectory = null;
+    });
     PackageInfo.setMockInitialValues(
       appName: 'Wiredash Test',
       packageName: 'io.wiredash.test',


### PR DESCRIPTION
`Wiredash.trackEvent` from a background isolate (e.g. via `compute()`) buffers the event and, until now, the main isolate only uploaded it on its next lifecycle flush — app backgrounding or the next launch. Nothing was lost, but delivery wasn't prompt, and on a long-lived foreground session a buffered event could even age past its 3-day retention window before the next flush.

### Why it waited

Two independent reasons:

1. **No signal.** A `compute()` isolate shares no memory with the main isolate, so the main isolate had no way to know a new event was buffered. It only checked on its next lifecycle trigger.
2. **Stale cache on Linux/Windows.** `shared_preferences` there keeps a **per-isolate** in-memory cache over its JSON file, and `reload()` reads that cache, not the disk. So even when the main isolate did read, it didn't pick up a background isolate's write until the process restarted. Apple (`NSUserDefaults`) and Android share the store across isolates and were unaffected.

### What changed

**Analytics events are stored in files instead of `shared_preferences`** (mobile & desktop). Each event is its own file under `<applicationSupport>/wiredash/events/`:

- Fresh disk reads are correct across isolates — no cache to go stale.
- One file per event avoids read-modify-write clobbering between isolates.
- Writes are atomic (temp file + rename), so a reader never sees a half-written event.
- Web keeps `shared_preferences` (no background isolates there), selected via `kIsWeb`.
- Events written by older SDK versions are migrated out of `shared_preferences` once.

**The background isolate wakes the main isolate.** After saving, it pings the main isolate via `IsolateNameServer`; the main isolate routes to the matching `Wiredash` instance (by `projectId`) and uploads immediately instead of waiting for the next flush. The ping carries `(projectId, environment, eventName)`, and the event keeps the environment it was given on the background isolate (default when unset).

No public API change — `trackEvent` is unchanged.

### Testing on the affected platform

The integration test (`examples/theming`) now also runs on **Linux** in CI (headless via `xvfb`). It exercises the real background-isolate → disk → main-isolate path, and with the app mounted asserts the event reaches the `Wiredash` widget and is uploaded to the backend — the full circle — by intercepting the `HttpClient` via `HttpOverrides`.

### Companion change

The `analytics_background_isolate/*` e2e scenarios are re-registered for Linux/Windows in `wiredash-demo` (`e2e-suite` branch).