### PR TITLE
Recover screenshots after app reinstall or update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Fix** Recover screenshots when the app's data directory moves between launches. On iOS the data container GUID is reassigned on every reinstall or update (Apple TN2406), invalidating the absolute screenshot path stored at capture time and dropping the screenshot from the feedback. Paths are now rebuilt against the current directory when loading pending feedback in `retrieveAllPendingItems`.
+
 ## 2.7.0
 
 - **Breaking** Raise minimum SDK to Dart 3.3 / Flutter 3.19 [#401](https://github.com/wiredashio/wiredash-sdk/pull/401)

--- a/lib/src/feedback/data/pending_feedback_item_storage.dart
+++ b/lib/src/feedback/data/pending_feedback_item_storage.dart
@@ -70,7 +70,65 @@ class PendingFeedbackItemStorage {
         }
       }
     }
-    return parsed.toList();
+
+    // Rebuild screenshot paths against the current directory, but only resolve
+    // that directory when at least one item actually has a screenshot on disk.
+    // Most feedback has no screenshot, and resolving the directory hits a
+    // platform channel (getApplicationDocumentsDirectory) that we don't want to
+    // require on every read.
+    if (!parsed.any(_hasOnDiskScreenshot)) {
+      return parsed;
+    }
+    final screenshotsDir = await _getScreenshotStorageDirectoryPath();
+    return parsed
+        .map((item) => _withCurrentScreenshotPaths(item, screenshotsDir))
+        .toList();
+  }
+
+  bool _hasOnDiskScreenshot(PendingFeedbackItem item) {
+    final attachments = item.feedbackItem.attachments;
+    if (attachments == null) {
+      return false;
+    }
+    return attachments.any((a) => a is Screenshot && a.file.isOnDisk);
+  }
+
+  /// Rebuilds on-disk screenshot paths against the *current* screenshot
+  /// directory.
+  ///
+  /// The absolute path to a file inside the app's container is not stable
+  /// between launches: on iOS the data container's GUID is reassigned when the
+  /// app is updated or reinstalled (Apple TN2406), so a path persisted earlier
+  /// may point at a directory that no longer exists even though the file itself
+  /// was migrated and still lives under the same name. Apple's guidance is to
+  /// resolve the standard directory at runtime rather than store an absolute
+  /// path, so we reconstruct the path from [screenshotsDir] (the current
+  /// directory) and the persisted file name.
+  PendingFeedbackItem _withCurrentScreenshotPaths(
+    PendingFeedbackItem item,
+    String screenshotsDir,
+  ) {
+    final attachments = item.feedbackItem.attachments;
+    if (attachments == null || attachments.isEmpty) {
+      return item;
+    }
+    final updated = <PersistedAttachment>[];
+    for (final attachment in attachments) {
+      if (attachment is Screenshot && attachment.file.isOnDisk) {
+        final fileName = _fs.path.basename(attachment.file.pathToFile!);
+        final currentPath =
+            _fs.path.normalize(_fs.path.join(screenshotsDir, fileName));
+        updated.add(
+          attachment.copyWith(file: FileDataEventuallyOnDisk.file(currentPath)),
+        );
+      } else {
+        updated.add(attachment);
+      }
+    }
+    return PendingFeedbackItem(
+      id: item.id,
+      feedbackItem: item.feedbackItem.copyWith(attachments: updated),
+    );
   }
 
   /// Saves [item] and [screenshot] in the persistent storage.

--- a/test/feedback/data/pending_feedback_item_storage_test.dart
+++ b/test/feedback/data/pending_feedback_item_storage_test.dart
@@ -85,6 +85,54 @@ void main() {
       ]);
     });
 
