### PR TITLE
Remove no-op build parameters from CustomizableWiredashMetaData.copyWith()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Breaking** Remove the `buildVersion`, `buildNumber` and `buildCommit` parameters from `CustomizableWiredashMetaData.copyWith()`. The matching properties were removed in 2.0.0, since then passing those arguments silently did nothing. Set build information at compile time with `env.BUILD_VERSION` / `env.BUILD_NUMBER` / `env.BUILD_COMMIT` instead, see [Custom Properties](https://docs.wiredash.com/sdk/custom-properties/#during-compile-time).
 - **Fix** Recover screenshots when the app's data directory moves between launches. On iOS the data container GUID is reassigned on every reinstall or update (Apple TN2406), invalidating the absolute screenshot path stored at capture time and dropping the screenshot from the feedback. Paths are now rebuilt against the current directory when loading pending feedback in `retrieveAllPendingItems`.
 
 ## 2.7.0

--- a/lib/src/metadata/user_meta_data.dart
+++ b/lib/src/metadata/user_meta_data.dart
@@ -56,18 +56,12 @@ class CustomizableWiredashMetaData {
   CustomizableWiredashMetaData Function({
     String? userId,
     String? userEmail,
-    String? buildVersion,
-    String? buildNumber,
-    String? buildCommit,
     Map<String, Object?>? custom,
   }) get copyWith => _copyWith;
 
   CustomizableWiredashMetaData _copyWith({
     Object? userId = defaultArgument,
     Object? userEmail = defaultArgument,
-    Object? buildVersion = defaultArgument,
-    Object? buildNumber = defaultArgument,
-    Object? buildCommit = defaultArgument,
     Object? custom = defaultArgument,
   }) {
     final metaData = CustomizableWiredashMetaData();

--- a/test/feedback/data/pending_feedback_item_storage_test.dart
+++ b/test/feedback/data/pending_feedback_item_storage_test.dart
@@ -129,7 +129,9 @@ void main() {
       final retrieved = await newStorage.retrieveAllPendingItems();
       final file = retrieved.single.feedbackItem.attachments!.single.file;
       expect(
-          file, FileDataEventuallyOnDisk.file('/new/Documents/00000000.png'));
+        file,
+        FileDataEventuallyOnDisk.file('/new/Documents/00000000.png'),
+      );
       expect(fileSystem.file(file.pathToFile).existsSync(), isTrue);
     });
 

--- a/test/metadata_test.dart
+++ b/test/metadata_test.dart
@@ -48,6 +48,48 @@ void main() {
     expect(map['foo'], isNull);
   });
 
