### PR TITLE
Add immediate analytics event upload

### DIFF
--- a/examples/theming/integration_test/events_on_isolate_test.dart
+++ b/examples/theming/integration_test/events_on_isolate_test.dart
@@ -66,14 +66,13 @@ void main() {
     await tester.pump();
 
     final token = ServicesBinding.rootIsolateToken!;
-    late final _CapturedRequest request;
-    await tester.runAsync(() async {
+    final request = (await tester.runAsync(() async {
       // Track on a background isolate. After saving the event the SDK pings the
       // main isolate, which reloads the event from disk and uploads it without
       // waiting for the next lifecycle flush.
       await compute(_trackEventOnBackgroundIsolate, token);
-      request = await captured.future.timeout(const Duration(seconds: 20));
-    });
+      return captured.future.timeout(const Duration(seconds: 20));
+    }))!;
 
     // Full circle: the event the background isolate wrote left the device as a
     // POST to the Wiredash backend, carrying the event name and the exact

--- a/lib/src/an4lytics/an4lytics.dart
+++ b/lib/src/an4lytics/an4lytics.dart
@@ -273,15 +273,16 @@ void ensureAnalyticsIsolateListenerRegistered() {
 void _syncAnalyticsIsolateListener() {
   final hasWidgets = WiredashRegistry.instance.referenceCount > 0;
   if (hasWidgets) {
+    // register listener once when >0 Wiredash widgets
     _analyticsIsolateListenerRegistration ??=
         registerMainIsolateAnalyticsListener();
-    return;
+  } else {
+    // cleanup when the last Wiredash widget got disposed
+    _analyticsIsolateListenerRegistration?.dispose();
+    _analyticsIsolateListenerRegistration = null;
+    _analyticsRegistryListenerRegistration?.dispose();
+    _analyticsRegistryListenerRegistration = null;
   }
-
-  _analyticsIsolateListenerRegistration?.dispose();
-  _analyticsIsolateListenerRegistration = null;
-  _analyticsRegistryListenerRegistration?.dispose();
-  _analyticsRegistryListenerRegistration = null;
 }
 
 /// This is the complete list of internal events that Wiredash uses.

--- a/lib/src/an4lytics/an4lytics.dart
+++ b/lib/src/an4lytics/an4lytics.dart
@@ -280,6 +280,8 @@ void _syncAnalyticsIsolateListener() {
 
   _analyticsIsolateListenerRegistration?.dispose();
   _analyticsIsolateListenerRegistration = null;
+  _analyticsRegistryListenerRegistration?.dispose();
+  _analyticsRegistryListenerRegistration = null;
 }
 
 /// This is the complete list of internal events that Wiredash uses.

--- a/lib/src/an4lytics/an4lytics.dart
+++ b/lib/src/an4lytics/an4lytics.dart
@@ -5,6 +5,8 @@ import 'dart:isolate';
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
+import 'package:wiredash/src/an4lytics/an4lytics_isolate_message.dart';
+import 'package:wiredash/src/an4lytics/an4lytics_upload_router.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_store.dart';
 import 'package:wiredash/src/an4lytics/isolate_messenger.dart'
     if (dart.library.io) 'package:wiredash/src/an4lytics/isolate_messenger_io.dart';
@@ -13,6 +15,7 @@ import 'package:wiredash/src/core/services/services.dart';
 import 'package:wiredash/src/core/version.dart';
 import 'package:wiredash/src/core/wiredash_registry.dart';
 import 'package:wiredash/src/core/wiredash_widget.dart';
+import 'package:wiredash/src/utils/disposable.dart';
 
 /// Interact with the Wiredash Analytics service.
 ///
@@ -179,6 +182,26 @@ class WiredashAnalytics {
     }
   }
 
+  /// Submits all pending analytics events to the server.
+  ///
+  /// Usually, events are submitted automatically, batched every 30 seconds, and
+  /// when the app goes to the background.
+  ///
+  /// This method wakes the matching mounted [Wiredash] widget and asks it to
+  /// submit pending events immediately.
+  ///
+  /// From a background isolate, this method only wakes the main isolate.
+  /// The returned [Future] completes after the wake-up request was sent, not
+  /// after the upload finished.
+  Future<void> forceSubmitEvents() async {
+    await _notifyWiredashInstance(
+      _projectId,
+      _environment,
+      'forceSubmitEvents',
+      submitImmediately: true,
+    );
+  }
+
   /// Finds the intrinsic matching [Wiredash] widget to gather information from,
   /// usually the only mounted one, or the one that matches the [projectId] and/or [environment].
   ///
@@ -206,18 +229,22 @@ class WiredashAnalytics {
   Future<void> _notifyWiredashInstance(
     String? projectId,
     String? environment,
-    String eventName,
-  ) async {
+    String eventName, {
+    bool submitImmediately = false,
+  }) async {
+    final message = AnalyticsIsolateMessage(
+      projectId: projectId,
+      environment: environment,
+      eventName: eventName,
+      submitImmediately: submitImmediately,
+    );
     final bool isMainIsolate = Isolate.current.debugName == 'main';
     if (isMainIsolate) {
-      await notifyMatchingWiredashInstance(projectId, environment, eventName);
-    } else {
-      // Background isolate: no Wiredash widgets are mounted here (the registry is
-      // per-isolate), so wake the main isolate to reload the just-saved event
-      // from disk and upload it now, instead of waiting for the next main-isolate
-      // event or app lifecycle trigger.
-      notifyMainIsolateOfNewEvent(projectId, environment, eventName);
+      await notifyMatchingWiredashInstance(message);
+      return;
     }
+
+    notifyMainIsolateOfAnalyticsEvent(message);
   }
 
   @override
@@ -226,113 +253,33 @@ class WiredashAnalytics {
   }
 }
 
-/// Triggers the upload of pending events on the single mounted [Wiredash]
-/// instance that matches [projectId], reporting a misconfiguration warning when
-/// the target is ambiguous (multiple instances, or none with that projectId).
-///
-/// Routing is by [projectId] only; the event keeps its own [environment], so the
-/// chosen instance's environment does not have to match. [environment] and
-/// [eventName] are only used in the warning messages.
-///
-/// Picking one instance keeps batching efficient and avoids sending the same
-/// event to multiple backends. Used both when an event is tracked on the main
-/// isolate and when a background isolate wakes the main isolate via
-/// [registerMainIsolateAnalyticsListener], so both paths route identically.
-Future<void> notifyMatchingWiredashInstance(
-  String? projectId,
-  String? environment,
-  String eventName,
-) async {
-  final allWidget = WiredashRegistry.instance.allWidgets;
-  if (allWidget.isEmpty) {
-    reportWiredashInfo(
-      NoWiredashInstanceFoundException(),
-      StackTrace.current,
-      "No Wiredash widget is mounted. "
-      "The event '$eventName' (environment: $environment) was captured but not "
-      "yet submitted to the server. "
-      "Please make sure to wrap your app with Wiredash. "
-      "See https://docs.wiredash.com/guide/start",
-    );
+Disposable? _analyticsRegistryListenerRegistration;
+Disposable? _analyticsIsolateListenerRegistration;
+
+/// Ensures analytics keeps one process-wide isolate listener while at least one
+/// [Wiredash] widget is mounted.
+void ensureAnalyticsIsolateListenerRegistered() {
+  if (_analyticsRegistryListenerRegistration != null) {
     return;
   }
 
-  if (allWidget.length == 1) {
-    final WiredashState state = allWidget.first;
-    final widget = state.widget;
-    if (projectId == null || widget.projectId == projectId) {
-      // projectId matches when set, notify the only and correct Wiredash
-      // instance. The event keeps its own environment, so the instance's
-      // environment does not have to match.
-      await state.triggerAnalyticsEventUpload();
-      return;
-    }
-    // The only registered Wiredash instance has a different projectId
-    reportWiredashInfo(
-      NoWiredashInstanceFoundException(),
-      StackTrace.current,
-      "Wiredash is registered with projectId:${widget.projectId}. "
-      "The event event '$eventName' was explicit sent to projectId projectId:$projectId. "
-      "No Wiredash instance was found with projectId:$projectId. "
-      "Please double check the projectId.",
-    );
-    return;
-  }
-  assert(allWidget.length > 1, "Multiple Wiredash instances are mounted.");
-
-  if (projectId == null) {
-    final firstWidgetState = allWidget.first;
-
-    final ids = allWidget.map((e) {
-      return "projectId:${e.widget.projectId}/environment:${e.widget.environment}";
-    }).join(", ");
-    reportWiredashInfo(
-      NoProjectIdSpecifiedException(),
-      StackTrace.current,
-      "Multiple Wiredash instances with different projectIds are mounted ($ids). "
-      "Please specify a projectId when using multiple Wiredash instances like this:\n"
-      "    Wiredash.trackEvent('$eventName', projectId: 'your_project_id');\n"
-      "    WiredashAnalytics(projectId: 'your_project_id').trackEvent('$eventName');\n"
-      "    Wiredash.of(context).trackEvent('$eventName');\n"
-      "The event '$eventName' was sent to project '${firstWidgetState.widget.projectId} "
-      "because that Wiredash widget was registered first.",
-    );
-    await firstWidgetState.triggerAnalyticsEventUpload();
-    return;
-  }
-
-  // Use the first matching Wiredash instance by projectId.
-  final projectInstances = WiredashRegistry.instance.findByProjectId(projectId);
-  if (projectInstances.isEmpty) {
-    reportWiredashInfo(
-      NoWiredashInstanceFoundException(),
-      StackTrace.current,
-      "No Wiredash instance was found with projectId:$projectId. "
-      "Please double check the projectId.",
-    );
-    return;
-  }
-  // multiple with the same projectId, take the first one
-  await projectInstances.first.triggerAnalyticsEventUpload();
-  debugPrint(
-    "Multiple Wiredash instances are mounted! "
-    "Please specify a projectId to avoid sending events to all instances, "
-    "or use Wiredash.of(context).trackEvent() to send events to a specific instance.",
+  _analyticsRegistryListenerRegistration =
+      WiredashRegistry.instance.addListener(
+    _syncAnalyticsIsolateListener,
   );
+  _syncAnalyticsIsolateListener();
 }
 
-/// Reported when [WiredashAnalytics.trackEvent] but no [Wiredash] widget is mounted.
-///
-/// This warning is only throw on the main isolate, where the [Wiredash] widget
-/// is expected to be always mounted.
-class NoWiredashInstanceFoundException implements Exception {
-  NoWiredashInstanceFoundException();
-}
+void _syncAnalyticsIsolateListener() {
+  final hasWidgets = WiredashRegistry.instance.referenceCount > 0;
+  if (hasWidgets) {
+    _analyticsIsolateListenerRegistration ??=
+        registerMainIsolateAnalyticsListener();
+    return;
+  }
 
-/// Reported when multiple [Wiredash] widgets with different projectIds are
-/// mounted but [Wiredash.trackEvent] is called without a [projectId].
-class NoProjectIdSpecifiedException implements Exception {
-  NoProjectIdSpecifiedException();
+  _analyticsIsolateListenerRegistration?.dispose();
+  _analyticsIsolateListenerRegistration = null;
 }
 
 /// This is the complete list of internal events that Wiredash uses.

--- a/lib/src/an4lytics/an4lytics_isolate_message.dart
+++ b/lib/src/an4lytics/an4lytics_isolate_message.dart
@@ -1,0 +1,53 @@
+import 'dart:isolate';
+
+/// Message sent from a background isolate to the main isolate when analytics
+/// events were saved and should be routed through a mounted Wiredash widget.
+class AnalyticsIsolateMessage {
+  const AnalyticsIsolateMessage({
+    required this.projectId,
+    required this.environment,
+    required this.eventName,
+    required this.submitImmediately,
+  });
+
+  /// Project id used to pick the matching mounted Wiredash widget.
+  final String? projectId;
+
+  /// Environment of the event, used only for diagnostics while routing.
+  final String? environment;
+
+  /// Event name used only for diagnostics while routing.
+  final String eventName;
+
+  /// Whether pending events should bypass the normal debounce and upload now.
+  final bool submitImmediately;
+
+  /// Parses a raw isolate payload.
+  ///
+  /// Throws when the payload is not the list shape produced by [toMessage].
+  factory AnalyticsIsolateMessage.fromObject(Object? message) {
+    if (message is! List<Object?>) {
+      throw ArgumentError.value(message, 'message', 'Expected a list');
+    }
+    final eventName = message[2];
+    if (eventName is! String) {
+      throw ArgumentError.value(message, 'message', 'Missing eventName');
+    }
+    return AnalyticsIsolateMessage(
+      projectId: message[0] as String?,
+      environment: message[1] as String?,
+      eventName: eventName,
+      submitImmediately: message[3] == true,
+    );
+  }
+
+  /// Converts this message into values that can be sent through a [SendPort].
+  List<Object?> toMessage() {
+    return [
+      projectId,
+      environment,
+      eventName,
+      submitImmediately,
+    ];
+  }
+}

--- a/lib/src/an4lytics/an4lytics_upload_router.dart
+++ b/lib/src/an4lytics/an4lytics_upload_router.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/widgets.dart';
+import 'package:wiredash/src/an4lytics/an4lytics_isolate_message.dart';
+import 'package:wiredash/src/core/services/error_report.dart';
+import 'package:wiredash/src/core/wiredash_registry.dart';
+import 'package:wiredash/src/core/wiredash_widget.dart';
+
+/// Triggers the upload of pending events on the single mounted [Wiredash]
+/// instance that matches [message], reporting a misconfiguration warning when
+/// the target is ambiguous (multiple instances, or none with that project id).
+///
+/// Routing is by [AnalyticsIsolateMessage.projectId] only; the event keeps its
+/// own [AnalyticsIsolateMessage.environment], so the chosen instance's
+/// environment does not have to match. The environment and event name are only
+/// used in the warning messages.
+///
+/// Picking one instance keeps batching efficient and avoids sending the same
+/// event to multiple backends. Used both when an event is tracked on the main
+/// isolate and when a background isolate wakes the main isolate, so both paths
+/// route identically.
+Future<void> notifyMatchingWiredashInstance(
+  AnalyticsIsolateMessage message,
+) async {
+  final projectId = message.projectId;
+  final environment = message.environment;
+  final eventName = message.eventName;
+  final submitImmediately = message.submitImmediately;
+  final allWidget = WiredashRegistry.instance.allWidgets;
+  if (allWidget.isEmpty) {
+    reportWiredashInfo(
+      NoWiredashInstanceFoundException(),
+      StackTrace.current,
+      "No Wiredash widget is mounted. "
+      "The event '$eventName' (environment: $environment) was captured but not "
+      "yet submitted to the server. "
+      "Please make sure to wrap your app with Wiredash. "
+      "See https://docs.wiredash.com/guide/start",
+    );
+    return;
+  }
+
+  if (allWidget.length == 1) {
+    final WiredashState state = allWidget.first;
+    final widget = state.widget;
+    if (projectId == null || widget.projectId == projectId) {
+      // projectId matches when set, notify the only and correct Wiredash
+      // instance. The event keeps its own environment, so the instance's
+      // environment does not have to match.
+      await submitAnalyticsEvents(
+        state,
+        submitImmediately: submitImmediately,
+      );
+      return;
+    }
+    // The only registered Wiredash instance has a different projectId
+    reportWiredashInfo(
+      NoWiredashInstanceFoundException(),
+      StackTrace.current,
+      "Wiredash is registered with projectId:${widget.projectId}. "
+      "The event '$eventName' was explicitly sent to projectId:$projectId. "
+      "No Wiredash instance was found with projectId:$projectId. "
+      "Please double check the projectId.",
+    );
+    return;
+  }
+  assert(allWidget.length > 1, "Multiple Wiredash instances are mounted.");
+
+  if (projectId == null) {
+    final firstWidgetState = allWidget.first;
+
+    final ids = allWidget.map((e) {
+      return "projectId:${e.widget.projectId}/environment:${e.widget.environment}";
+    }).join(", ");
+    reportWiredashInfo(
+      NoProjectIdSpecifiedException(),
+      StackTrace.current,
+      "Multiple Wiredash instances with different projectIds are mounted ($ids). "
+      "Please specify a projectId when using multiple Wiredash instances like this:\n"
+      "    Wiredash.trackEvent('$eventName', projectId: 'your_project_id');\n"
+      "    WiredashAnalytics(projectId: 'your_project_id').trackEvent('$eventName');\n"
+      "    Wiredash.of(context).trackEvent('$eventName');\n"
+      "The event '$eventName' was sent to project '${firstWidgetState.widget.projectId} "
+      "because that Wiredash widget was registered first.",
+    );
+    await submitAnalyticsEvents(
+      firstWidgetState,
+      submitImmediately: submitImmediately,
+    );
+    return;
+  }
+
+  // Use the first matching Wiredash instance by projectId.
+  final projectInstances = WiredashRegistry.instance.findByProjectId(projectId);
+  if (projectInstances.isEmpty) {
+    reportWiredashInfo(
+      NoWiredashInstanceFoundException(),
+      StackTrace.current,
+      "No Wiredash instance was found with projectId:$projectId. "
+      "Please double check the projectId.",
+    );
+    return;
+  }
+  // multiple with the same projectId, take the first one
+  await submitAnalyticsEvents(
+    projectInstances.first,
+    submitImmediately: submitImmediately,
+  );
+  debugPrint(
+    "Multiple Wiredash instances are mounted! "
+    "Please specify a projectId to avoid sending events to all instances, "
+    "or use Wiredash.of(context).trackEvent() to send events to a specific instance.",
+  );
+}
+
+/// Reported when `WiredashAnalytics.trackEvent` runs but no [Wiredash] widget
+/// is mounted.
+///
+/// This warning is only thrown on the main isolate, where the [Wiredash] widget
+/// is expected to be always mounted.
+class NoWiredashInstanceFoundException implements Exception {
+  NoWiredashInstanceFoundException();
+}
+
+/// Reported when multiple [Wiredash] widgets with different projectIds are
+/// mounted but [Wiredash.trackEvent] is called without a [projectId].
+class NoProjectIdSpecifiedException implements Exception {
+  NoProjectIdSpecifiedException();
+}

--- a/lib/src/an4lytics/ev3nt_submitter.dart
+++ b/lib/src/an4lytics/ev3nt_submitter.dart
@@ -14,9 +14,10 @@ import 'package:wiredash/src/utils/delay.dart';
 /// - [DebounceEventSubmitter] for batching events within a certain time frame (usually mobile)
 abstract class EventSubmitter {
   /// Submits all pending events in [AnalyticsEventStore] ([SharedPreferences]) to the backend
-  ///
-  /// If [force] is `true`, the events are submitted immediately, regardless of the throttle duration.
-  Future<void> submitEvents({bool? force});
+  Future<void> submitEvents();
+
+  /// Submits all pending events immediately, regardless of the throttle duration.
+  Future<void> forceSubmitEvents();
 
   /// Disposes the [EventSubmitter], cancels all scheduled tasks and timers
   void dispose();
@@ -76,16 +77,7 @@ class DebounceEventSubmitter implements EventSubmitter {
   Future<void>? _pendingSubmit;
 
   @override
-  Future<void> submitEvents({bool? force}) async {
-    if (force == true) {
-      // submit again after previous submit is done
-      await _pendingSubmit;
-      _pendingSubmit = _actuallySubmit();
-      await _pendingSubmit;
-      _pendingSubmit = null;
-      return;
-    }
-
+  Future<void> submitEvents() async {
     if (_pendingSubmit != null) {
       await _pendingSubmit!;
       return;
@@ -111,9 +103,25 @@ class DebounceEventSubmitter implements EventSubmitter {
     _pendingSubmit = null;
   }
 
+  @override
+  Future<void> forceSubmitEvents() async {
+    // Replace an already scheduled debounce with an immediate submit.
+    _delay?.disposeWithError();
+    await _pendingSubmit;
+    _delay = Delay(Duration.zero);
+    _pendingSubmit = _actuallySubmit();
+    await _pendingSubmit;
+    _pendingSubmit = null;
+  }
+
   /// Gathers events from [eventStore] and sends them to the backend via [api]
   Future<void> _actuallySubmit() async {
-    await _delay!.future;
+    try {
+      await _delay!.future;
+    } on DelayCancelledException {
+      _delay = null;
+      return;
+    }
     _lastSubmit = clock.now();
     _delay = null;
 

--- a/lib/src/an4lytics/isolate_messenger.dart
+++ b/lib/src/an4lytics/isolate_messenger.dart
@@ -7,30 +7,23 @@
 /// hours or days on a long-lived foreground session, exceeding the event TTL.
 ///
 /// The main isolate publishes a port via [registerMainIsolateAnalyticsListener];
-/// a background isolate pings it via [notifyMainIsolateOfNewEvent], which makes
-/// the main isolate reload pending events from disk and upload them.
+/// a background isolate pings it via [notifyMainIsolateOfAnalyticsEvent], which
+/// makes the main isolate reload pending events from disk and upload them.
 ///
 /// No-op on the web, which has no background isolates (the io variant uses
 /// `IsolateNameServer`).
 library;
 
-/// Publishes the main isolate's wake-up port and runs [onEvent] with the pinged
-/// event's `projectId`, `environment` and `eventName` on each ping.
+import 'package:wiredash/src/an4lytics/an4lytics_isolate_message.dart';
+import 'package:wiredash/src/utils/disposable.dart';
+
+/// Publishes the main isolate's wake-up port.
 ///
-/// Idempotent: the first registration handles any number of Wiredash widgets.
-void registerMainIsolateAnalyticsListener(
-  void Function(String? projectId, String? environment, String eventName)
-      onEvent,
-) {}
+/// The listener is kept alive until the returned disposable is disposed.
+Disposable registerMainIsolateAnalyticsListener() {
+  return Disposable(() {});
+}
 
-/// Removes the main isolate's wake-up port. Call when the last Wiredash widget
-/// is disposed.
-void unregisterMainIsolateAnalyticsListener() {}
-
-/// Pings the main isolate from a background isolate so it routes and uploads the
-/// just-saved event. No-op if no main isolate has registered a listener.
-void notifyMainIsolateOfNewEvent(
-  String? projectId,
-  String? environment,
-  String eventName,
-) {}
+/// Pings the main isolate from a background isolate so it routes and uploads
+/// pending events. No-op if no main isolate has registered a listener.
+void notifyMainIsolateOfAnalyticsEvent(AnalyticsIsolateMessage message) {}

--- a/lib/src/an4lytics/isolate_messenger_io.dart
+++ b/lib/src/an4lytics/isolate_messenger_io.dart
@@ -15,6 +15,11 @@ const String _portName = 'io.wiredash.analytics.events';
 ReceivePort? _receivePort;
 final _registrations = <Object, StackTrace>{};
 
+@visibleForTesting
+int get debugMainIsolateAnalyticsRegistrationCount {
+  return _registrations.length;
+}
+
 /// Publishes the main isolate's wake-up port.
 Disposable registerMainIsolateAnalyticsListener() {
   final token = Object();

--- a/lib/src/an4lytics/isolate_messenger_io.dart
+++ b/lib/src/an4lytics/isolate_messenger_io.dart
@@ -1,22 +1,28 @@
+import 'dart:async';
 import 'dart:isolate';
 import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:wiredash/src/an4lytics/an4lytics_isolate_message.dart';
+import 'package:wiredash/src/an4lytics/an4lytics_upload_router.dart';
+import 'package:wiredash/src/core/services/error_report.dart';
+import 'package:wiredash/src/utils/disposable.dart';
 
 /// Name under which the main isolate publishes its analytics wake-up port in the
 /// process-wide [IsolateNameServer]. See `isolate_messenger.dart`.
 const String _portName = 'io.wiredash.analytics.events';
 
 ReceivePort? _receivePort;
+final _registrations = <Object, StackTrace>{};
 
-/// Publishes the main isolate's wake-up port and runs [onEvent] with the pinged
-/// event's `projectId`, `environment` and `eventName`.
-void registerMainIsolateAnalyticsListener(
-  void Function(String? projectId, String? environment, String eventName)
-      onEvent,
-) {
+/// Publishes the main isolate's wake-up port.
+Disposable registerMainIsolateAnalyticsListener() {
+  final token = Object();
+  _registrations[token] = StackTrace.current;
   if (_receivePort != null) {
-    // Already listening. [onEvent] routes to the matching instance, so a single
-    // registration is enough regardless of how many widgets mount.
-    return;
+    // Already listening. Keep the shared port alive until this registration is
+    // disposed too.
+    return Disposable(() => _disposeMainIsolateAnalyticsListener(token));
   }
   final port = ReceivePort();
   // Drop a mapping left over from a previous run (e.g. after a hot restart),
@@ -25,35 +31,71 @@ void registerMainIsolateAnalyticsListener(
   final registered =
       IsolateNameServer.registerPortWithName(port.sendPort, _portName);
   if (!registered) {
+    _registrations.remove(token);
     port.close();
-    return;
+    return Disposable(() {});
   }
   _receivePort = port;
   port.listen((message) {
+    final AnalyticsIsolateMessage analyticsMessage;
     try {
       // The port name is process-global, so ignore anything that isn't the
       // [projectId, environment, eventName] shape we send.
-      final list = message as List<Object?>;
-      onEvent(list[0] as String?, list[1] as String?, list[2]! as String);
-    } catch (_) {
-      // Malformed message from a foreign sender; ignore it.
+      analyticsMessage = AnalyticsIsolateMessage.fromObject(message);
+    } catch (e, stack) {
+      reportWiredashInfo(
+        e,
+        stack,
+        'Received malformed analytics isolate message: $message',
+      );
+      return;
     }
+    if (_registrations.isEmpty) {
+      return;
+    }
+    final registeredAt = _registrations.values.first;
+    unawaited(_notifyMatchingWiredashInstance(analyticsMessage, registeredAt));
   });
+  return Disposable(() => _disposeMainIsolateAnalyticsListener(token));
 }
 
-/// Removes the main isolate's wake-up port.
-void unregisterMainIsolateAnalyticsListener() {
+void _disposeMainIsolateAnalyticsListener(Object token) {
+  _registrations.remove(token);
+  if (_registrations.isNotEmpty) {
+    return;
+  }
   IsolateNameServer.removePortNameMapping(_portName);
   _receivePort?.close();
   _receivePort = null;
 }
 
 /// Pings the main isolate from a background isolate.
-void notifyMainIsolateOfNewEvent(
-  String? projectId,
-  String? environment,
-  String eventName,
-) {
+void notifyMainIsolateOfAnalyticsEvent(AnalyticsIsolateMessage message) {
+  _sendMainIsolateAnalyticsMessage(message.toMessage());
+}
+
+@visibleForTesting
+void sendRawMainIsolateAnalyticsMessage(Object? message) {
+  _sendMainIsolateAnalyticsMessage(message);
+}
+
+void _sendMainIsolateAnalyticsMessage(Object? message) {
   final sendPort = IsolateNameServer.lookupPortByName(_portName);
-  sendPort?.send(<Object?>[projectId, environment, eventName]);
+  sendPort?.send(message);
+}
+
+Future<void> _notifyMatchingWiredashInstance(
+  AnalyticsIsolateMessage message,
+  StackTrace registeredAt,
+) async {
+  try {
+    await notifyMatchingWiredashInstance(message);
+  } catch (e, stack) {
+    reportWiredashInfo(
+      e,
+      stack,
+      'Analytics isolate message routing failed. '
+      'The listener was registered at:\n$registeredAt',
+    );
+  }
 }

--- a/lib/src/core/wiredash_model.dart
+++ b/lib/src/core/wiredash_model.dart
@@ -186,7 +186,7 @@ class WiredashModel with ChangeNotifier {
   /// This methods allows manually submitting events at any time.
   Future<void> forceSubmitAnalyticsEvents() async {
     try {
-      await services.eventSubmitter.submitEvents(force: true);
+      await services.eventSubmitter.forceSubmitEvents();
     } catch (e, stack) {
       reportWiredashInfo(e, stack, 'Unexpected error while submitting events');
     }

--- a/lib/src/core/wiredash_registry.dart
+++ b/lib/src/core/wiredash_registry.dart
@@ -19,8 +19,17 @@ class WiredashRegistry {
   static final WiredashRegistry instance = WiredashRegistry._();
 
   final List<WeakReference<WiredashState>> _refs = [];
+  final List<VoidCallback> _listeners = [];
 
   final Finalizer<Disposable> _finalizer = Finalizer((d) => d.dispose());
+
+  /// Runs [listener] whenever the mounted [Wiredash] widget list changes.
+  Disposable addListener(VoidCallback listener) {
+    _listeners.add(listener);
+    return Disposable(() {
+      _listeners.remove(listener);
+    });
+  }
 
   /// Register all [Wiredash] widget state to eventually receive updates
   ///
@@ -42,14 +51,13 @@ class WiredashRegistry {
       // the context has been garbage collected, clean up in case
       // the dispose method was not called
       Disposable(() {
-        _refs.remove(elementRef);
+        _removeRef(elementRef);
       }),
     );
 
     // dispose called manually
-    return Disposable(() {
-      _refs.remove(elementRef);
-    });
+    _notifyListeners();
+    return Disposable(() => _removeRef(elementRef));
   }
 
   List<WiredashState> get allWidgets {
@@ -68,16 +76,35 @@ class WiredashRegistry {
   /// receive updates via [forEach].
   @visibleForTesting
   void clear() {
+    final hadWidgets = _refs.isNotEmpty;
     _refs.clear();
+    if (hadWidgets) {
+      _notifyListeners();
+    }
   }
 
   /// Removes all inaccessible references, Widgets that have already been garbage collected
   void purge() {
-    for (final ref in _refs) {
-      final state = ref.target;
-      if (state == null) {
-        _refs.remove(ref);
-      }
+    final before = _refs.length;
+    _refs.removeWhere((ref) => ref.target == null);
+    if (_refs.length == before) {
+      return;
+    }
+    _notifyListeners();
+  }
+
+  void _removeRef(WeakReference<WiredashState> ref) {
+    final removed = _refs.remove(ref);
+    if (!removed) {
+      return;
+    }
+    _notifyListeners();
+  }
+
+  void _notifyListeners() {
+    final listeners = List<VoidCallback>.of(_listeners);
+    for (final listener in listeners) {
+      listener();
     }
   }
 }

--- a/lib/src/core/wiredash_registry.dart
+++ b/lib/src/core/wiredash_registry.dart
@@ -23,6 +23,11 @@ class WiredashRegistry {
 
   final Finalizer<Disposable> _finalizer = Finalizer((d) => d.dispose());
 
+  @visibleForTesting
+  int get debugListenerCount {
+    return _listeners.length;
+  }
+
   /// Runs [listener] whenever the mounted [Wiredash] widget list changes.
   Disposable addListener(VoidCallback listener) {
     _listeners.add(listener);

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -5,8 +5,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:wiredash/src/an4lytics/an4lytics.dart';
-import 'package:wiredash/src/an4lytics/isolate_messenger.dart'
-    if (dart.library.io) 'package:wiredash/src/an4lytics/isolate_messenger_io.dart';
 import 'package:wiredash/src/core/context_cache.dart';
 import 'package:wiredash/src/core/services/error_report.dart';
 import 'package:wiredash/src/core/support/back_button_interceptor.dart';
@@ -298,16 +296,10 @@ class WiredashState extends State<Wiredash> {
     );
     _verifySyncLocalizationsDelegate();
 
-    _unregister = WiredashRegistry.instance.register(this);
     // Let background isolates wake the main isolate to upload events they
-    // buffered to disk, instead of waiting for the next lifecycle trigger. The
-    // ping carries the projectId so it routes to the matching instance, exactly
-    // like a main-isolate trackEvent.
-    registerMainIsolateAnalyticsListener((projectId, environment, eventName) {
-      unawaited(
-        notifyMatchingWiredashInstance(projectId, environment, eventName),
-      );
-    });
+    // buffered to disk, instead of waiting for the next lifecycle trigger.
+    ensureAnalyticsIsolateListenerRegistered();
+    _unregister = WiredashRegistry.instance.register(this);
     _services.updateWidget(widget);
     _services.addListener(_markNeedsBuild);
     _services.wiredashModel.addListener(_markNeedsBuild);
@@ -334,7 +326,18 @@ class WiredashState extends State<Wiredash> {
   /// This method is called by [WiredashAnalytics] when new events have been
   /// added or the app goes to the background.
   Future<void> triggerAnalyticsEventUpload() async {
+    await _submitAnalyticsEvents(submitImmediately: false);
+  }
+
+  Future<void> _submitAnalyticsEvents({
+    required bool submitImmediately,
+  }) async {
     try {
+      if (submitImmediately) {
+        await _services.eventSubmitter.forceSubmitEvents();
+        return;
+      }
+
       await _services.eventSubmitter.submitEvents();
     } catch (e, stack) {
       reportWiredashInfo(e, stack, 'Unexpected error while submitting events');
@@ -344,10 +347,6 @@ class WiredashState extends State<Wiredash> {
   @override
   void dispose() {
     _unregister?.dispose();
-    if (WiredashRegistry.instance.allWidgets.isEmpty) {
-      // Last Wiredash widget gone, stop listening for background-isolate pings.
-      unregisterMainIsolateAnalyticsListener();
-    }
     _services.dispose();
     _backButtonDispatcher.dispose();
     _appFocusScopeNode.dispose();
@@ -571,6 +570,21 @@ class WiredashState extends State<Wiredash> {
       return true;
     }());
   }
+}
+
+/// Submits the pending analytics events of [state] to the server.
+///
+/// When [submitImmediately] is `true` the debounce is bypassed and the upload
+/// starts right away, otherwise events are batched on the regular schedule.
+/// Used by the analytics upload router to forward events to the matching
+/// [Wiredash] instance.
+Future<void> submitAnalyticsEvents(
+  WiredashState state, {
+  required bool submitImmediately,
+}) async {
+  await state._submitAnalyticsEvents(
+    submitImmediately: submitImmediately,
+  );
 }
 
 Locale get _defaultLocale {

--- a/lib/src/core/wiredash_widget.dart
+++ b/lib/src/core/wiredash_widget.dart
@@ -296,10 +296,10 @@ class WiredashState extends State<Wiredash> {
     );
     _verifySyncLocalizationsDelegate();
 
+    _unregister = WiredashRegistry.instance.register(this);
     // Let background isolates wake the main isolate to upload events they
     // buffered to disk, instead of waiting for the next lifecycle trigger.
     ensureAnalyticsIsolateListenerRegistered();
-    _unregister = WiredashRegistry.instance.register(this);
     _services.updateWidget(widget);
     _services.addListener(_markNeedsBuild);
     _services.wiredashModel.addListener(_markNeedsBuild);
@@ -359,6 +359,7 @@ class WiredashState extends State<Wiredash> {
 
     _unregister?.dispose();
     _unregister = WiredashRegistry.instance.register(this);
+    ensureAnalyticsIsolateListenerRegistered();
     _services.updateWidget(widget);
 
     if (oldWidget.projectId != widget.projectId ||

--- a/lib/src/utils/delay.dart
+++ b/lib/src/utils/delay.dart
@@ -38,6 +38,13 @@ class Delay {
       }
     }
   }
+
+  void disposeWithError() {
+    _timer?.cancel();
+    if (!_completer.isCompleted) {
+      _completer.completeError(DelayCancelledException());
+    }
+  }
 }
 
 class DelayCancelledException implements Exception {}

--- a/lib/wiredash.dart
+++ b/lib/wiredash.dart
@@ -4,10 +4,10 @@ export 'assets/l10n/wiredash_localizations_en.g.dart';
 export 'src/an4lytics/an4lytics.dart'
     show
         InvalidEventKeyFormatException,
-        NoProjectIdSpecifiedException,
-        NoWiredashInstanceFoundException,
         TooManyEventParametersException,
         WiredashAnalytics;
+export 'src/an4lytics/an4lytics_upload_router.dart'
+    show NoProjectIdSpecifiedException, NoWiredashInstanceFoundException;
 export 'src/core/options/wiredash_options_data.dart';
 export 'src/core/theme/wiredash_theme_data.dart';
 export 'src/core/widgets/confidential.dart';

--- a/test/analytics/analytics_test.dart
+++ b/test/analytics/analytics_test.dart
@@ -11,8 +11,10 @@ import 'package:file/memory.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
+import 'package:wiredash/src/an4lytics/an4lytics_isolate_message.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_file_store.dart';
 import 'package:wiredash/src/an4lytics/ev3nt_store.dart';
+import 'package:wiredash/src/an4lytics/isolate_messenger_io.dart';
 import 'package:wiredash/src/core/network/wiredash_api.dart';
 import 'package:wiredash/src/core/services/services.dart';
 import 'package:wiredash/src/core/sync/sync_engine.dart';
@@ -760,6 +762,70 @@ void main() {
       expect(batches[0], hasLength(1));
       expect(batches[1], hasLength(1));
     });
+
+    testWidgets('forceSubmitEvents submits pending context events immediately',
+        (tester) async {
+      final robot = WiredashTestRobot(tester);
+      await robot.launchApp(useDirectEventSubmitter: false);
+
+      await robot.triggerAnalyticsEvent();
+      robot.mockServices.mockApi.sendEventsInvocations.verifyHasNoInvocation();
+
+      await robot.wiredashController.forceSubmitEvents();
+
+      robot.mockServices.mockApi.sendEventsInvocations.verifyInvocationCount(1);
+      final events = robot.mockServices.mockApi.sendEventsInvocations.latest[0]!
+          as List<RequestEvent>;
+      expect(events, hasLength(1));
+      expect(events.single.eventName, 'default_event');
+    });
+
+    testWidgets('WiredashAnalytics.forceSubmitEvents submits pending events',
+        (tester) async {
+      final robot = WiredashTestRobot(tester);
+      await robot.launchApp(useDirectEventSubmitter: false);
+
+      final analytics = WiredashAnalytics();
+      await analytics.trackEvent('test_event');
+      robot.mockServices.mockApi.sendEventsInvocations.verifyHasNoInvocation();
+
+      await analytics.forceSubmitEvents();
+
+      robot.mockServices.mockApi.sendEventsInvocations.verifyInvocationCount(1);
+      final events = robot.mockServices.mockApi.sendEventsInvocations.latest[0]!
+          as List<RequestEvent>;
+      expect(events, hasLength(1));
+      expect(events.single.eventName, 'test_event');
+    });
+
+    testWidgets('isolate wake-up submits pending events after widget registers',
+        (tester) async {
+      final robot = WiredashTestRobot(tester);
+      await robot.launchApp(useDirectEventSubmitter: false);
+
+      final analytics = WiredashAnalytics();
+      await analytics.trackEvent('test_event');
+      robot.mockServices.mockApi.sendEventsInvocations.verifyHasNoInvocation();
+
+      notifyMainIsolateOfAnalyticsEvent(
+        const AnalyticsIsolateMessage(
+          projectId: null,
+          environment: null,
+          eventName: 'test_event',
+          submitImmediately: true,
+        ),
+      );
+      await tester.waitUntil(
+        () => robot.mockServices.mockApi.sendEventsInvocations.count,
+        equals(1),
+      );
+
+      robot.mockServices.mockApi.sendEventsInvocations.verifyInvocationCount(1);
+      final events = robot.mockServices.mockApi.sendEventsInvocations.latest[0]!
+          as List<RequestEvent>;
+      expect(events, hasLength(1));
+      expect(events.single.eventName, 'test_event');
+    });
   });
 
   testWidgets('Server marks event as illegal - code 2200', (tester) async {
@@ -1113,6 +1179,9 @@ void main() {
 
 // verifies no new methods are accidentally added to WiredashAnalytics, making it easy to mock
 class ThirdPartyAnalytics implements WiredashAnalytics {
+  @override
+  Future<void> forceSubmitEvents() async {}
+
   @override
   Future<void> trackEvent(
     String eventName, {

--- a/test/analytics/event_submitter_test.dart
+++ b/test/analytics/event_submitter_test.dart
@@ -78,6 +78,39 @@ void main() {
       await tester.pumpSmart(const Duration(seconds: 30));
       expect(api.sendEventsInvocations.invocations, isEmpty);
     });
+
+    testWidgets('force submits without waiting for pending debounce',
+        (tester) async {
+      final store = InMemoryEventStore.withDefaults();
+      final api = MockWiredashApi();
+      final DebounceEventSubmitter submitter = DebounceEventSubmitter(
+        eventStore: () => store,
+        api: () => api,
+        projectId: () => 'project-abc',
+        initialThrottleDuration: const Duration(days: 1),
+      );
+      addTearDown(() => submitter.dispose());
+
+      await store.saveEvent(
+        AnalyticsEvent(
+          eventName: 'test',
+          analyticsId: nanoid(length: 16),
+          createdAt: clock.now(),
+          sdkVersion: wiredashSdkVersion,
+        ),
+        'project-abc',
+      );
+
+      final debouncedSubmit = ResultFuture(submitter.submitEvents());
+      await tester.pumpSmart(const Duration(seconds: 10));
+      expect(api.sendEventsInvocations.invocations, isEmpty);
+      expect(debouncedSubmit.isComplete, isFalse);
+
+      await submitter.forceSubmitEvents();
+
+      expect(debouncedSubmit.isComplete, isTrue);
+      api.sendEventsInvocations.verifyInvocationCount(1);
+    });
   });
 }
 

--- a/test/analytics/isolate_messenger_test.dart
+++ b/test/analytics/isolate_messenger_test.dart
@@ -1,37 +1,153 @@
 @TestOn('vm')
 library;
 
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wiredash/src/an4lytics/an4lytics_isolate_message.dart';
 import 'package:wiredash/src/an4lytics/isolate_messenger_io.dart';
 
+import '../util/flutter_error.dart';
+
 void main() {
-  // The real cross-isolate wake-up runs across two isolates; here we exercise
-  // the IsolateNameServer round-trip within one isolate, which is enough to
-  // prove a ping reaches the registered listener.
-  test('a ping delivers projectId, environment and eventName to the listener',
-      () async {
-    final pinged = Completer<(String?, String?, String)>();
-    registerMainIsolateAnalyticsListener((projectId, environment, eventName) {
-      if (!pinged.isCompleted) {
-        pinged.complete((projectId, environment, eventName));
+  group('AnalyticsIsolateMessage.fromObject', () {
+    test('parses a serialized message', () {
+      final message = AnalyticsIsolateMessage.fromObject([
+        'my_project',
+        'prod',
+        'test_event',
+        true,
+      ]);
+
+      expect(message.projectId, 'my_project');
+      expect(message.environment, 'prod');
+      expect(message.eventName, 'test_event');
+      expect(message.submitImmediately, isTrue);
+    });
+
+    test('parses nullable routing fields', () {
+      final message = AnalyticsIsolateMessage.fromObject([
+        null,
+        null,
+        'test_event',
+        false,
+      ]);
+
+      expect(message.projectId, isNull);
+      expect(message.environment, isNull);
+      expect(message.eventName, 'test_event');
+      expect(message.submitImmediately, isFalse);
+    });
+
+    test('treats only true as immediate submit', () {
+      final message = AnalyticsIsolateMessage.fromObject([
+        null,
+        null,
+        'test_event',
+        'true',
+      ]);
+
+      expect(message.submitImmediately, isFalse);
+    });
+
+    test('throws for malformed messages', () {
+      final malformedMessages = <Object?>[
+        null,
+        'test_event',
+        <Object?>[],
+        <Object?>[null, null, null, false],
+        <Object?>[null, null, 42, false],
+      ];
+
+      for (final message in malformedMessages) {
+        expect(
+          () => AnalyticsIsolateMessage.fromObject(message),
+          throwsA(isA<Object>()),
+        );
       }
     });
-    addTearDown(unregisterMainIsolateAnalyticsListener);
+  });
 
-    notifyMainIsolateOfNewEvent('my_project', 'prod', 'test_event');
+  // The real cross-isolate wake-up runs across two isolates; here we exercise
+  // the IsolateNameServer round-trip within one isolate, which is enough to
+  // prove a ping reaches the main-isolate analytics router.
+  test('a ping reaches the analytics router', () async {
+    final errors = captureFlutterErrors();
+    final registration = registerMainIsolateAnalyticsListener();
+    addTearDown(registration.dispose);
 
-    final received = await pinged.future.timeout(const Duration(seconds: 5));
-    expect(received, ('my_project', 'prod', 'test_event'));
+    notifyMainIsolateOfAnalyticsEvent(
+      const AnalyticsIsolateMessage(
+        projectId: 'my_project',
+        environment: 'prod',
+        eventName: 'test_event',
+        submitImmediately: true,
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(errors.warnings, hasLength(1));
+    expect(errors.warningText, contains("No Wiredash widget is mounted"));
+    expect(errors.warningText, contains("test_event"));
   });
 
   test('notifying without a listener is a no-op', () async {
-    unregisterMainIsolateAnalyticsListener();
     // Must not throw when no main isolate has registered a port.
     expect(
-      () => notifyMainIsolateOfNewEvent(null, null, 'test_event'),
+      () => notifyMainIsolateOfAnalyticsEvent(
+        const AnalyticsIsolateMessage(
+          projectId: null,
+          environment: null,
+          eventName: 'test_event',
+          submitImmediately: false,
+        ),
+      ),
       returnsNormally,
     );
+  });
+
+  test('reports malformed isolate messages', () async {
+    final errors = captureFlutterErrors();
+    final registration = registerMainIsolateAnalyticsListener();
+    addTearDown(registration.dispose);
+
+    sendRawMainIsolateAnalyticsMessage('bad_message');
+    await pumpEventQueue();
+
+    expect(errors.warnings, hasLength(1));
+    expect(errors.warningText, contains('Received malformed'));
+    expect(errors.warningText, contains('bad_message'));
+  });
+
+  test('each registration disposes only its own port ownership', () async {
+    final errors = captureFlutterErrors();
+    final firstRegistration = registerMainIsolateAnalyticsListener();
+    addTearDown(firstRegistration.dispose);
+    final secondRegistration = registerMainIsolateAnalyticsListener();
+    addTearDown(secondRegistration.dispose);
+
+    firstRegistration.dispose();
+    notifyMainIsolateOfAnalyticsEvent(
+      const AnalyticsIsolateMessage(
+        projectId: 'my_project',
+        environment: 'prod',
+        eventName: 'test_event',
+        submitImmediately: false,
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(errors.warnings, hasLength(1));
+
+    secondRegistration.dispose();
+    notifyMainIsolateOfAnalyticsEvent(
+      const AnalyticsIsolateMessage(
+        projectId: 'my_project',
+        environment: 'prod',
+        eventName: 'test_event',
+        submitImmediately: false,
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(errors.warnings, hasLength(1));
   });
 }

--- a/test/analytics/isolate_messenger_test.dart
+++ b/test/analytics/isolate_messenger_test.dart
@@ -119,12 +119,16 @@ void main() {
 
   test('each registration disposes only its own port ownership', () async {
     final errors = captureFlutterErrors();
+    expect(debugMainIsolateAnalyticsRegistrationCount, 0);
     final firstRegistration = registerMainIsolateAnalyticsListener();
     addTearDown(firstRegistration.dispose);
+    expect(debugMainIsolateAnalyticsRegistrationCount, 1);
     final secondRegistration = registerMainIsolateAnalyticsListener();
     addTearDown(secondRegistration.dispose);
+    expect(debugMainIsolateAnalyticsRegistrationCount, 2);
 
     firstRegistration.dispose();
+    expect(debugMainIsolateAnalyticsRegistrationCount, 1);
     notifyMainIsolateOfAnalyticsEvent(
       const AnalyticsIsolateMessage(
         projectId: 'my_project',
@@ -138,6 +142,7 @@ void main() {
     expect(errors.warnings, hasLength(1));
 
     secondRegistration.dispose();
+    expect(debugMainIsolateAnalyticsRegistrationCount, 0);
     notifyMainIsolateOfAnalyticsEvent(
       const AnalyticsIsolateMessage(
         projectId: 'my_project',

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -442,6 +442,23 @@ void main() {
       expect(registry.referenceCount, 1);
     });
 
+    testWidgets('notifies listeners when widgets register and unregister',
+        (tester) async {
+      final registry = WiredashRegistry.instance;
+      final counts = <int>[];
+      final listenerRegistration = registry.addListener(() {
+        counts.add(registry.referenceCount);
+      });
+      addTearDown(listenerRegistration.dispose);
+
+      final robot = WiredashTestRobot(tester);
+      await robot.launchApp();
+      expect(counts, [1]);
+
+      await tester.pumpWidget(const SizedBox());
+      expect(counts, [1, 0]);
+    });
+
     test('zero items', () {
       // by default, the registry is empty.
       // and the state added in the previous test is not present anymore

--- a/test/wiredash_widget_test.dart
+++ b/test/wiredash_widget_test.dart
@@ -445,18 +445,22 @@ void main() {
     testWidgets('notifies listeners when widgets register and unregister',
         (tester) async {
       final registry = WiredashRegistry.instance;
+      expect(registry.debugListenerCount, 0);
       final counts = <int>[];
       final listenerRegistration = registry.addListener(() {
         counts.add(registry.referenceCount);
       });
       addTearDown(listenerRegistration.dispose);
+      expect(registry.debugListenerCount, 1);
 
       final robot = WiredashTestRobot(tester);
       await robot.launchApp();
       expect(counts, [1]);
+      expect(registry.debugListenerCount, 2);
 
       await tester.pumpWidget(const SizedBox());
       expect(counts, [1, 0]);
+      expect(registry.debugListenerCount, 1);
     });
 
     test('zero items', () {


### PR DESCRIPTION
Add `forceSubmitEvents()` to `WiredashAnalytics` and route background-isolate wake-ups through the same registry-backed upload path.

```dart
await WiredashAnalytics().forceSubmitEvents();
```

The main isolate keeps one analytics wake-up listener while any `Wiredash` widget is mounted, and malformed isolate messages are reported instead of silently ignored.

Also covers immediate debounce bypassing, isolate message parsing, listener ownership, and registry-driven listener lifecycle in focused tests.