+    test(
+        'reconstructs the screenshot path against the current directory '
+        'when the container path changed (iOS reinstall, Apple TN2406)',
+        () async {
+      // Persist a screenshot under the "old" container directory.
+      await fileSystem.directory('/old/Documents').create(recursive: true);
+      final oldStorage = PendingFeedbackItemStorage(
+        fileSystem: fileSystem,
+        sharedPreferencesProvider: () async => prefs,
+        dirPathProvider: () async => '/old/Documents',
+        wuidGenerator: wuidGenerator,
+      );
+      final saved = await oldStorage.addPendingItem(
+        createFeedback(
+          attachments: [
+            PersistedAttachment.screenshot(
+              file: FileDataEventuallyOnDisk.inMemory(kTransparentImage),
+            ),
+          ],
+        ),
+      );
+      expect(
+        saved.feedbackItem.attachments!.single.file,
+        FileDataEventuallyOnDisk.file('/old/Documents/00000000.png'),
+      );
+
+      // The OS migrates the file to a new container on reinstall; the old
+      // absolute path no longer resolves.
+      await fileSystem.directory('/new/Documents').create(recursive: true);
+      await fileSystem
+          .file('/old/Documents/00000000.png')
+          .rename('/new/Documents/00000000.png');
+
+      // The next launch sees a new container directory but the same persisted
+      // pending items.
+      final newStorage = PendingFeedbackItemStorage(
+        fileSystem: fileSystem,
+        sharedPreferencesProvider: () async => prefs,
+        dirPathProvider: () async => '/new/Documents',
+        wuidGenerator: wuidGenerator,
+      );
+      final retrieved = await newStorage.retrieveAllPendingItems();
+      final file = retrieved.single.feedbackItem.attachments!.single.file;
+      expect(
+          file, FileDataEventuallyOnDisk.file('/new/Documents/00000000.png'));
+      expect(fileSystem.file(file.pathToFile).existsSync(), isTrue);
+    });
+
     test('store a second item without overriding the first one', () async {
       final firstFeedback = createFeedback(
         attachments: [

--- a/test/offline_feedback_test.dart
+++ b/test/offline_feedback_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 // ignore: depend_on_referenced_packages
 import 'package:async/async.dart' show ResultFuture;
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiredash/src/core/network/wiredash_api.dart';
@@ -42,6 +43,9 @@ void main() {
 
       // insert feedback in v2 format with attachment
       final tempDir = Directory.systemTemp.createTempSync();
+      // The screenshot lives in the app documents directory; loading pending
+      // feedback rebuilds its path against the current directory.
+      _mockApplicationDocumentsDirectory(tester, tempDir.path);
       File('${tempDir.path}/image.png').writeAsStringSync('test img content');
       final json = fullJsonV2;
       // ignore: avoid_dynamic_calls
@@ -88,6 +92,9 @@ void main() {
 
       // insert feedback in v3 format with attachment
       final tempDir = Directory.systemTemp.createTempSync();
+      // The screenshot lives in the app documents directory; loading pending
+      // feedback rebuilds its path against the current directory.
+      _mockApplicationDocumentsDirectory(tester, tempDir.path);
       File('${tempDir.path}/image.png').writeAsStringSync('test img content');
       final json = fullJsonV3;
       // ignore: avoid_dynamic_calls
@@ -128,6 +135,21 @@ void main() {
       );
     });
   });
+}
+
+/// Routes `getApplicationDocumentsDirectory()` to [path] for the duration of a
+/// test, so the storage layer can rebuild persisted screenshot paths against a
+/// known directory.
+void _mockApplicationDocumentsDirectory(WidgetTester tester, String path) {
+  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    const MethodChannel('plugins.flutter.io/path_provider'),
+    (call) async {
+      if (call.method == 'getApplicationDocumentsDirectory') {
+        return path;
+      }
+      return null;
+    },
+  );
 }
 
 Map get fullJsonV2 => {


### PR DESCRIPTION
## Problem

Screenshots vanished from feedback submitted after an app reinstall or update.

On iOS the data container GUID is reassigned on every install ([Apple TN2406](https://developer.apple.com/library/archive/qa/qa1719/_index.html)). The absolute screenshot path persisted at capture time points at a directory that no longer exists — even though the file itself was migrated under the same name. When loading pending feedback, the file couldn't be found and the screenshot was dropped.

## Fix

`retrieveAllPendingItems` now rebuilds each on-disk screenshot path from the *current* documents directory and the persisted file name, instead of trusting the stored absolute path.

The current directory is resolved lazily — only when an item actually has a screenshot on disk — so screenshot-less feedback (the common case) never touches the `path_provider` platform channel.

**Before**
```
stored path:  /var/.../<OLD-GUID>/screenshots/abc.png   → missing → screenshot lost
```

**After**
```
rebuilt path: /var/.../<NEW-GUID>/screenshots/abc.png   → found → screenshot recovered
```

## Tests

- New unit test in `pending_feedback_item_storage_test.dart` simulating the iOS container path change (TN2406).
- `offline_feedback_test.dart` covers v2/v3 offline feedback with screenshots end-to-end.