+  group('CustomizableWiredashMetaData.copyWith', () {
+    CustomizableWiredashMetaData createMetaData() {
+      return CustomizableWiredashMetaData()
+        ..userId = '123'
+        ..userEmail = 'dash@flutter.io'
+        ..custom = {'foo': 'bar'};
+    }
+
+    test('copies all properties when no argument is passed', () async {
+      final copy = createMetaData().copyWith();
+      expect(copy.userId, '123');
+      expect(copy.userEmail, 'dash@flutter.io');
+      expect(copy.custom, {'foo': 'bar'});
+    });
+
+    test('replaces only the properties that are passed', () async {
+      final copy = createMetaData().copyWith(userId: '456');
+      expect(copy.userId, '456');
+      expect(copy.userEmail, 'dash@flutter.io');
+      expect(copy.custom, {'foo': 'bar'});
+    });
+
+    test('explicit null clears a property', () async {
+      final copy = createMetaData().copyWith(userId: null, userEmail: null);
+      expect(copy.userId, isNull);
+      expect(copy.userEmail, isNull);
+      expect(copy.custom, {'foo': 'bar'});
+    });
+
+    test('custom can be replaced', () async {
+      final copy = createMetaData().copyWith(custom: {'baz': 'qux'});
+      expect(copy.custom, {'baz': 'qux'});
+      expect(copy.userId, '123');
+      expect(copy.userEmail, 'dash@flutter.io');
+    });
+
+    test('null custom keeps the existing map', () async {
+      final copy = createMetaData().copyWith(custom: null);
+      expect(copy.custom, {'foo': 'bar'});
+    });
+  });
+
   testWidgets('build information can be set via ENV', (tester) async {
     final robot = WiredashTestRobot(tester);
     await robot.launchApp();

--- a/wiresdk_sidekick/lib/src/commands/gen_l10n_command.dart
+++ b/wiresdk_sidekick/lib/src/commands/gen_l10n_command.dart
@@ -16,16 +16,19 @@ class GenL10nCommand extends Command {
       from: SidekickContext.projectRoot.path,
     );
 
-    await flutter([
-      'gen-l10n',
-      '--arb-dir=$arbDir',
-      '--no-synthetic-package',
-      '--output-dir=$arbDir',
-      '--template-arb-file=wiredash_en.arb',
-      '--no-nullable-getter',
-      '--output-class=WiredashLocalizations',
-      '--output-localization-file=wiredash_localizations.g.dart',
-    ], workingDirectory: SidekickContext.projectRoot);
+    await flutter(
+      [
+        'gen-l10n',
+        '--arb-dir=$arbDir',
+        '--no-synthetic-package',
+        '--output-dir=$arbDir',
+        '--template-arb-file=wiredash_en.arb',
+        '--no-nullable-getter',
+        '--output-class=WiredashLocalizations',
+        '--output-localization-file=wiredash_localizations.g.dart',
+      ],
+      workingDirectory: SidekickContext.projectRoot,
+    );
 
     await runWiresdk(['format']);
 

--- a/wiresdk_sidekick/lib/src/commands/gen_l10n_command.dart
+++ b/wiresdk_sidekick/lib/src/commands/gen_l10n_command.dart
@@ -16,19 +16,16 @@ class GenL10nCommand extends Command {
       from: SidekickContext.projectRoot.path,
     );
 
-    await flutter(
-      [
-        'gen-l10n',
-        '--arb-dir=$arbDir',
-        '--no-synthetic-package',
-        '--output-dir=$arbDir',
-        '--template-arb-file=wiredash_en.arb',
-        '--no-nullable-getter',
-        '--output-class=WiredashLocalizations',
-        '--output-localization-file=wiredash_localizations.g.dart',
-      ],
-      workingDirectory: SidekickContext.projectRoot,
-    );
+    await flutter([
+      'gen-l10n',
+      '--arb-dir=$arbDir',
+      '--no-synthetic-package',
+      '--output-dir=$arbDir',
+      '--template-arb-file=wiredash_en.arb',
+      '--no-nullable-getter',
+      '--output-class=WiredashLocalizations',
+      '--output-localization-file=wiredash_localizations.g.dart',
+    ], workingDirectory: SidekickContext.projectRoot);
 
     await runWiresdk(['format']);
 


### PR DESCRIPTION
`CustomizableWiredashMetaData.copyWith()` still accepts `buildVersion`, `buildNumber` and `buildCommit`, but those arguments have been silently discarded since 2.0.0.

b7ecf24 removed the three deprecated properties from the class and the matching assignments from `_copyWith`, but left the parameters in place — both in the public function type and in the private implementation. The result compiles, runs, and does nothing:

```dart
Wiredash.of(context).modifyMetaData((metaData) {
  return metaData.copyWith(buildVersion: '1.2.3'); // dropped on the floor
});
```

The parameters are now gone, so that call fails to compile instead of failing silently.

### Migration

Build information is read from the native platform, or provided at compile time:

```sh
flutter build appbundle --dart-define=BUILD_VERSION=1.2.3 --dart-define=BUILD_NUMBER=42
```

See [Custom Properties](https://docs.wiredash.com/sdk/custom-properties/#during-compile-time).

### Also in here

`copyWith` had no test coverage at all. Added a group covering copy-all, selective override, explicit-`null` clearing, and the `custom` replace/keep semantics.

Two `require_trailing_commas` lints that fail `analyze --fatal-infos` are fixed along the way (`pending_feedback_item_storage_test.dart`, `wiresdk_sidekick`).
